### PR TITLE
feat: remove TextInput prefix on focus / when not empty

### DIFF
--- a/lib/app/components/inputs/hooks/use_node_focused.dart
+++ b/lib/app/components/inputs/hooks/use_node_focused.dart
@@ -12,7 +12,7 @@ ValueNotifier<bool> useNodeFocused(FocusNode focusNode) {
       focusNode.addListener(onFocusChange);
       return () => focusNode.removeListener(onFocusChange);
     },
-    <Object?>[focusNode],
+    [focusNode],
   );
   return focused;
 }

--- a/lib/app/components/inputs/hooks/use_text_changed.dart
+++ b/lib/app/components/inputs/hooks/use_text_changed.dart
@@ -17,6 +17,6 @@ void useTextChanged({
       }
       return null;
     },
-    <Object?>[onTextChanged, controller],
+    [onTextChanged, controller],
   );
 }

--- a/lib/app/components/inputs/search_input/search_input.dart
+++ b/lib/app/components/inputs/search_input/search_input.dart
@@ -3,7 +3,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:ice/app/components/inputs/hooks/use_text_changed.dart';
 import 'package:ice/app/components/inputs/search_input/components/cancel_button.dart';
 import 'package:ice/app/components/inputs/search_input/components/search_clear_button.dart';
-import 'package:ice/app/components/inputs/search_input/hooks/use_node_focused.dart';
+import 'package:ice/app/components/inputs/hooks/use_node_focused.dart';
 import 'package:ice/app/extensions/asset_gen_image.dart';
 import 'package:ice/app/extensions/build_context.dart';
 import 'package:ice/app/extensions/num.dart';

--- a/lib/app/components/inputs/text_input/text_input.dart
+++ b/lib/app/components/inputs/text_input/text_input.dart
@@ -1,12 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:ice/app/components/inputs/hooks/use_node_focused.dart';
 import 'package:ice/app/components/inputs/hooks/use_text_changed.dart';
 import 'package:ice/app/components/inputs/text_input/components/text_input_decoration.dart';
-import 'package:ice/app/extensions/build_context.dart';
-import 'package:ice/app/extensions/num.dart';
-import 'package:ice/app/extensions/string.dart';
-import 'package:ice/app/extensions/theme_data.dart';
+import 'package:ice/app/extensions/extensions.dart';
 
 class TextInput extends HookWidget {
   TextInput({
@@ -63,17 +61,26 @@ class TextInput extends HookWidget {
 
   @override
   Widget build(BuildContext context) {
+    final focusNode = useFocusNode();
     final error = useState<String?>(null);
+    final hasValue = useState(initialValue.isNotEmpty);
+    final hasFocus = useNodeFocused(focusNode);
+
+    void onChangedHandler(String text) {
+      hasValue.value = text.isNotEmpty;
+      onChanged?.call(text);
+    }
 
     useTextChanged(
       controller: controller,
-      onTextChanged: onChanged,
+      onTextChanged: onChangedHandler,
     );
 
     return TextFormField(
       scrollPadding: scrollPadding,
       controller: controller,
-      onChanged: controller == null ? onChanged : null,
+      focusNode: focusNode,
+      onChanged: controller == null ? onChangedHandler : null,
       initialValue: initialValue,
       maxLines: maxLines,
       minLines: minLines,
@@ -101,7 +108,7 @@ class TextInput extends HookWidget {
         context: context,
         verified: verified,
         prefix: prefix,
-        prefixIcon: prefixIcon,
+        prefixIcon: !hasFocus.value && !hasValue.value ? prefixIcon : null,
         suffixIcon: suffixIcon,
         errorText: errorText ?? error.value,
         contentPadding: contentPadding,

--- a/lib/app/components/inputs/text_input/widgetbook.dart
+++ b/lib/app/components/inputs/text_input/widgetbook.dart
@@ -114,6 +114,12 @@ class TextInputWithClear extends HookWidget {
     return TextInput(
       controller: controller,
       labelText: 'With clear button',
+      prefixIcon: TextInputIcons(
+        icons: [
+          Assets.images.icons.iconBadgeCompany.icon(),
+        ],
+        hasRightDivider: true,
+      ),
       suffixIcon: TextInputIcons(
         icons: [
           TextInputClearButton(


### PR DESCRIPTION
Remove TextInput's prefix when it's focused / when not empty according to design

<img width="250" alt="image" src="https://github.com/user-attachments/assets/acff21f2-2e34-4d4b-ac71-591fb4dba72e">
<img width="250" alt="image" src="https://github.com/user-attachments/assets/cc43e598-6a37-4bfb-a04e-ef2b54a468ce">
<img width="250" alt="image" src="https://github.com/user-attachments/assets/ee279b0b-7b1f-48e2-b622-e7ab8d708ffb">


