### PR TITLE
feat: add OverlayMenu to display context menus for Posts

### DIFF
--- a/lib/app/components/overlay_menu/overlay_menu.dart
+++ b/lib/app/components/overlay_menu/overlay_menu.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+class OverlayMenu extends HookWidget {
+  const OverlayMenu({
+    super.key,
+    required this.child,
+    required this.menuBuilder,
+    this.offset = Offset.zero,
+  });
+
+  final Widget child;
+  final Widget Function(VoidCallback closeMenu) menuBuilder;
+  final Offset offset;
+
+  @override
+  Widget build(BuildContext context) {
+    final overlayPortalController = useMemoized(() => OverlayPortalController());
+    final followLink = useMemoized(() => LayerLink());
+
+    return OverlayPortal(
+      controller: overlayPortalController,
+      overlayChildBuilder: (_) {
+        final renderBox = context.findRenderObject() as RenderBox;
+
+        return GestureDetector(
+          behavior: HitTestBehavior.translucent,
+          onTap: overlayPortalController.hide,
+          child: Stack(
+            children: [
+              CompositedTransformFollower(
+                link: followLink,
+                offset: Offset(0, renderBox.size.height).translate(offset.dx, offset.dy),
+                child: menuBuilder(overlayPortalController.hide),
+              ),
+            ],
+          ),
+        );
+      },
+      child: GestureDetector(
+        onTap: overlayPortalController.show,
+        child: CompositedTransformTarget(
+          link: followLink,
+          child: child,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/app/features/feed/views/components/post/components/post_header/post_menu.dart
+++ b/lib/app/features/feed/views/components/post/components/post_header/post_menu.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:ice/app/components/overlay_menu/overlay_menu.dart';
 import 'package:ice/app/extensions/asset_gen_image.dart';
 import 'package:ice/app/extensions/build_context.dart';
 import 'package:ice/app/extensions/num.dart';
@@ -10,14 +11,27 @@ class PostMenu extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      width: 48.0.s,
-      height: 48.0.s,
-      transform: Matrix4.translationValues(12.0.s, 0, 0),
-      child: IconButton(
-        onPressed: () {},
-        icon: Assets.images.icons.iconMorePopup.icon(
-          color: context.theme.appColors.onTertararyBackground,
+    return OverlayMenu(
+      menuBuilder: (closeMenu) => Card(
+        child: SizedBox.square(
+          dimension: 48.0.s,
+          child: InkWell(
+            onTap: closeMenu,
+            child: Icon(Icons.close),
+          ),
+        ),
+      ),
+      child: SizedBox(
+        width: 48.0.s,
+        height: 48.0.s,
+        child: Transform(
+          transform: Matrix4.translationValues(12.0.s, 0, 0),
+          child: IconButton(
+            onPressed: null,
+            icon: Assets.images.icons.iconMorePopup.icon(
+              color: context.theme.appColors.onTertararyBackground,
+            ),
+          ),
         ),
       ),
     );


### PR DESCRIPTION
### What does this PR do?
This PR adds `OverlayMenu` that provides convenient API to `OverlayPortal`.

### Changes Brought by This PR
- `OverlayPortal` uses `OverlayPortalController` to show/hide `OverlayEntry`
- `CompositedTransformTarget` writes position to `LayerLink followLink`. And `CompositedTransformFollower` reads position from `LayerLink followLink`

<img src="https://github.com/user-attachments/assets/7cef3801-6580-4302-9588-6dbd85c337b7" width="300">
After scroll:
<img src="https://github.com/user-attachments/assets/01d3ccfb-639e-48f7-8dc0-4d62fff125bb" width="300">
