### PR TITLE
chose: set modal physics to Clamping

### DIFF
--- a/lib/app/router/base_route_data.dart
+++ b/lib/app/router/base_route_data.dart
@@ -53,6 +53,7 @@ class FadeTransitionSheetPage extends ScrollableNavigationSheetPage<void> {
     required GoRouterState state,
   }) : super(
           key: state.pageKey,
+          physics: ClampingSheetPhysics(),
           transitionsBuilder: (context, animation, secondaryAnimation, child) {
             final fadeInTween = TweenSequence<double>([
               TweenSequenceItem(tween: ConstantTween(0), weight: 1),


### PR DESCRIPTION
### Reason for changes
Request from the stakeholder

### What does this PR do
Sets modal physics to `ClampingSheetPhysics` that makes it impossible to overscroll the modals

### Additional information
https://github.com/user-attachments/assets/da8e9812-49a8-4c3e-b3e1-fcb359e07e64

