### PR TITLE
fix(auth ui): show loading indicator for loading and authenticated states

### DIFF
--- a/lib/app/features/auth/views/pages/get_started/login_form.dart
+++ b/lib/app/features/auth/views/pages/get_started/login_form.dart
@@ -31,11 +31,11 @@ class LoginForm extends HookConsumerWidget {
           SizedBox(height: 16.0.s),
           Button(
             disabled: authState is AuthenticationLoading,
-            trailingIcon: authState is AuthenticationLoading
-                ? const IceLoadingIndicator()
-                : Assets.images.icons.iconButtonNext.icon(
-                    color: context.theme.appColors.onPrimaryAccent,
-                  ),
+            trailingIcon: switch (authState) {
+              AuthenticationLoading() || Authenticated(authToken: _) => const IceLoadingIndicator(),
+              _ => Assets.images.icons.iconButtonNext
+                  .icon(color: context.theme.appColors.onPrimaryAccent),
+            },
             onPressed: () {
               if (formKey.value.currentState!.validate()) {
                 hideKeyboardAndCallOnce(

--- a/lib/app/features/auth/views/pages/sign_up_passkey/sign_up_passkey_form.dart
+++ b/lib/app/features/auth/views/pages/sign_up_passkey/sign_up_passkey_form.dart
@@ -27,9 +27,10 @@ class SignUpPasskeyForm extends HookConsumerWidget {
           SizedBox(height: 16.0.s),
           Button(
             disabled: authState is AuthenticationLoading,
-            trailingIcon: authState is AuthenticationLoading
-                ? const IceLoadingIndicator()
-                : const SizedBox.shrink(),
+            trailingIcon: switch (authState) {
+              AuthenticationLoading() || Authenticated(authToken: _) => const IceLoadingIndicator(),
+              _ => const SizedBox.shrink(),
+            },
             onPressed: () {
               if (formKey.value.currentState!.validate()) {
                 hideKeyboardAndCallOnce(


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue when a user can see `->` arrow on the Login button after the login request is completed.

### Changes brought by this PR
I've fixes the issue by showing loading indicator for both Loading and Authenticated states