### PR TITLE
feat: implement token persistence and session rehydration logic

### DIFF
--- a/lib/app/features/auth/providers/auth_provider.dart
+++ b/lib/app/features/auth/providers/auth_provider.dart
@@ -1,18 +1,35 @@
 import 'package:ice/app/features/auth/data/models/auth_state.dart';
 import 'package:ice/app/features/auth/data/models/auth_token.dart';
+import 'package:ice/app/features/user/providers/user_data_provider.dart';
+import 'package:ice/app/services/storage/user_preferences_service.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'auth_provider.g.dart';
 
 @Riverpod(keepAlive: true)
 class Auth extends _$Auth {
+  static const String authTokenKey = 'authToken';
+
   @override
   AuthState build() {
     return const AuthenticationUnknown();
   }
 
   Future<void> rehydrate() async {
-    state = const Unauthenticated();
+    final activeUser = ref.read(userDataNotifierProvider);
+    final storedToken = ref
+            .read(userPreferencesServiceProvider(userId: activeUser.id))
+            .getValue<String>(authTokenKey) ??
+        '';
+
+    state = storedToken.isEmpty
+        ? const Unauthenticated()
+        : Authenticated(
+            authToken: AuthToken(
+              access: storedToken,
+              refresh: 'refresh',
+            ),
+          );
   }
 
   Future<void> signUp({required String keyName}) async {
@@ -21,12 +38,18 @@ class Auth extends _$Auth {
 
       await Future<void>.delayed(const Duration(seconds: 1));
 
-      state = Authenticated(
-        authToken: AuthToken(
-          access: 'access',
-          refresh: 'refresh',
-        ),
+      final activeUser = ref.read(userDataNotifierProvider);
+
+      final authToken = AuthToken(
+        access: 'access',
+        refresh: 'refresh',
       );
+
+      ref
+          .read(userPreferencesServiceProvider(userId: activeUser.id))
+          .setValue(authTokenKey, authToken.access);
+
+      state = Authenticated(authToken: authToken);
     } catch (error) {
       state = AuthenticationFailure(message: error.toString());
       rethrow;
@@ -39,12 +62,18 @@ class Auth extends _$Auth {
 
       await Future<void>.delayed(const Duration(seconds: 1));
 
-      state = Authenticated(
-        authToken: AuthToken(
-          access: 'access',
-          refresh: 'refresh',
-        ),
+      final activeUser = ref.read(userDataNotifierProvider);
+
+      final authToken = AuthToken(
+        access: 'access',
+        refresh: 'refresh',
       );
+
+      ref
+          .read(userPreferencesServiceProvider(userId: activeUser.id))
+          .setValue(authTokenKey, authToken.access);
+
+      state = Authenticated(authToken: authToken);
     } catch (error) {
       state = AuthenticationFailure(message: error.toString());
       rethrow;
@@ -55,6 +84,11 @@ class Auth extends _$Auth {
     try {
       state = const AuthenticationLoading();
       await Future<void>.delayed(const Duration(seconds: 2));
+
+      final activeUser = ref.read(userDataNotifierProvider);
+
+      ref.read(userPreferencesServiceProvider(userId: activeUser.id)).setValue(authTokenKey, '');
+
       state = const Unauthenticated();
     } catch (error) {
       state = AuthenticationFailure(message: error.toString());

--- a/lib/app/features/core/providers/init_provider.dart
+++ b/lib/app/features/core/providers/init_provider.dart
@@ -13,12 +13,12 @@ part 'init_provider.g.dart';
 Future<void> initApp(InitAppRef ref) async {
   Nostr.initialize();
   await ref.read(envProvider.future);
+  await ref.watch(sharedPreferencesProvider.future);
   await Future.wait([
     ref.read(appTemplateProvider.future),
     ref.read(authProvider.notifier).rehydrate(),
   ]);
 
-  await ref.watch(sharedPreferencesProvider.future);
   ref.watch(relaysProvider.notifier);
   await ref.read(permissionsProvider.notifier).checkAllPermissions();
 }


### PR DESCRIPTION
From [task](https://leftclick-io.slack.com/archives/C0391DGLW8M/p1726047961847529?thread_ts=1726042660.833959&cid=C0391DGLW8M)

- Added logic for saving auth token in user preferences 
- Implemented rehydration of user session based on stored token


https://github.com/user-attachments/assets/a25b1156-779d-415d-8502-8dce119d1212

