### PR TITLE
build: set build cache key depending on env

### DIFF
--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -108,7 +108,7 @@ jobs:
           path: |
             ~/.pub-cache
             ./*
-          key: ${{ github.sha }}
+          key: ${{ github.sha }}_${{ github.ref_name }}_${{ inputs.environment }}
       - name: Slack Notification
         if: ${{ success() == false}}
         uses: act10ns/slack@v2
@@ -133,7 +133,7 @@ jobs:
           path: |
             ~/.pub-cache
             ./*
-          key: ${{ github.sha }}
+          key: ${{ github.sha }}_${{ github.ref_name }}_${{ inputs.environment }}
       - name: Mask APP environment and keys in logs
         id: mask-secrets
         run: |
@@ -218,7 +218,7 @@ jobs:
           path: |
             ~/.pub-cache
             ./*
-          key: ${{ github.sha }}
+          key: ${{ github.sha }}_${{ github.ref_name }}_${{ inputs.environment }}
       - name: Mask APP environment and keys in logs
         id: mask-secrets
         run: |


### PR DESCRIPTION
### What does this PR do?
This PR resolves the build issue caused by conflicting caches from different environments