### PR TITLE
build(cicd): use build number for the cache key to avoid obsolete secrets usage

### DIFF
--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -102,13 +102,13 @@ jobs:
         run: |
           cd main-repo
           ./scripts/license_check.sh
-      - uses: actions/cache@v3
+      - uses: actions/cache/save@v3
         id: cache_all
         with:
           path: |
             ~/.pub-cache
             ./*
-          key: ${{ github.sha }}_${{ github.ref_name }}_${{ inputs.environment }}
+          key: ${{ github.sha }}_${{ github.run_number }}
       - name: Slack Notification
         if: ${{ success() == false}}
         uses: act10ns/slack@v2
@@ -133,7 +133,7 @@ jobs:
           path: |
             ~/.pub-cache
             ./*
-          key: ${{ github.sha }}_${{ github.ref_name }}_${{ inputs.environment }}
+          key: ${{ github.sha }}_${{ github.run_number }}
       - name: Mask APP environment and keys in logs
         id: mask-secrets
         run: |
@@ -218,7 +218,7 @@ jobs:
           path: |
             ~/.pub-cache
             ./*
-          key: ${{ github.sha }}_${{ github.ref_name }}_${{ inputs.environment }}
+          key: ${{ github.sha }}_${{ github.run_number }}
       - name: Mask APP environment and keys in logs
         id: mask-secrets
         run: |


### PR DESCRIPTION
### What does this PR do?
This PR changes the keys for ci/cd build cache so that each run has it's individual cache because otherwise secrets changes still lead to cache hit