### PR TITLE
feat: enable disable next button depending on image and text

### DIFF
--- a/lib/app/features/feed/create_article/views/pages/create_article_modal/components/create_article_add_image.dart
+++ b/lib/app/features/feed/create_article/views/pages/create_article_modal/components/create_article_add_image.dart
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:flutter/material.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/screen_offset/screen_side_offset.dart';
@@ -18,12 +17,15 @@ import 'package:photo_manager/photo_manager.dart';
 import 'package:photo_manager_image_provider/photo_manager_image_provider.dart';
 
 class CreateArticleAddImage extends HookConsumerWidget {
-  const CreateArticleAddImage({super.key});
+  const CreateArticleAddImage({
+    required this.selectedImage,
+    super.key,
+  });
+
+  final ValueNotifier<MediaFile?> selectedImage;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final selectedImage = useState<MediaFile?>(null);
-
     return PermissionAwareWidget(
       permissionType: Permission.photos,
       onGranted: () async {
@@ -102,7 +104,7 @@ class CreateArticleAddImage extends HookConsumerWidget {
                                 right: 12.0.s,
                                 child: IconButton(
                                   onPressed: () {
-                                    selectedImage.value = null; // Clears the selected image
+                                    selectedImage.value = null;
                                   },
                                   icon: Assets.svg.iconFieldClearall.icon(size: 20.0.s),
                                 ),

--- a/lib/app/features/feed/create_article/views/pages/create_article_modal/create_article_modal.dart
+++ b/lib/app/features/feed/create_article/views/pages/create_article_modal/create_article_modal.dart
@@ -9,7 +9,7 @@ import 'package:ion/app/components/separated/separator.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/feed/create_article/views/pages/create_article_modal/components/create_article_add_image.dart';
 import 'package:ion/app/features/feed/create_article/views/pages/create_article_modal/components/create_article_toolbar.dart';
-import 'package:ion/app/features/feed/views/components/text_editor/hooks/use_quill_controller.dart';
+import 'package:ion/app/features/feed/create_article/views/pages/create_article_modal/hooks/use_create_article.dart';
 import 'package:ion/app/features/feed/views/components/text_editor/text_editor.dart';
 import 'package:ion/app/features/feed/views/pages/cancel_creation_modal/cancel_creation_modal.dart';
 import 'package:ion/app/router/app_routes.dart';
@@ -22,8 +22,7 @@ class CreateArticleModal extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final textEditorController = useQuillController();
-    final titleController = TextEditingController();
+    final articleState = useCreateArticle();
 
     Future<bool?> showCancelCreationModal(BuildContext context) {
       return showSimpleBottomSheet<bool>(
@@ -55,18 +54,23 @@ class CreateArticleModal extends HookConsumerWidget {
                   label: Text(
                     context.i18n.button_next,
                     style: context.theme.appTextThemes.body.copyWith(
-                      color: context.theme.appColors.primaryAccent,
+                      color: articleState.isButtonEnabled
+                          ? context.theme.appColors.primaryAccent
+                          : context.theme.appColors.sheetLine,
                     ),
                   ),
                   backgroundColor: context.theme.appColors.secondaryBackground,
                   borderColor: context.theme.appColors.secondaryBackground,
+                  disabled: !articleState.isButtonEnabled,
                   onPressed: () {
                     ArticlePreviewRoute().push<void>(context);
                   },
                 ),
               ],
             ),
-            const CreateArticleAddImage(),
+            CreateArticleAddImage(
+              selectedImage: articleState.selectedImage,
+            ),
             Padding(
               padding: EdgeInsets.only(
                 left: ScreenSideOffset.defaultSmallMargin,
@@ -75,7 +79,7 @@ class CreateArticleModal extends HookConsumerWidget {
                 bottom: 6.0.s,
               ),
               child: TextField(
-                controller: titleController,
+                controller: articleState.titleController,
                 style: context.theme.appTextThemes.headline2.copyWith(
                   color: context.theme.appColors.primaryText,
                 ),
@@ -91,7 +95,7 @@ class CreateArticleModal extends HookConsumerWidget {
             Expanded(
               child: ScreenSideOffset.small(
                 child: TextEditor(
-                  textEditorController,
+                  articleState.textEditorController,
                   placeholder: context.i18n.create_article_story_placeholder,
                 ),
               ),
@@ -101,7 +105,7 @@ class CreateArticleModal extends HookConsumerWidget {
                 const HorizontalSeparator(),
                 ScreenSideOffset.small(
                   child: CreateArticleToolbar(
-                    textEditorController: textEditorController,
+                    textEditorController: articleState.textEditorController,
                   ),
                 ),
               ],

--- a/lib/app/features/feed/create_article/views/pages/create_article_modal/hooks/use_create_article.dart
+++ b/lib/app/features/feed/create_article/views/pages/create_article_modal/hooks/use_create_article.dart
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:flutter_quill/flutter_quill.dart';
+import 'package:ion/app/features/feed/views/components/text_editor/hooks/use_quill_controller.dart';
+import 'package:ion/app/services/media_service/media_service.dart';
+
+class CreateArticleState {
+  CreateArticleState({
+    required this.selectedImage,
+    required this.titleFilled,
+    required this.titleController,
+    required this.textEditorController,
+    required this.isButtonEnabled,
+  });
+  final ValueNotifier<MediaFile?> selectedImage;
+  final ValueNotifier<bool> titleFilled;
+  final TextEditingController titleController;
+  final QuillController textEditorController;
+  final bool isButtonEnabled;
+}
+
+CreateArticleState useCreateArticle() {
+  final selectedImage = useState<MediaFile?>(null);
+  final titleFilled = useState(false);
+  final textEditorController = useQuillController();
+  final titleController = useTextEditingController();
+  final isButtonEnabled = selectedImage.value != null && titleFilled.value;
+
+  useEffect(
+    () {
+      void listener() {
+        titleFilled.value = titleController.text.trim().isNotEmpty;
+      }
+
+      titleController.addListener(listener);
+      return () => titleController.removeListener(listener);
+    },
+    [titleController],
+  );
+
+  return CreateArticleState(
+    selectedImage: selectedImage,
+    titleFilled: titleFilled,
+    titleController: titleController,
+    textEditorController: textEditorController,
+    isButtonEnabled: isButtonEnabled,
+  );
+}


### PR DESCRIPTION
## Description
This PR introduces `Next` button enabling/disabling based on the image and title required fields for the article


## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<img width="180" alt="Screenshot 2024-12-04 at 15 40 18" src="https://github.com/user-attachments/assets/7da61fc8-b3a0-432a-851e-5d336df503c5">
<img width="180" alt="Screenshot 2024-12-04 at 15 40 28" src="https://github.com/user-attachments/assets/c48692e6-326c-401f-941e-8b279cf749ef">
<img width="180" alt="Screenshot 2024-12-04 at 15 40 21" src="https://github.com/user-attachments/assets/92de48a5-40c3-4474-b235-53a3cd6d6326">
