### PR TITLE
fix: alert buttons color

### DIFF
--- a/lib/app/features/feed/views/components/toolbar_buttons/toolbar_link_button.dart
+++ b/lib/app/features/feed/views/components/toolbar_buttons/toolbar_link_button.dart
@@ -70,13 +70,19 @@ class ToolbarLinkButton extends StatelessWidget {
           ),
           actions: [
             CupertinoDialogAction(
-              child: Text(context.i18n.button_cancel),
+              child: Text(
+                context.i18n.button_cancel,
+                style: TextStyle(color: context.theme.appColors.primaryAccent),
+              ),
               onPressed: () {
                 Navigator.of(context).pop();
               },
             ),
             CupertinoDialogAction(
-              child: Text(context.i18n.button_link),
+              child: Text(
+                context.i18n.button_link,
+                style: TextStyle(color: context.theme.appColors.primaryAccent),
+              ),
               onPressed: () {
                 Navigator.of(context).pop(linkController.text.trim());
               },


### PR DESCRIPTION
## Description
This PR changes the color of link alert buttons

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<img width="180" alt="Screenshot 2024-12-04 at 18 02 34" src="https://github.com/user-attachments/assets/54a2f475-f7d6-4a75-8b44-7a29c517feb2">
