### PR TITLE
fix: media picker add button

### DIFF
--- a/lib/app/features/gallery/views/components/add_media_button.dart
+++ b/lib/app/features/gallery/views/components/add_media_button.dart
@@ -16,12 +16,7 @@ class AddMediaButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final notSelected = mediaCount == 0;
     final text = context.i18n.button_add;
-
-    if (notSelected) {
-      return const SizedBox.shrink();
-    }
 
     return TextButton(
       onPressed: onPressed,

--- a/lib/app/features/gallery/views/pages/media_picker_page.dart
+++ b/lib/app/features/gallery/views/pages/media_picker_page.dart
@@ -50,10 +50,11 @@ class MediaPickerPage extends HookConsumerWidget {
           ),
           onBackPress: () => Navigator.of(context).pop(),
           actions: [
-            AddMediaButton(
-              onPressed: () => Navigator.of(context).pop(selectedMedia),
-              mediaCount: selectedMedia.length,
-            ),
+            if (selectedMedia.isNotEmpty)
+              AddMediaButton(
+                onPressed: () => Navigator.of(context).pop(selectedMedia),
+                mediaCount: selectedMedia.length,
+              ),
           ],
         ),
         automaticallyImplyLeading: false,


### PR DESCRIPTION
## Description
This PR fixes the add button behavior, we should hide it if no media items are selected

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<img width="180" alt="Screenshot 2024-12-19 at 18 09 01" src="https://github.com/user-attachments/assets/cdfa188f-6c49-4c60-9b01-377b5f8c87c6" />
<img width="180" alt="Screenshot 2024-12-19 at 18 09 02" src="https://github.com/user-attachments/assets/c0b17741-b4e0-4e52-a711-7f37ef8c9a16" />

