### PR TITLE
fix: remove # from hashtag tag

### DIFF
--- a/lib/app/features/nostr/model/related_hashtag.c.dart
+++ b/lib/app/features/nostr/model/related_hashtag.c.dart
@@ -25,7 +25,7 @@ class RelatedHashtag with _$RelatedHashtag {
   }
 
   List<String> toTag() {
-    return [tagName, value];
+    return [tagName, if (value.startsWith('#')) value.substring(1) else value];
   }
 
   static const String tagName = 't';


### PR DESCRIPTION
## Description
* Removes `#` from `t` tags

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
