### PR TITLE
feat: don't keep private key even in secure storage

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -140,6 +140,9 @@ PODS:
     - Flutter
   - ion_screenshot_detector (0.0.1):
     - Flutter
+  - local_auth_crypto (1.0.0):
+    - Flutter
+    - SecureBiometricSwift (~> 0.0.2)
   - local_auth_darwin (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -165,6 +168,7 @@ PODS:
   - SDWebImage (5.20.0):
     - SDWebImage/Core (= 5.20.0)
   - SDWebImage/Core (5.20.0)
+  - SecureBiometricSwift (0.0.2)
   - shake_gesture_ios (0.0.1):
     - Flutter
   - share_plus (0.0.1):
@@ -241,6 +245,7 @@ DEPENDENCIES:
   - image_cropper (from `.symlinks/plugins/image_cropper/ios`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
   - ion_screenshot_detector (from `.symlinks/plugins/ion_screenshot_detector/ios`)
+  - local_auth_crypto (from `.symlinks/plugins/local_auth_crypto/ios`)
   - local_auth_darwin (from `.symlinks/plugins/local_auth_darwin/darwin`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - passkeys_ios (from `.symlinks/plugins/passkeys_ios/ios`)
@@ -283,6 +288,7 @@ SPEC REPOS:
     - MTBBarcodeScanner
     - OrderedSet
     - SDWebImage
+    - SecureBiometricSwift
     - sqlite3
     - SwiftyGif
     - TOCropViewController
@@ -330,6 +336,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/image_picker_ios/ios"
   ion_screenshot_detector:
     :path: ".symlinks/plugins/ion_screenshot_detector/ios"
+  local_auth_crypto:
+    :path: ".symlinks/plugins/local_auth_crypto/ios"
   local_auth_darwin:
     :path: ".symlinks/plugins/local_auth_darwin/darwin"
   package_info_plus:
@@ -406,6 +414,7 @@ SPEC CHECKSUMS:
   image_cropper: 37d40f62177c101ff4c164906d259ea2c3aa70cf
   image_picker_ios: c560581cceedb403a6ff17f2f816d7fea1421fc1
   ion_screenshot_detector: bd85296e1347b5bf5acf71407a6d9b7933bfe604
+  local_auth_crypto: 3ee858ca5d40c9da56dcd1fe8d814e92438a9371
   local_auth_darwin: 66e40372f1c29f383a314c738c7446e2f7fdadc3
   MTBBarcodeScanner: f453b33c4b7dfe545d8c6484ed744d55671788cb
   OrderedSet: e539b66b644ff081c73a262d24ad552a69be3a94
@@ -417,6 +426,7 @@ SPEC CHECKSUMS:
   qr_code_scanner: bb67d64904c3b9658ada8c402e8b4d406d5d796e
   quill_native_bridge: e5afa7d49c08cf68c52a5e23bc272eba6925c622
   SDWebImage: 73c6079366fea25fa4bb9640d5fb58f0893facd8
+  SecureBiometricSwift: f8a373c07fb46c9ca1b2b53be51a485d2828a3d8
   shake_gesture_ios: 64f1f579f314c58445761992a123111b3d7b3492
   share_plus: 8b6f8b3447e494cca5317c8c3073de39b3600d1f
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78

--- a/lib/app/features/auth/views/pages/sign_up_password/sign_up_password.dart
+++ b/lib/app/features/auth/views/pages/sign_up_password/sign_up_password.dart
@@ -118,7 +118,10 @@ class SignUpPasswordPage extends HookConsumerWidget {
                                   keyName: identityKeyNameController.text,
                                   password: passwordController.text,
                                 );
-                            await onSuggestToAddBiometrics(identityKeyNameController.text);
+                            await onSuggestToAddBiometrics(
+                              username: identityKeyNameController.text,
+                              password: passwordController.text,
+                            );
                           }
                         } else {
                           passwordsError.value = context.i18n.error_passwords_are_not_equal;

--- a/lib/app/features/components/biometrics/hooks/use_on_suggest_biometrics.dart
+++ b/lib/app/features/components/biometrics/hooks/use_on_suggest_biometrics.dart
@@ -7,16 +7,23 @@ import 'package:ion/app/features/user/providers/biometrics_provider.c.dart';
 import 'package:ion/app/router/utils/show_simple_bottom_sheet.dart';
 import 'package:ion_identity_client/ion_identity.dart';
 
-Future<void> Function(String username) useOnSuggestToAddBiometrics(WidgetRef ref) {
+Future<void> Function({required String username, required String password})
+    useOnSuggestToAddBiometrics(WidgetRef ref) {
   final context = useContext();
   return useCallback(
-    (String username) async {
+    ({
+      required String username,
+      required String password,
+    }) async {
       final userBiometricsState =
           await ref.read(userBiometricsStateProvider(username: username).future);
       if (userBiometricsState == BiometricsState.canSuggest && context.mounted) {
         await showSimpleBottomSheet<void>(
           context: context,
-          child: SuggestToAddBiometricsPopup(username: username),
+          child: SuggestToAddBiometricsPopup(
+            username: username,
+            password: password,
+          ),
         );
       }
     },

--- a/lib/app/features/components/biometrics/suggest_to_add_biometrics_popup.dart
+++ b/lib/app/features/components/biometrics/suggest_to_add_biometrics_popup.dart
@@ -14,10 +14,12 @@ import 'package:ion/generated/assets.gen.dart';
 class SuggestToAddBiometricsPopup extends ConsumerWidget {
   const SuggestToAddBiometricsPopup({
     required this.username,
+    required this.password,
     super.key,
   });
 
   final String username;
+  final String password;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -69,6 +71,7 @@ class SuggestToAddBiometricsPopup extends ConsumerWidget {
                         .read(biometricsActionsNotifierProvider.notifier)
                         .enrollToUseBiometrics(
                           username: username,
+                          password: password,
                           localisedReason: context.i18n.biometrics_suggestion_title,
                         );
                     if (context.mounted) {

--- a/lib/app/features/components/verify_identity/verify_identity_prompt_dialog_helper.dart
+++ b/lib/app/features/components/verify_identity/verify_identity_prompt_dialog_helper.dart
@@ -63,6 +63,7 @@ class RiverpodVerifyIdentityRequestBuilder<T, P> extends HookConsumerWidget {
               onPasskeyFlow: onPasskeyFlow,
               onBiometricsFlow: onBiometricsFlow,
               localisedReasonForBiometricsDialog: context.i18n.verify_with_biometrics_title,
+              localisedCancelForBiometricsDialog: context.i18n.button_cancel,
               identityKeyName: identityKeyName,
             ).future,
           );
@@ -103,6 +104,7 @@ class HookVerifyIdentityRequestBuilder<P> extends HookConsumerWidget {
                 onPasskeyFlow: onPasskeyFlow,
                 onBiometricsFlow: onBiometricsFlow,
                 localisedReasonForBiometricsDialog: context.i18n.verify_with_biometrics_title,
+                localisedCancelForBiometricsDialog: context.i18n.button_cancel,
               ).future,
             );
           } finally {

--- a/lib/app/features/ion_connect/providers/ion_connect_event_signer_provider.c.dart
+++ b/lib/app/features/ion_connect/providers/ion_connect_event_signer_provider.c.dart
@@ -4,7 +4,6 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/features/auth/providers/auth_provider.c.dart';
 import 'package:ion/app/features/ion_connect/ion_connect.dart';
 import 'package:ion/app/services/ion_connect/ed25519_key_store.dart';
-import 'package:ion/app/services/ion_identity/ion_identity_provider.c.dart';
 import 'package:ion/app/services/storage/secure_storage.c.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -34,25 +33,12 @@ class IonConnectEventSigner extends _$IonConnectEventSigner {
       return currentUserIonConnectEventSigner;
     }
 
-    final ionIdentityClient =
-        (await ref.read(ionIdentityProvider.future))(username: identityKeyName);
-    final privateKey = ionIdentityClient.auth.getUserPrivateKey();
-    if (privateKey != null) {
-      // Private key was generated during the auth flow (password), reuse it
-      return _generateFromPrivate(privateKey);
-    }
-
     // Generate a new event signer
     return _generate();
   }
 
   Future<EventSigner> _generate() async {
     final keyStore = await Ed25519KeyStore.generate();
-    return _setEventSigner(keyStore);
-  }
-
-  Future<EventSigner> _generateFromPrivate(String privateKey) async {
-    final keyStore = await Ed25519KeyStore.fromPrivate(privateKey);
     return _setEventSigner(keyStore);
   }
 

--- a/lib/app/features/user/providers/biometrics_provider.c.dart
+++ b/lib/app/features/user/providers/biometrics_provider.c.dart
@@ -38,12 +38,14 @@ class BiometricsActionsNotifier extends _$BiometricsActionsNotifier {
 
   Future<void> enrollToUseBiometrics({
     required String username,
+    required String password,
     required String localisedReason,
   }) async {
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
       final ionIdentity = await ref.read(ionIdentityProvider.future);
       await ionIdentity(username: username).auth.enrollToUseBiometrics(
+            password: password,
             localisedReason: localisedReason,
           );
     });

--- a/lib/app/features/user/providers/user_verify_identity_provider.c.dart
+++ b/lib/app/features/user/providers/user_verify_identity_provider.c.dart
@@ -17,6 +17,7 @@ AutoDisposeFutureProvider<T> verifyUserIdentityProvider<T>({
   required OnPasskeyFlow<T> onPasskeyFlow,
   required OnBiometricsFlow<T> onBiometricsFlow,
   required String localisedReasonForBiometricsDialog,
+  required String localisedCancelForBiometricsDialog,
   String? identityKeyName,
 }) {
   return FutureProvider.autoDispose<T>((ref) async {
@@ -28,7 +29,10 @@ AutoDisposeFutureProvider<T> verifyUserIdentityProvider<T>({
     if (isPasswordFlowUser) {
       if (biometricsState == BiometricsState.enabled) {
         try {
-          return await onBiometricsFlow(localisedReason: localisedReasonForBiometricsDialog);
+          return await onBiometricsFlow(
+            localisedReason: localisedReasonForBiometricsDialog,
+            localisedCancel: localisedCancelForBiometricsDialog,
+          );
           // If biometrics flow fails then fallback to password flow
         } catch (_) {}
       }

--- a/packages/ion_identity_client/example/pubspec.lock
+++ b/packages/ion_identity_client/example/pubspec.lock
@@ -581,6 +581,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.46"
+  local_auth_crypto:
+    dependency: transitive
+    description:
+      name: local_auth_crypto
+      sha256: "3523683bea6e531178c672e8b60a2c1d1e8043f25ddcf961db4ea11745f6be10"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   local_auth_darwin:
     dependency: transitive
     description:

--- a/packages/ion_identity_client/lib/src/auth/dtos/private_key_data.c.dart
+++ b/packages/ion_identity_client/lib/src/auth/dtos/private_key_data.c.dart
@@ -7,12 +7,12 @@ part 'private_key_data.c.g.dart';
 @JsonSerializable()
 class PrivateKeyData {
   PrivateKeyData({
-    this.hexEncodedPrivateKeyBytes,
+    this.biometricsEncryptedPassword,
   });
 
   factory PrivateKeyData.fromJson(Map<String, dynamic> json) => _$PrivateKeyDataFromJson(json);
 
   Map<String, dynamic> toJson() => _$PrivateKeyDataToJson(this);
 
-  final String? hexEncodedPrivateKeyBytes;
+  final String? biometricsEncryptedPassword;
 }

--- a/packages/ion_identity_client/lib/src/auth/dtos/private_key_data.c.g.dart
+++ b/packages/ion_identity_client/lib/src/auth/dtos/private_key_data.c.g.dart
@@ -8,10 +8,11 @@ part of 'private_key_data.c.dart';
 
 PrivateKeyData _$PrivateKeyDataFromJson(Map<String, dynamic> json) =>
     PrivateKeyData(
-      hexEncodedPrivateKeyBytes: json['hexEncodedPrivateKeyBytes'] as String?,
+      biometricsEncryptedPassword:
+          json['biometricsEncryptedPassword'] as String?,
     );
 
 Map<String, dynamic> _$PrivateKeyDataToJson(PrivateKeyData instance) =>
     <String, dynamic>{
-      'hexEncodedPrivateKeyBytes': instance.hexEncodedPrivateKeyBytes,
+      'biometricsEncryptedPassword': instance.biometricsEncryptedPassword,
     };

--- a/packages/ion_identity_client/lib/src/auth/ion_identity_auth.dart
+++ b/packages/ion_identity_client/lib/src/auth/ion_identity_auth.dart
@@ -81,9 +81,6 @@ class IONIdentityAuth {
   Future<void> deleteUser({required String base64Kind5Event}) =>
       deleteService.deleteUser(base64Kind5Event: base64Kind5Event);
 
-  String? getUserPrivateKey() =>
-      privateKeyStorage.getPrivateKey(username: username)?.hexEncodedPrivateKeyBytes;
-
   Future<bool> isPasskeyAvailable() => identitySigner.isPasskeyAvailable();
 
   bool isPasswordFlowUser() => privateKeyStorage.getPrivateKey(username: username) != null;
@@ -93,8 +90,9 @@ class IONIdentityAuth {
 
   Future<void> rejectToUseBiometrics() => identitySigner.rejectToUseBiometrics(username);
 
-  Future<void> enrollToUseBiometrics({required String localisedReason}) =>
+  Future<void> enrollToUseBiometrics({required String localisedReason, required String password}) =>
       identitySigner.enrollToUseBiometrics(
+        password: password,
         username: username,
         localisedReason: localisedReason,
       );

--- a/packages/ion_identity_client/lib/src/auth/services/credentials/create_new_credentials_service.dart
+++ b/packages/ion_identity_client/lib/src/auth/services/credentials/create_new_credentials_service.dart
@@ -52,7 +52,7 @@ class CreateNewCredentialsService {
           ),
         );
       },
-      onBiometricsFlow: ({required String localisedReason}) {
+      onBiometricsFlow: ({required String localisedReason, required String localisedCancel}) {
         throw UnimplementedError('Cannot register with biometrics');
       },
     );

--- a/packages/ion_identity_client/lib/src/auth/services/credentials/create_recovery_credentials_service.dart
+++ b/packages/ion_identity_client/lib/src/auth/services/credentials/create_recovery_credentials_service.dart
@@ -63,11 +63,12 @@ class CreateRecoveryCredentialsService {
           CredentialResponse.fromJson,
         );
       },
-      onBiometricsFlow: ({required String localisedReason}) {
+      onBiometricsFlow: ({required String localisedReason, required String localisedCancel}) {
         return userActionSigner.signWithBiometrics(
           credentialRequest,
           CredentialResponse.fromJson,
           localisedReason,
+          localisedCancel,
         );
       },
     );

--- a/packages/ion_identity_client/lib/src/auth/services/login/login_service.dart
+++ b/packages/ion_identity_client/lib/src/auth/services/login/login_service.dart
@@ -106,14 +106,16 @@ class LoginService {
           password: password,
         );
       },
-      onBiometricsFlow: ({required String localisedReason}) {
+      onBiometricsFlow: ({required String localisedReason, required String localisedCancel}) {
         final credentialDescriptor = identitySigner.extractPasswordProtectedCredentials(challenge);
         return identitySigner.signWithBiometrics(
           challenge: challenge.challenge,
           username: username,
+          encryptedPrivateKey: credentialDescriptor.encryptedPrivateKey!,
           credentialId: credentialDescriptor.id,
           credentialKind: CredentialKind.PasswordProtectedKey,
           localisedReason: localisedReason,
+          localisedCancel: localisedCancel,
         );
       },
     );

--- a/packages/ion_identity_client/lib/src/auth/services/logout/logout_service.dart
+++ b/packages/ion_identity_client/lib/src/auth/services/logout/logout_service.dart
@@ -29,8 +29,6 @@ class LogoutService {
     await Future.wait([
       dataSource.logOut(username: username, token: token.token),
       tokenStorage.removeToken(username: username),
-      privateKeyStorage.removePrivateKey(username: username),
-      biometricsStateStorage.removeBiometricsState(username: username),
     ]);
   }
 }

--- a/packages/ion_identity_client/lib/src/core/types/types.dart
+++ b/packages/ion_identity_client/lib/src/core/types/types.dart
@@ -4,7 +4,10 @@ typedef JsonObject = Map<String, dynamic>;
 
 typedef OnPasswordFlow<T> = Future<T> Function({required String password});
 typedef OnPasskeyFlow<T> = Future<T> Function();
-typedef OnBiometricsFlow<T> = Future<T> Function({required String localisedReason});
+typedef OnBiometricsFlow<T> = Future<T> Function({
+  required String localisedReason,
+  required String localisedCancel,
+});
 
 typedef OnVerifyIdentity<T> = Future<T> Function({
   required OnBiometricsFlow<T> onBiometricsFlow,

--- a/packages/ion_identity_client/lib/src/signer/identity_signer.dart
+++ b/packages/ion_identity_client/lib/src/signer/identity_signer.dart
@@ -61,16 +61,20 @@ class IdentitySigner {
   Future<AssertionRequestData> signWithBiometrics({
     required String username,
     required String localisedReason,
+    required String localisedCancel,
+    required String encryptedPrivateKey,
     required String challenge,
     required String credentialId,
     required CredentialKind credentialKind,
   }) async {
     return passwordSigner.signWithBiometrics(
       username: username,
+      encryptedPrivateKey: encryptedPrivateKey,
       localisedReason: localisedReason,
       challenge: challenge,
       credentialKind: credentialKind,
       credentialId: credentialId,
+      localisedCancel: localisedCancel,
     );
   }
 
@@ -84,10 +88,12 @@ class IdentitySigner {
 
   Future<void> enrollToUseBiometrics({
     required String username,
+    required String password,
     required String localisedReason,
   }) {
     return passwordSigner.enrollToUseBiometrics(
       username: username,
+      password: password,
       localisedReason: localisedReason,
     );
   }

--- a/packages/ion_identity_client/lib/src/signer/user_action_signer.dart
+++ b/packages/ion_identity_client/lib/src/signer/user_action_signer.dart
@@ -68,6 +68,7 @@ class UserActionSigner {
     UserActionSigningRequest request,
     T Function(JsonObject) responseDecoder,
     String localisedReason,
+    String localisedCancel,
   ) async {
     return _sign(
       request: request,
@@ -78,9 +79,11 @@ class UserActionSigner {
         return identitySigner.signWithBiometrics(
           challenge: challenge.challenge,
           username: request.username,
+          encryptedPrivateKey: credentialDescriptor.encryptedPrivateKey!,
           credentialId: credentialDescriptor.id,
           credentialKind: CredentialKind.PasswordProtectedKey,
           localisedReason: localisedReason,
+          localisedCancel: localisedCancel,
         );
       },
     );

--- a/packages/ion_identity_client/lib/src/wallets/ion_identity_wallets.dart
+++ b/packages/ion_identity_client/lib/src/wallets/ion_identity_wallets.dart
@@ -137,11 +137,12 @@ class IONIdentityWallets {
           hash: hash,
         );
       },
-      onBiometricsFlow: ({required String localisedReason}) {
+      onBiometricsFlow: ({required String localisedReason, required String localisedCancel}) {
         return _generateSignatureService.generateHashSignatureWithBiometrics(
           walletId: walletId,
           hash: hash,
           localisedReason: localisedReason,
+          localisedCancel: localisedCancel,
         );
       },
     );

--- a/packages/ion_identity_client/lib/src/wallets/services/create_wallet/create_wallet_service.dart
+++ b/packages/ion_identity_client/lib/src/wallets/services/create_wallet/create_wallet_service.dart
@@ -41,11 +41,12 @@ class CreateWalletService {
           Wallet.fromJson,
         );
       },
-      onBiometricsFlow: ({required String localisedReason}) {
+      onBiometricsFlow: ({required String localisedReason, required String localisedCancel}) {
         return _userActionSigner.signWithBiometrics(
           request,
           Wallet.fromJson,
           localisedReason,
+          localisedCancel,
         );
       },
     );

--- a/packages/ion_identity_client/lib/src/wallets/services/generate_signature/generate_signature_service.dart
+++ b/packages/ion_identity_client/lib/src/wallets/services/generate_signature/generate_signature_service.dart
@@ -55,6 +55,7 @@ class GenerateSignatureService {
     required String walletId,
     required String hash,
     required String localisedReason,
+    required String localisedCancel,
     String? externalId,
   }) async {
     return _generateSignature(
@@ -65,6 +66,7 @@ class GenerateSignatureService {
         request,
         GenerateSignatureResponse.fromJson,
         localisedReason,
+        localisedCancel,
       ),
     );
   }

--- a/packages/ion_identity_client/pubspec.yaml
+++ b/packages/ion_identity_client/pubspec.yaml
@@ -11,8 +11,8 @@ dependencies:
   asn1lib: ^1.5.4
   bdk_flutter:
     git:
-        url: https://github.com/ice-tychon/bdk-flutter.git
-        ref: chore/update-flutter-rust-bridge
+      url: https://github.com/ice-tychon/bdk-flutter.git
+      ref: chore/update-flutter-rust-bridge
   collection: ^1.18.0
   convert: ^3.1.1
   crypto: ^3.0.5
@@ -26,6 +26,7 @@ dependencies:
   freezed_annotation: ^2.4.4
   json_annotation: ^4.9.0
   local_auth: ^2.3.0
+  local_auth_crypto: ^1.1.1
   passkeys: ^2.1.0
   pointycastle: ^3.9.1
   rxdart: ^0.28.0

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1361,6 +1361,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.46"
+  local_auth_crypto:
+    dependency: transitive
+    description:
+      name: local_auth_crypto
+      sha256: "3523683bea6e531178c672e8b60a2c1d1e8043f25ddcf961db4ea11745f6be10"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   local_auth_darwin:
     dependency: transitive
     description:


### PR DESCRIPTION
## Description
Don't keep private key even in secure storage but keep biometrics encrypted password if biometrics enabled.

Used local_auth_crypto to encrypt/decrypt password with biometrics. That is only happening if password flow user enrolls to use biometrics

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [x] Chore

