### PR TITLE
feat: moved delete account action from user settings

### DIFF
--- a/lib/app/features/components/biometrics/suggest_to_add_biometrics_popup.dart
+++ b/lib/app/features/components/biometrics/suggest_to_add_biometrics_popup.dart
@@ -9,6 +9,7 @@ import 'package:ion/app/components/screen_offset/screen_bottom_offset.dart';
 import 'package:ion/app/components/screen_offset/screen_side_offset.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/user/providers/biometrics_provider.c.dart';
+import 'package:ion/app/services/logger/logger.dart';
 import 'package:ion/generated/assets.gen.dart';
 
 class SuggestToAddBiometricsPopup extends ConsumerWidget {
@@ -67,15 +68,25 @@ class SuggestToAddBiometricsPopup extends ConsumerWidget {
                       ? const IONLoadingIndicator()
                       : const SizedBox.shrink(),
                   onPressed: () async {
-                    await ref
-                        .read(biometricsActionsNotifierProvider.notifier)
-                        .enrollToUseBiometrics(
-                          username: username,
-                          password: password,
-                          localisedReason: context.i18n.biometrics_suggestion_title,
-                        );
-                    if (context.mounted) {
-                      Navigator.of(context).pop();
+                    try {
+                      await ref
+                          .read(biometricsActionsNotifierProvider.notifier)
+                          .enrollToUseBiometrics(
+                            username: username,
+                            password: password,
+                            localisedReason: context.i18n.biometrics_suggestion_title,
+                          );
+                    } catch (error, stackTrace) {
+                      // intentionally ignore exceptions
+                      Logger.log(
+                        'Error during biometrics enrolment',
+                        error: error,
+                        stackTrace: stackTrace,
+                      );
+                    } finally {
+                      if (context.mounted) {
+                        Navigator.of(context).pop();
+                      }
                     }
                   },
                 ),

--- a/lib/app/features/settings/model/settings_action.dart
+++ b/lib/app/features/settings/model/settings_action.dart
@@ -11,8 +11,7 @@ enum SettingsAction {
   pushNotifications,
   privacyPolicy,
   termsConditions,
-  logout,
-  delete;
+  logout;
 
   String getLabel(BuildContext context) => switch (this) {
         SettingsAction.account => context.i18n.common_account,
@@ -22,12 +21,10 @@ enum SettingsAction {
         SettingsAction.privacyPolicy => context.i18n.settings_privacy_policy,
         SettingsAction.termsConditions => context.i18n.settings_terms_conditions,
         SettingsAction.logout => context.i18n.settings_logout,
-        SettingsAction.delete => context.i18n.settings_delete,
       };
 
   Color getIconColor(BuildContext context) => switch (this) {
         SettingsAction.logout => context.theme.appColors.attentionRed,
-        SettingsAction.delete => context.theme.appColors.attentionRed,
         _ => context.theme.appColors.primaryAccent,
       };
 
@@ -40,7 +37,6 @@ enum SettingsAction {
       SettingsAction.privacyPolicy => Assets.svg.iconProfilePrivacypolicy,
       SettingsAction.termsConditions => Assets.svg.iconProfileTerms,
       SettingsAction.logout => Assets.svg.iconMenuLogout,
-      SettingsAction.delete => Assets.svg.iconBlockDelete,
     };
 
     return icon.icon(color: getIconColor(context));

--- a/lib/app/features/settings/views/account_settings_modal.dart
+++ b/lib/app/features/settings/views/account_settings_modal.dart
@@ -93,6 +93,13 @@ class AccountSettingsModal extends ConsumerWidget {
                     ContentLanguagesRoute().push<void>(context);
                   },
                 ),
+                ModalActionButton(
+                  icon: Assets.svg.iconBlockDelete.icon(
+                    color: context.theme.appColors.attentionRed,
+                  ),
+                  label: context.i18n.settings_delete,
+                  onTap: () => ConfirmDeleteRoute().push<void>(context),
+                ),
               ],
             ),
           ),

--- a/lib/app/features/settings/views/delete_confirm_modal.dart
+++ b/lib/app/features/settings/views/delete_confirm_modal.dart
@@ -15,9 +15,7 @@ import 'package:ion/generated/assets.gen.dart';
 import 'package:ion_identity_client/ion_identity.dart';
 
 class ConfirmDeleteModal extends HookConsumerWidget {
-  const ConfirmDeleteModal({required this.pubkey, super.key});
-
-  final String pubkey;
+  const ConfirmDeleteModal({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/app/features/settings/views/settings_modal.dart
+++ b/lib/app/features/settings/views/settings_modal.dart
@@ -35,7 +35,6 @@ class SettingsModal extends ConsumerWidget {
         SettingsAction.privacyPolicy => () => openUrlInAppBrowser(Links.privacy),
         SettingsAction.termsConditions => () => openUrlInAppBrowser(Links.terms),
         SettingsAction.logout => () => ConfirmLogoutRoute(pubkey: pubkey).push<void>(context),
-        SettingsAction.delete => () => ConfirmDeleteRoute(pubkey: pubkey).push<void>(context),
       };
     }
 

--- a/lib/app/features/user/providers/user_verify_identity_provider.c.dart
+++ b/lib/app/features/user/providers/user_verify_identity_provider.c.dart
@@ -5,6 +5,7 @@ import 'package:ion/app/features/auth/providers/auth_provider.c.dart';
 import 'package:ion/app/features/user/model/verify_identity_type.dart';
 import 'package:ion/app/features/user/providers/biometrics_provider.c.dart';
 import 'package:ion/app/services/ion_identity/ion_identity_provider.c.dart';
+import 'package:ion/app/services/logger/logger.dart';
 import 'package:ion_identity_client/ion_identity.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -75,6 +76,12 @@ Future<bool> isPasswordFlowUser(Ref ref) async {
 
 @riverpod
 Future<bool> isPasskeyAvailable(Ref ref) async {
-  final ionIdentity = await ref.read(ionIdentityProvider.future);
-  return ionIdentity(username: '').auth.isPasskeyAvailable();
+  try {
+    final ionIdentity = await ref.read(ionIdentityProvider.future);
+    return ionIdentity(username: '').auth.isPasskeyAvailable();
+  } catch (error, stackTrace) {
+    // intentionally ignore exceptions
+    Logger.log('Passkey check exception', error: error, stackTrace: stackTrace);
+    return false;
+  }
 }

--- a/lib/app/router/settings_routes.dart
+++ b/lib/app/router/settings_routes.dart
@@ -84,11 +84,9 @@ class ConfirmLogoutRoute extends BaseRouteData {
 }
 
 class ConfirmDeleteRoute extends BaseRouteData {
-  ConfirmDeleteRoute({required this.pubkey})
+  ConfirmDeleteRoute()
       : super(
-          child: ConfirmDeleteModal(pubkey: pubkey),
+          child: const ConfirmDeleteModal(),
           type: IceRouteType.bottomSheet,
         );
-
-  final String pubkey;
 }

--- a/packages/ion_identity_client/lib/src/core/types/ion_exception.dart
+++ b/packages/ion_identity_client/lib/src/core/types/ion_exception.dart
@@ -34,6 +34,10 @@ class BiometricsValidationException extends IONIdentityException {
   const BiometricsValidationException() : super('Biometrics validation failed');
 }
 
+class BiometricsEnrollmentException extends IONIdentityException {
+  const BiometricsEnrollmentException() : super('Biometrics enrollment failed');
+}
+
 class InvalidPasswordException extends IONIdentityException {
   const InvalidPasswordException() : super('Invalid Password');
 }


### PR DESCRIPTION
## Description
- Moved delete account action from user settings to user account modal.
- Wrapped isPasskeyAvailable with try catch and silently return false in case of exception so we can fallback to password flow
- Handling of negative scenario during biometrics enrollment


## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [x] Chore

## Screenshots (if applicable)

![Simulator Screenshot - iPhone 16 Pro Max - 2025-02-06 at 19 57 51](https://github.com/user-attachments/assets/7f970873-82ec-4775-95c6-7d4da70de105)
