### PR TITLE
fix: split replies REQ to kind1 and kind30175

### DIFF
--- a/lib/app/features/feed/providers/replies_data_source_provider.c.dart
+++ b/lib/app/features/feed/providers/replies_data_source_provider.c.dart
@@ -49,7 +49,7 @@ List<EntitiesDataSource>? repliesDataSource(
           (entity is PostEntity && entity.data.parentEvent?.eventReference == eventReference),
       requestFilters: [
         RequestFilter(
-          kinds: const [ModifiablePostEntity.kind, PostEntity.kind],
+          kinds: const [ModifiablePostEntity.kind],
           tags: Map.fromEntries([eventReference.toFilterEntry()]),
           search: SearchExtensions(
             [
@@ -72,6 +72,16 @@ List<EntitiesDataSource>? repliesDataSource(
                 currentPubkey: currentPubkey,
                 root: false,
               ).extensions,
+              ExpirationSearchExtension(expiration: false),
+            ],
+          ).toString(),
+          limit: 10,
+        ),
+        RequestFilter(
+          kinds: const [PostEntity.kind],
+          tags: Map.fromEntries([eventReference.toFilterEntry()]),
+          search: SearchExtensions(
+            [
               ...SearchExtensions.withCounters(
                 [
                   TagMarkerSearchExtension(


### PR DESCRIPTION
## Description
This PR splits the replies REQ to kind1 and kind30175 so that `amarker:reply` and `emarker:reply` do not intercept.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
