### PR TITLE
fix: misc fill profile screen fixes

### DIFF
--- a/lib/app/features/auth/views/pages/discover_creators/discover_creators.dart
+++ b/lib/app/features/auth/views/pages/discover_creators/discover_creators.dart
@@ -2,6 +2,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/button/button.dart';
 import 'package:ion/app/components/list_item/list_item.dart';
@@ -19,9 +20,11 @@ import 'package:ion/app/features/auth/views/components/auth_scrolled_body/auth_s
 import 'package:ion/app/features/auth/views/pages/discover_creators/creator_list_item.dart';
 import 'package:ion/app/features/components/verify_identity/verify_identity_prompt_dialog_helper.dart';
 import 'package:ion/app/features/core/model/feature_flags.dart';
+import 'package:ion/app/features/core/model/paged.c.dart';
 import 'package:ion/app/features/core/providers/feature_flags_provider.c.dart';
 import 'package:ion/app/features/ion_connect/providers/entities_paged_data_provider.c.dart';
 import 'package:ion/app/features/user/model/user_metadata.c.dart';
+import 'package:ion/app/hooks/use_on_init.dart';
 import 'package:ion/app/hooks/use_selected_state.dart';
 import 'package:ion/app/router/components/sheet_content/sheet_content.dart';
 import 'package:ion_identity_client/ion_identity.dart';
@@ -35,7 +38,6 @@ class DiscoverCreators extends HookConsumerWidget {
     final dataSource = ref.watch(contentCreatorsDataSourceProvider);
     final entitiesPagedData = ref.watch(entitiesPagedDataProvider(dataSource));
     final contentCreators = entitiesPagedData?.data.items?.whereType<UserMetadataEntity>();
-
     final hideCreatorsWithoutPicture = ref
         .read(featureFlagsProvider.notifier)
         .get(HideCreatorsWithoutPicture.hideCreatorsWithoutPicture);
@@ -43,6 +45,20 @@ class DiscoverCreators extends HookConsumerWidget {
     final filteredCreators = hideCreatorsWithoutPicture
         ? contentCreators?.where((creator) => creator.data.picture != null)
         : contentCreators;
+
+    final forceLoadMore = useState(false);
+    useOnInit(
+      () {
+        if (entitiesPagedData != null && entitiesPagedData.data is! PagedLoading) {
+          if (filteredCreators != null && filteredCreators.length < 20) {
+            forceLoadMore.value = true;
+            return;
+          }
+        }
+        forceLoadMore.value = false;
+      },
+      [filteredCreators, entitiesPagedData],
+    );
 
     ref.displayErrors(onboardingCompleteNotifierProvider);
 
@@ -84,6 +100,7 @@ class DiscoverCreators extends HookConsumerWidget {
               slivers: slivers,
               onLoadMore: ref.read(entitiesPagedDataProvider(dataSource).notifier).fetchEntities,
               hasMore: entitiesPagedData?.hasMore ?? false,
+              forceLoadMore: forceLoadMore.value,
               builder: (context, slivers) {
                 return AuthScrollContainer(
                   title: context.i18n.discover_creators_title,

--- a/lib/app/features/auth/views/pages/fill_profile/fill_profile.dart
+++ b/lib/app/features/auth/views/pages/fill_profile/fill_profile.dart
@@ -52,6 +52,7 @@ class FillProfile extends HookConsumerWidget {
     });
 
     return SheetContent(
+      bottomPadding: 0,
       body: KeyboardDismissOnTap(
         child: AuthScrollContainer(
           title: context.i18n.fill_profile_title,

--- a/lib/app/features/gallery/views/pages/album_selection_page.dart
+++ b/lib/app/features/gallery/views/pages/album_selection_page.dart
@@ -14,63 +14,72 @@ import 'package:ion/app/router/components/sheet_content/sheet_content.dart';
 class AlbumSelectionPage extends ConsumerWidget {
   const AlbumSelectionPage({
     required this.type,
+    this.isBottomSheet = false,
     super.key,
   });
 
   final MediaPickerType type;
+  final bool isBottomSheet;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final albumsAsync = ref.watch(albumsProvider(type: type));
     final currentAlbum = ref.watch(galleryNotifierProvider(type: type)).valueOrNull?.selectedAlbum;
 
-    return SheetContent(
-      body: CustomScrollView(
-        slivers: [
-          SliverAppBar(
-            primary: false,
-            flexibleSpace: NavigationAppBar.modal(
-              title: Text(
-                context.i18n.gallery_albums_select_title,
-                style: context.theme.appTextThemes.subtitle,
-              ),
-              onBackPress: () => context.pop(),
+    final content = CustomScrollView(
+      slivers: [
+        SliverAppBar(
+          primary: false,
+          flexibleSpace: NavigationAppBar.modal(
+            title: Text(
+              context.i18n.gallery_albums_select_title,
+              style: context.theme.appTextThemes.subtitle,
             ),
-            automaticallyImplyLeading: false,
-            toolbarHeight: NavigationAppBar.modalHeaderHeight,
-            pinned: true,
+            onBackPress: () => context.pop(),
           ),
-          SliverPadding(padding: EdgeInsets.only(top: 12.0.s)),
-          SliverList(
-            delegate: SliverChildBuilderDelegate(
-              childCount: albumsAsync.valueOrNull?.length ?? 0,
-              (context, index) {
-                final albums = albumsAsync.valueOrNull;
-                if (albums == null) {
-                  return const SizedBox.shrink();
-                }
+          automaticallyImplyLeading: false,
+          toolbarHeight: NavigationAppBar.modalHeaderHeight,
+          pinned: true,
+        ),
+        SliverPadding(padding: EdgeInsets.only(top: 12.0.s)),
+        SliverList(
+          delegate: SliverChildBuilderDelegate(
+            childCount: albumsAsync.valueOrNull?.length ?? 0,
+            (context, index) {
+              final albums = albumsAsync.valueOrNull;
+              if (albums == null) {
+                return const SizedBox.shrink();
+              }
 
-                if (index >= albums.length) return null;
+              if (index >= albums.length) return null;
 
-                final album = albums[index];
-                final isSelected = (album.id == currentAlbum?.id);
+              final album = albums[index];
+              final isSelected = (album.id == currentAlbum?.id);
 
-                return AlbumItem(
-                  albumId: album.id,
-                  name: album.name,
-                  assetCount: album.assetCount,
-                  isAll: album.isAll,
-                  isSelected: isSelected,
-                  onTap: () {
-                    ref.read(galleryNotifierProvider(type: type).notifier).selectAlbum(album);
-                    context.pop();
-                  },
-                );
-              },
-            ),
+              return AlbumItem(
+                albumId: album.id,
+                name: album.name,
+                assetCount: album.assetCount,
+                isAll: album.isAll,
+                isSelected: isSelected,
+                onTap: () {
+                  ref.read(galleryNotifierProvider(type: type).notifier).selectAlbum(album);
+                  context.pop();
+                },
+              );
+            },
           ),
-        ],
-      ),
+        ),
+      ],
     );
+
+    return isBottomSheet
+        ? SizedBox(
+            height: MediaQuery.sizeOf(context).height * 0.9,
+            child: content,
+          )
+        : SheetContent(
+            body: content,
+          );
   }
 }

--- a/lib/app/features/gallery/views/pages/media_picker_page.dart
+++ b/lib/app/features/gallery/views/pages/media_picker_page.dart
@@ -8,11 +8,13 @@ import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/gallery/data/models/gallery_state.c.dart';
 import 'package:ion/app/features/gallery/providers/providers.dart';
 import 'package:ion/app/features/gallery/views/components/components.dart';
+import 'package:ion/app/features/gallery/views/pages/album_selection_page.dart';
 import 'package:ion/app/features/gallery/views/pages/media_picker_type.dart';
 import 'package:ion/app/hooks/use_on_init.dart';
-import 'package:ion/app/router/app_routes.c.dart';
 import 'package:ion/app/router/components/navigation_app_bar/navigation_app_bar.dart';
 import 'package:ion/app/router/components/sheet_content/sheet_content.dart';
+import 'package:ion/app/router/utils/show_simple_bottom_sheet.dart';
+import 'package:ion/app/services/media_service/media_service.c.dart';
 
 class MediaPickerPage extends HookConsumerWidget {
   const MediaPickerPage({
@@ -57,7 +59,13 @@ class MediaPickerPage extends HookConsumerWidget {
         flexibleSpace: NavigationAppBar.modal(
           title: Button.dropdown(
             onPressed: () {
-              AlbumSelectionRoute(mediaPickerType: type).push<void>(context);
+              showSimpleBottomSheet<List<MediaFile>>(
+                context: context,
+                child: AlbumSelectionPage(
+                  type: type,
+                  isBottomSheet: true,
+                ),
+              );
             },
             label: Text(
               isAll ? context.i18n.core_all : albumName,


### PR DESCRIPTION
## Description
Misc onboarding flow fixes:

- “Discover creators” screen - sometimes screen is not filled fully with creators but they are added when user scrolls the screen;
- “Your profile” screen - white line appears above the keyboard when keyboard is opened;
- “Your profile” screen - “All photo” album selector is inactive on image picker modal for avatar upload flow;

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
