### PR TITLE
fix: separate text editor keys for different flows

### DIFF
--- a/lib/app/components/text_editor/components/suggestions_container.dart
+++ b/lib/app/components/text_editor/components/suggestions_container.dart
@@ -16,13 +16,15 @@ import 'package:ion/app/features/core/providers/feature_flags_provider.c.dart';
 class SuggestionsContainer extends HookConsumerWidget {
   const SuggestionsContainer({
     required this.scrollController,
+    required this.editorKey,
     super.key,
   });
 
   final ScrollController scrollController;
+  final GlobalKey<TextEditorState> editorKey;
 
   void _onSuggestionSelected(String suggestion) {
-    final textEditorState = TextEditor.textEditorKey.currentState;
+    final textEditorState = editorKey.currentState;
     textEditorState?.mentionsHashtagsHandler.onSuggestionSelected(suggestion);
   }
 
@@ -31,7 +33,7 @@ class SuggestionsContainer extends HookConsumerWidget {
     final suggestionsState = useTextEditorSuggestions(
       ref: ref,
       scrollController: scrollController,
-      editorKey: TextEditor.textEditorKey,
+      editorKey: editorKey,
     );
 
     final showMentionsSuggestions =

--- a/lib/app/components/text_editor/text_editor.dart
+++ b/lib/app/components/text_editor/text_editor.dart
@@ -10,16 +10,22 @@ import 'package:ion/app/components/text_editor/components/custom_blocks/text_edi
 import 'package:ion/app/components/text_editor/utils/mentions_hashtags_handler.dart';
 import 'package:ion/app/components/text_editor/utils/text_editor_styles.dart';
 
+class TextEditorKeys {
+  const TextEditorKeys._();
+
+  static GlobalKey<TextEditorState> createArticle() => GlobalKey<TextEditorState>();
+  static GlobalKey<TextEditorState> replyInput() => GlobalKey<TextEditorState>();
+  static GlobalKey<TextEditorState> createPost() => GlobalKey<TextEditorState>();
+}
+
 class TextEditor extends ConsumerStatefulWidget {
-  TextEditor(
+  const TextEditor(
     this.controller, {
-    Key? key,
+    required GlobalKey<TextEditorState> key,
     this.placeholder,
     this.focusNode,
     this.autoFocus = true,
-  }) : super(key: key ?? textEditorKey);
-
-  static final textEditorKey = GlobalKey<TextEditorState>();
+  }) : super(key: key);
 
   final QuillController controller;
   final String? placeholder;

--- a/lib/app/features/feed/create_article/views/pages/create_article_modal/components/article_main_toolbar.dart
+++ b/lib/app/features/feed/create_article/views/pages/create_article_modal/components/article_main_toolbar.dart
@@ -2,17 +2,20 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart';
+import 'package:ion/app/components/text_editor/text_editor.dart';
 import 'package:ion/app/features/feed/views/components/actions_toolbar/actions_toolbar.dart';
 import 'package:ion/app/features/feed/views/components/toolbar_buttons/toolbar_buttons.dart';
 
 class ArticleMainToolbar extends StatelessWidget {
   const ArticleMainToolbar({
     required this.textEditorController,
+    required this.textEditorKey,
     required this.onTypographyPressed,
     super.key,
   });
 
   final QuillController textEditorController;
+  final GlobalKey<TextEditorState> textEditorKey;
   final VoidCallback onTypographyPressed;
 
   @override
@@ -28,8 +31,14 @@ class ArticleMainToolbar extends StatelessWidget {
         ),
         ToolbarListButton(textEditorController: textEditorController, listType: Attribute.ul),
         ToolbarListQuoteButton(textEditorController: textEditorController),
-        ToolbarMentionButton(textEditorController: textEditorController),
-        ToolbarHashtagButton(textEditorController: textEditorController),
+        ToolbarMentionButton(
+          textEditorController: textEditorController,
+          textEditorKey: textEditorKey,
+        ),
+        ToolbarHashtagButton(
+          textEditorController: textEditorController,
+          textEditorKey: textEditorKey,
+        ),
         ToolbarSeparatorButton(textEditorController: textEditorController),
         ToolbarCodeButton(textEditorController: textEditorController),
       ],

--- a/lib/app/features/feed/create_article/views/pages/create_article_modal/components/create_article_toolbar.dart
+++ b/lib/app/features/feed/create_article/views/pages/create_article_modal/components/create_article_toolbar.dart
@@ -3,16 +3,19 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_quill/flutter_quill.dart';
+import 'package:ion/app/components/text_editor/text_editor.dart';
 import 'package:ion/app/features/feed/create_article/views/pages/create_article_modal/components/Article_typography_toolbar.dart';
 import 'package:ion/app/features/feed/create_article/views/pages/create_article_modal/components/article_main_toolbar.dart';
 
 class CreateArticleToolbar extends HookWidget {
   const CreateArticleToolbar({
     required this.textEditorController,
+    required this.textEditorKey,
     super.key,
   });
 
   final QuillController textEditorController;
+  final GlobalKey<TextEditorState> textEditorKey;
 
   @override
   Widget build(BuildContext context) {
@@ -29,6 +32,7 @@ class CreateArticleToolbar extends HookWidget {
             )
           : ArticleMainToolbar(
               textEditorController: textEditorController,
+              textEditorKey: textEditorKey,
               onTypographyPressed: () {
                 isTypographyToolbarVisible.value = true;
               },

--- a/lib/app/features/feed/create_article/views/pages/create_article_modal/create_article_modal.dart
+++ b/lib/app/features/feed/create_article/views/pages/create_article_modal/create_article_modal.dart
@@ -27,6 +27,7 @@ class CreateArticleModal extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final articleState = useCreateArticle(ref);
     final scrollController = useScrollController();
+    final textEditorKey = useMemoized(TextEditorKeys.createArticle);
 
     Future<bool?> showCancelCreationModal(BuildContext context) {
       return showSimpleBottomSheet<bool>(
@@ -117,6 +118,7 @@ class CreateArticleModal extends HookConsumerWidget {
                               autoFocus: isFocused,
                               articleState.textEditorController,
                               placeholder: context.i18n.create_article_story_placeholder,
+                              key: textEditorKey,
                             );
                           },
                         ),
@@ -131,11 +133,15 @@ class CreateArticleModal extends HookConsumerWidget {
             ),
             Column(
               children: [
-                SuggestionsContainer(scrollController: scrollController),
+                SuggestionsContainer(
+                  scrollController: scrollController,
+                  editorKey: textEditorKey,
+                ),
                 const HorizontalSeparator(),
                 ScreenSideOffset.small(
                   child: CreateArticleToolbar(
                     textEditorController: articleState.textEditorController,
+                    textEditorKey: textEditorKey,
                   ),
                 ),
               ],

--- a/lib/app/features/feed/create_post/views/components/reply_input_field/reply_input_field.dart
+++ b/lib/app/features/feed/create_post/views/components/reply_input_field/reply_input_field.dart
@@ -42,7 +42,7 @@ class ReplyInputField extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final textEditorController = useQuillController();
-
+    final textEditorKey = useMemoized(TextEditorKeys.replyInput);
     final currentUserMetadata = ref.watch(currentUserMetadataProvider).valueOrNull;
 
     final inputContainerKey = useRef(GlobalKey());
@@ -100,6 +100,7 @@ class ReplyInputField extends HookConsumerWidget {
                                 focusNode: focusNode,
                                 autoFocus: false,
                                 placeholder: context.i18n.post_reply_hint,
+                                key: textEditorKey,
                               ),
                             ),
                             if (hasFocus.value)

--- a/lib/app/features/feed/create_post/views/pages/create_post_modal/components/create_post_content.dart
+++ b/lib/app/features/feed/create_post/views/pages/create_post_modal/components/create_post_content.dart
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -104,6 +105,7 @@ class _TextInputSection extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final mediaFiles = attachedMediaNotifier.value;
+    final textEditorKey = useMemoized(TextEditorKeys.createPost);
     final links = useUrlLinks(
       textEditorController: textEditorController,
       mediaFiles: mediaFiles,
@@ -131,6 +133,7 @@ class _TextInputSection extends HookConsumerWidget {
                   TextEditor(
                     textEditorController,
                     placeholder: createOption.getPlaceholder(context),
+                    key: textEditorKey,
                   ),
                   if (mediaFiles.isNotEmpty) ...[
                     SizedBox(height: 12.0.s),

--- a/lib/app/features/feed/views/components/toolbar_buttons/toolbar_hashtag_button.dart
+++ b/lib/app/features/feed/views/components/toolbar_buttons/toolbar_hashtag_button.dart
@@ -8,8 +8,13 @@ import 'package:ion/app/features/feed/views/components/actions_toolbar_button/ac
 import 'package:ion/generated/assets.gen.dart';
 
 class ToolbarHashtagButton extends StatelessWidget {
-  const ToolbarHashtagButton({required this.textEditorController, super.key});
+  const ToolbarHashtagButton({
+    required this.textEditorController,
+    required this.textEditorKey,
+    super.key,
+  });
   final QuillController textEditorController;
+  final GlobalKey<TextEditorState> textEditorKey;
 
   @override
   Widget build(BuildContext context) {
@@ -26,7 +31,7 @@ class ToolbarHashtagButton extends StatelessWidget {
               ChangeSource.local,
             );
 
-          final textEditorState = TextEditor.textEditorKey.currentState;
+          final textEditorState = textEditorKey.currentState;
           if (textEditorState != null) {
             textEditorState.mentionsHashtagsHandler
               ..taggingCharacter = '#'

--- a/lib/app/features/feed/views/components/toolbar_buttons/toolbar_mention_button.dart
+++ b/lib/app/features/feed/views/components/toolbar_buttons/toolbar_mention_button.dart
@@ -9,8 +9,14 @@ import 'package:ion/app/features/feed/views/components/actions_toolbar_button/ac
 import 'package:ion/generated/assets.gen.dart';
 
 class ToolbarMentionButton extends ConsumerWidget {
-  const ToolbarMentionButton({required this.textEditorController, super.key});
+  const ToolbarMentionButton({
+    required this.textEditorController,
+    required this.textEditorKey,
+    super.key,
+  });
+
   final QuillController textEditorController;
+  final GlobalKey<TextEditorState> textEditorKey;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -27,7 +33,7 @@ class ToolbarMentionButton extends ConsumerWidget {
               ChangeSource.local,
             );
 
-          final textEditorState = TextEditor.textEditorKey.currentState;
+          final textEditorState = textEditorKey.currentState;
           if (textEditorState != null) {
             textEditorState.mentionsHashtagsHandler
               ..taggingCharacter = '@'


### PR DESCRIPTION
## Description
This PR fixes the exception: Duplicate GlobalKey detected in the widget tree, related to text editor use in different flows


## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

