### PR TITLE
fix: scroll down to text input on long posts reply

### DIFF
--- a/lib/app/features/feed/create_post/views/pages/create_post_modal/components/create_post_content.dart
+++ b/lib/app/features/feed/create_post/views/pages/create_post_modal/components/create_post_content.dart
@@ -17,6 +17,7 @@ import 'package:ion/app/features/feed/create_post/views/pages/create_post_modal/
 import 'package:ion/app/features/feed/create_post/views/pages/create_post_modal/hooks/use_url_links.dart';
 import 'package:ion/app/features/feed/views/components/url_preview_content/url_preview_content.dart';
 import 'package:ion/app/features/ion_connect/model/event_reference.c.dart';
+import 'package:ion/app/hooks/use_on_init.dart';
 import 'package:ion/app/services/media_service/media_service.c.dart';
 
 class CreatePostContent extends StatelessWidget {
@@ -48,10 +49,12 @@ class CreatePostContent extends StatelessWidget {
           children: [
             _VideoPreviewSection(attachedVideoNotifier: attachedVideoNotifier),
             if (parentEvent != null) _ParentEntitySection(eventReference: parentEvent!),
-            _TextInputSection(
-              textEditorController: textEditorController,
-              createOption: createOption,
-              attachedMediaNotifier: attachedMediaNotifier,
+            KeyboardVisibilityProvider(
+              child: _TextInputSection(
+                textEditorController: textEditorController,
+                createOption: createOption,
+                attachedMediaNotifier: attachedMediaNotifier,
+              ),
             ),
             if (quotedEvent != null) _QuotedEntitySection(eventReference: quotedEvent!),
           ],
@@ -106,6 +109,22 @@ class _TextInputSection extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final mediaFiles = attachedMediaNotifier.value;
     final textEditorKey = useMemoized(TextEditorKeys.createPost);
+    final isKeyboardVisible = KeyboardVisibilityProvider.isKeyboardVisible(context);
+    useOnInit(
+      () {
+        if (textEditorKey.currentContext != null && isKeyboardVisible) {
+          Future.delayed(const Duration(milliseconds: 300), () {
+            Scrollable.ensureVisible(
+              textEditorKey.currentContext!,
+              duration: const Duration(milliseconds: 100),
+              curve: Curves.easeInOut,
+            );
+          });
+        }
+      },
+      [isKeyboardVisible],
+    );
+
     final links = useUrlLinks(
       textEditorController: textEditorController,
       mediaFiles: mediaFiles,


### PR DESCRIPTION
## Description
Fix for the scenario when you want to add a reply to a post with long content and in the pop up with the reply input the content is not scrolled down to the input.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)

https://github.com/user-attachments/assets/b0f3de53-d7ef-44c9-8b80-62f7b23bd2ab

