### PR TITLE
fix(wallet): remove "back" button for the Send flow's first step

### DIFF
--- a/lib/app/features/wallets/views/pages/coins_flow/send_coins/send_coin_modal_page.dart
+++ b/lib/app/features/wallets/views/pages/coins_flow/send_coins/send_coin_modal_page.dart
@@ -24,7 +24,6 @@ class SendCoinModalPage extends ConsumerWidget {
           NetworkSelectSendRoute().push<void>(context);
         },
         title: context.i18n.wallet_send_coins,
-        showBackButton: true,
         onQueryChanged: (String query) {
           ref.read(filteredCoinsNotifierProvider.notifier).search(query);
         },


### PR DESCRIPTION
## Description
This PR removes "back" button for the "Send" dialog

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
