### PR TITLE
fix: remove user info menu

### DIFF
--- a/lib/app/features/feed/create_article/views/pages/create_article_preview_modal/components/article_preview.dart
+++ b/lib/app/features/feed/create_article/views/pages/create_article_preview_modal/components/article_preview.dart
@@ -8,7 +8,6 @@ import 'package:ion/app/features/auth/providers/auth_provider.c.dart';
 import 'package:ion/app/features/feed/create_article/providers/draft_article_provider.c.dart';
 import 'package:ion/app/features/feed/create_article/views/pages/create_article_preview_modal/components/article_preview_image.dart';
 import 'package:ion/app/features/feed/views/components/article/components/article_footer/article_footer.dart';
-import 'package:ion/app/features/feed/views/components/overlay_menu/user_info_menu.dart';
 import 'package:ion/app/features/feed/views/components/post/post_skeleton.dart';
 import 'package:ion/app/features/feed/views/components/user_info/user_info.dart';
 import 'package:ion/app/utils/algorithm.dart';
@@ -55,7 +54,6 @@ class ArticlePreview extends ConsumerWidget {
                 children: [
                   UserInfo(
                     pubkey: currentPubkey,
-                    trailing: UserInfoMenu(pubkey: currentPubkey),
                   ),
                   SizedBox(height: 10.0.s),
                   ArticlePreviewImage(


### PR DESCRIPTION
## Description
This PR removes the ability to open the user info options menu when we preview the article

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<img width="180" alt="Screenshot 2025-02-28 at 14 12 30" src="https://github.com/user-attachments/assets/dcc1b8ee-ce92-4321-a132-47607ae2b99b" />

