### PR TITLE
fix: do not allow to deselect all content languages

### DIFF
--- a/lib/app/features/settings/views/account_settings_modal.dart
+++ b/lib/app/features/settings/views/account_settings_modal.dart
@@ -96,7 +96,7 @@ class AccountSettingsModal extends HookConsumerWidget {
                           _RemainingLanguagesLabel(
                             value: contentLanguages.length,
                           )
-                        else
+                        else if (contentLanguages.isNotEmpty)
                           Text(
                             contentLanguages.first.name,
                             style:

--- a/lib/app/features/settings/views/content_language_modal.dart
+++ b/lib/app/features/settings/views/content_language_modal.dart
@@ -29,9 +29,11 @@ class ContentLanguageModal extends HookConsumerWidget {
           } else {
             updatedLanguages.add(lang);
           }
-          ref
-              .read(currentUserInterestsSetProvider(InterestSetType.languages).notifier)
-              .set(updatedLanguages.toList());
+          if (updatedLanguages.isNotEmpty) {
+            ref
+                .read(currentUserInterestsSetProvider(InterestSetType.languages).notifier)
+                .set(updatedLanguages.toList());
+          }
         }
       },
       selectedLanguages: selectedLanguages ?? [],


### PR DESCRIPTION
## Description
This PR fixes the issue when user could deselect all the languages in content languages modal

## Type of Change
- [x] Bug fix
