### PR TITLE
fix: remove duplicate p tags during reply

### DIFF
--- a/lib/app/features/feed/create_post/providers/create_post_notifier.c.dart
+++ b/lib/app/features/feed/create_post/providers/create_post_notifier.c.dart
@@ -282,11 +282,11 @@ class CreatePostNotifier extends _$CreatePostNotifier {
   }
 
   List<RelatedPubkey> _buildRelatedPubkeys(IonConnectEntity parentEntity) {
-    return [
+    return <RelatedPubkey>{
       RelatedPubkey(value: parentEntity.masterPubkey),
       if (parentEntity is ModifiablePostEntity) ...(parentEntity.data.relatedPubkeys ?? []),
       if (parentEntity is PostEntity) ...(parentEntity.data.relatedPubkeys ?? []),
-    ];
+    }.toList();
   }
 
   Future<({List<FileMetadata> fileMetadatas, MediaAttachment mediaAttachment})> _uploadMedia(


### PR DESCRIPTION
## Description
This PR removed duplicate `p` tags during reply

## Type of Change
- [x] Bug fix