### PR TITLE
fix: urls for old posts

### DIFF
--- a/lib/app/features/ion_connect/views/hooks/use_parsed_media_content.dart
+++ b/lib/app/features/ion_connect/views/hooks/use_parsed_media_content.dart
@@ -42,7 +42,11 @@ import 'package:ion/app/services/markdown/quill.dart';
           ? plainTextContentDelta
           : markdownContentDelta;
 
-  return _parseMediaContentDelta(delta: delta, media: media);
+  final mediaDeltaFallback = _parseMediaContentDelta(delta: delta, media: media);
+  return (
+    content: processDeltaMatches(mediaDeltaFallback.content),
+    media: mediaDeltaFallback.media
+  );
 }
 
 /// Parses the provided [delta] content to extract media links and separate them from non-media content.

--- a/lib/app/services/markdown/quill.dart
+++ b/lib/app/services/markdown/quill.dart
@@ -106,7 +106,7 @@ Delta markdownToDelta(String markdown) {
         processedDelta.insert(op.data, op.attributes);
       }
     } else {
-      _processMatches(op, processedDelta);
+      processedDelta.insert(op.data, op.attributes);
     }
   }
 


### PR DESCRIPTION
## Description
This PR fixes the issue with URLs displaying for media for old posts that we created without richText tag

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

