### PR TITLE
fix: link preview rendering condition

### DIFF
--- a/lib/app/features/feed/views/components/url_preview_content/url_preview_content.dart
+++ b/lib/app/features/feed/views/components/url_preview_content/url_preview_content.dart
@@ -31,7 +31,7 @@ class UrlPreviewContent extends HookWidget {
       key: ValueKey(normalizedUrl),
       url: normalizedUrl,
       builder: (meta, favIconUrl) {
-        if (meta == null) {
+        if (meta == null || meta.title == null || meta.title!.isEmpty) {
           return const SizedBox.shrink();
         }
 


### PR DESCRIPTION
## Description
This PR fixes an issue with rendering empty link previews, the metadata title becomes required

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

