### PR TITLE
feat: shadow for trending video overlay data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,8 +28,7 @@ migrate_working_dir/
 .packages
 .pub-cache/
 .pub/
-**/build/
-**/custom_lint.log
+/build/
 
 # Symbolication related
 app.*.symbols

--- a/lib/app/components/section_header/section_header.dart
+++ b/lib/app/components/section_header/section_header.dart
@@ -13,6 +13,7 @@ class SectionHeader extends StatelessWidget {
     String? title,
     this.onPress,
     this.leadingIcon,
+    this.trailingIconSize,
     double? leadingIconOffset,
   })  : leadingIconOffset = leadingIconOffset ?? 4.0.s,
         title = title ?? '';
@@ -21,6 +22,7 @@ class SectionHeader extends StatelessWidget {
   final double leadingIconOffset;
   final VoidCallback? onPress;
   final Widget? leadingIcon;
+  final double? trailingIconSize;
 
   @override
   Widget build(BuildContext context) {
@@ -47,7 +49,10 @@ class SectionHeader extends StatelessWidget {
                 padding: EdgeInsetsDirectional.only(
                   end: ScreenSideOffset.defaultSmallMargin - SectionHeaderButton.hitSlop,
                 ),
-                child: SectionHeaderButton(onPress!),
+                child: SectionHeaderButton(
+                  onPress!,
+                  iconSize: trailingIconSize,
+                ),
               ),
           ],
         ),

--- a/lib/app/components/section_header/section_header_button.dart
+++ b/lib/app/components/section_header/section_header_button.dart
@@ -11,18 +11,19 @@ class SectionHeaderButton extends StatelessWidget {
   const SectionHeaderButton(
     this.onPress, {
     super.key,
+    this.iconSize,
   });
 
   final VoidCallback onPress;
+  final double? iconSize;
 
   static double get hitSlop => 10.0.s;
 
-  static double get iconSize => 24.0.s;
-
-  static double get totalSize => iconSize + hitSlop * 2;
-
   @override
   Widget build(BuildContext context) {
+    final size = iconSize ?? 24.0.s;
+    final totalSize = size + hitSlop * 2;
+
     return SizedBox(
       width: totalSize,
       height: totalSize,
@@ -33,7 +34,8 @@ class SectionHeaderButton extends StatelessWidget {
           alignment: Alignment.center,
           transform: Matrix4.rotationY(pi),
           child: Assets.svg.iconChatBack.icon(
-            size: iconSize,
+            size: size,
+            flipForRtl: true,
           ),
         ),
       ),

--- a/lib/app/extensions/asset_gen_image.dart
+++ b/lib/app/extensions/asset_gen_image.dart
@@ -39,7 +39,7 @@ extension IconStringExtension on String {
     Color? color,
     double? size,
     BoxFit? fit,
-    bool flipForRtl = true,
+    bool flipForRtl = false,
   }) {
     final iconSize = size ?? 24.0.s;
     final colorFilter = color == null ? null : ColorFilter.mode(color, BlendMode.srcIn);
@@ -74,7 +74,7 @@ extension IconStringExtension on String {
     Color? color,
     double? width,
     double? height,
-    bool flipForRtl = true,
+    bool flipForRtl = false,
   }) {
     final iconWidth = width ?? 24.0.s;
     final iconHeight = height ?? 24.0.s;

--- a/lib/app/features/chat/community/channel/views/components/channel_detail_app_bar.dart
+++ b/lib/app/features/chat/community/channel/views/components/channel_detail_app_bar.dart
@@ -27,6 +27,7 @@ class ChannelDetailAppBar extends StatelessWidget {
               context.pop();
             },
             assetName: Assets.svg.iconProfileBack,
+            flipForRtl: true,
             opacity: 1,
           ),
           HeaderAction(

--- a/lib/app/features/chat/components/messaging_header/messaging_header.dart
+++ b/lib/app/features/chat/components/messaging_header/messaging_header.dart
@@ -32,7 +32,10 @@ class MessagingHeader extends StatelessWidget {
         children: [
           GestureDetector(
             onTap: () => Navigator.pop(context),
-            child: Assets.svg.iconChatBack.icon(size: 24.0.s),
+            child: Assets.svg.iconChatBack.icon(
+              size: 24.0.s,
+              flipForRtl: true,
+            ),
           ),
           SizedBox(width: 12.0.s),
           GestureDetector(

--- a/lib/app/features/core/providers/feature_flags_provider.c.dart
+++ b/lib/app/features/core/providers/feature_flags_provider.c.dart
@@ -24,8 +24,8 @@ class FeatureFlags extends _$FeatureFlags {
       if (ref.watch(envProvider.notifier).get(EnvVariable.SHOW_DEBUG_INFO)) ...{
         LoggerFeatureFlag.logApp: true,
         LoggerFeatureFlag.logRouters: false,
-        LoggerFeatureFlag.logIonConnect: true,
-        LoggerFeatureFlag.logIonIdentityClient: true,
+        LoggerFeatureFlag.logIonConnect: false,
+        LoggerFeatureFlag.logIonIdentityClient: false,
       },
     };
   }

--- a/lib/app/features/core/views/photo_gallery_page/photo_gallery_page.dart
+++ b/lib/app/features/core/views/photo_gallery_page/photo_gallery_page.dart
@@ -39,6 +39,7 @@ class PhotoGalleryPage extends HookWidget {
           icon: Assets.svg.iconChatBack.icon(
             size: NavigationAppBar.actionButtonSide,
             color: context.theme.appColors.onPrimaryAccent,
+            flipForRtl: true,
           ),
         ),
         title: Text(

--- a/lib/app/features/dapps/views/components/dapps_header/dapps_header.dart
+++ b/lib/app/features/dapps/views/components/dapps_header/dapps_header.dart
@@ -27,6 +27,7 @@ class DAppsHeader extends ConsumerWidget {
               onPressed: context.pop,
               icon: Assets.svg.iconBackArrow.icon(
                 color: context.theme.appColors.primaryText,
+                flipForRtl: true,
               ),
             ),
             SizedBox(width: 12.0.s),

--- a/lib/app/features/feed/views/pages/feed_page/components/trending_videos/components/trending_video_author.dart
+++ b/lib/app/features/feed/views/pages/feed_page/components/trending_videos/components/trending_video_author.dart
@@ -24,6 +24,14 @@ class TrendingVideoAuthor extends ConsumerWidget {
       return const SizedBox.shrink();
     }
 
+    final boxShadow = [
+      BoxShadow(
+        offset: const Offset(0, 1),
+        blurRadius: 1,
+        color: Colors.black.withValues(alpha: 0.40),
+      ),
+    ];
+
     return Padding(
       padding: EdgeInsets.all(8.0.s),
       child: TextButton(
@@ -44,6 +52,7 @@ class TrendingVideoAuthor extends ConsumerWidget {
                     overflow: TextOverflow.ellipsis,
                     style: context.theme.appTextThemes.caption3.copyWith(
                       color: context.theme.appColors.secondaryBackground,
+                      shadows: boxShadow,
                     ),
                   ),
                 ),

--- a/lib/app/features/feed/views/pages/feed_page/components/trending_videos/components/trending_video_likes_button.dart
+++ b/lib/app/features/feed/views/pages/feed_page/components/trending_videos/components/trending_video_likes_button.dart
@@ -2,10 +2,9 @@
 
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:ion/app/extensions/asset_gen_image.dart';
-import 'package:ion/app/extensions/build_context.dart';
-import 'package:ion/app/extensions/num.dart';
-import 'package:ion/app/extensions/theme_data.dart';
+import 'package:ion/app/components/shadow/svg_shadow.dart';
+import 'package:ion/app/extensions/extensions.dart';
+import 'package:ion/app/features/feed/providers/counters/like_reaction_provider.c.dart';
 import 'package:ion/app/features/feed/providers/counters/likes_count_provider.c.dart';
 import 'package:ion/app/features/ion_connect/model/event_reference.c.dart';
 import 'package:ion/app/utils/num.dart';
@@ -22,6 +21,16 @@ class TrendingVideoLikesButton extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final likesCount = ref.watch(likesCountProvider(eventReference));
+    final isLiked = ref.watch(isLikedProvider(eventReference));
+    final boxShadow = [
+      BoxShadow(
+        offset: const Offset(0, 1),
+        blurRadius: 1,
+        color: Colors.black.withValues(alpha: 0.40),
+      ),
+    ];
+    final appColors = context.theme.appColors;
+    final iconColor = isLiked ? appColors.attentionRed : appColors.onPrimaryAccent;
 
     return TextButton(
       style: TextButton.styleFrom(
@@ -30,16 +39,19 @@ class TrendingVideoLikesButton extends ConsumerWidget {
       onPressed: () {},
       child: Row(
         children: [
-          Assets.svg.iconVideoLikeOn.icon(
-            size: 14.0.s,
-            color: context.theme.appColors.secondaryBackground,
+          SvgShadow(
+            child: (isLiked ? Assets.svg.iconVideoLikeOn : Assets.svg.iconVideoLikeOff).icon(
+              size: 14.0.s,
+              color: iconColor,
+            ),
           ),
           Padding(
             padding: EdgeInsetsDirectional.only(start: 2.0.s),
             child: Text(
               formatDoubleCompact(likesCount),
               style: context.theme.appTextThemes.caption3.copyWith(
-                color: context.theme.appColors.secondaryBackground,
+                color: appColors.secondaryBackground,
+                shadows: boxShadow,
               ),
             ),
           ),

--- a/lib/app/features/feed/views/pages/feed_page/components/trending_videos/components/trending_video_menu_button.dart
+++ b/lib/app/features/feed/views/pages/feed_page/components/trending_videos/components/trending_video_menu_button.dart
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:flutter/material.dart';
-import 'package:ion/app/extensions/asset_gen_image.dart';
-import 'package:ion/app/extensions/build_context.dart';
-import 'package:ion/app/extensions/num.dart';
-import 'package:ion/app/extensions/theme_data.dart';
+import 'package:ion/app/components/shadow/svg_shadow.dart';
+import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/generated/assets.gen.dart';
 
 class TrendingVideoMenuButton extends StatelessWidget {
@@ -21,9 +19,11 @@ class TrendingVideoMenuButton extends StatelessWidget {
       width: 40.0.s,
       child: IconButton(
         onPressed: onPressed,
-        icon: Assets.svg.iconMorePopup.icon(
-          size: 16.0.s,
-          color: context.theme.appColors.secondaryBackground,
+        icon: SvgShadow(
+          child: Assets.svg.iconMorePopup.icon(
+            size: 16.0.s,
+            color: context.theme.appColors.onPrimaryAccent,
+          ),
         ),
       ),
     );

--- a/lib/app/features/feed/views/pages/feed_page/components/trending_videos/trending_videos.dart
+++ b/lib/app/features/feed/views/pages/feed_page/components/trending_videos/trending_videos.dart
@@ -57,6 +57,7 @@ class TrendingVideos extends ConsumerWidget {
           title: context.i18n.feed_trending_videos,
           leadingIcon: const VideosIcon(),
           leadingIconOffset: 8.0.s,
+          trailingIconSize: 20.0.s,
         ),
         LoadMoreBuilder(
           slivers: [

--- a/lib/app/features/feed/views/pages/fullscreen_media/fullscreen_media_page.dart
+++ b/lib/app/features/feed/views/pages/fullscreen_media/fullscreen_media_page.dart
@@ -51,6 +51,7 @@ class FullscreenMediaPage extends HookConsumerWidget {
               icon: Assets.svg.iconChatBack.icon(
                 size: NavigationAppBar.actionButtonSide,
                 color: context.theme.appColors.onPrimaryAccent,
+                flipForRtl: true,
               ),
             ),
             onBackPress: () => context.pop(),

--- a/lib/app/features/search/views/components/advanced_search_navigation/advanced_search_navigation.dart
+++ b/lib/app/features/search/views/components/advanced_search_navigation/advanced_search_navigation.dart
@@ -43,6 +43,7 @@ class AdvancedSearchNavigation extends HookConsumerWidget {
             onPressed: context.pop,
             icon: Assets.svg.iconBackArrow.icon(
               color: context.theme.appColors.primaryText,
+              flipForRtl: true,
             ),
           ),
           SizedBox(width: 12.0.s),

--- a/lib/app/features/user/pages/components/header_action/header_action.dart
+++ b/lib/app/features/user/pages/components/header_action/header_action.dart
@@ -14,6 +14,7 @@ class HeaderAction extends StatelessWidget {
     this.disabled = false,
     this.loading = false,
     this.opacity = 0,
+    this.flipForRtl = false,
     super.key,
   });
 
@@ -22,6 +23,7 @@ class HeaderAction extends StatelessWidget {
   final bool disabled;
   final bool loading;
   final double opacity;
+  final bool flipForRtl;
 
   static double get buttonSize => 40.0.s;
 
@@ -49,7 +51,11 @@ class HeaderAction extends StatelessWidget {
       tintColor: context.theme.appColors.primaryText,
       icon: loading
           ? const IONLoadingIndicator(type: IndicatorType.dark)
-          : assetName.icon(size: iconSize, color: context.theme.appColors.primaryText),
+          : assetName.icon(
+              size: iconSize,
+              color: context.theme.appColors.primaryText,
+              flipForRtl: flipForRtl,
+            ),
       onPressed: onPressed,
     );
   }

--- a/lib/app/features/user/pages/profile_edit_page/components/header/header.dart
+++ b/lib/app/features/user/pages/profile_edit_page/components/header/header.dart
@@ -27,6 +27,7 @@ class Header extends StatelessWidget {
               },
               opacity: 1,
               assetName: Assets.svg.iconProfileBack,
+              flipForRtl: true,
             ),
           ],
         ),

--- a/lib/app/features/user/pages/profile_page/components/header/header.dart
+++ b/lib/app/features/user/pages/profile_page/components/header/header.dart
@@ -41,6 +41,7 @@ class Header extends ConsumerWidget {
                   },
                   assetName: Assets.svg.iconProfileBack,
                   opacity: 1,
+                  flipForRtl: true,
                 ),
               Expanded(
                 child: Padding(

--- a/lib/app/features/video/views/pages/videos_vertical_scroll_page.dart
+++ b/lib/app/features/video/views/pages/videos_vertical_scroll_page.dart
@@ -106,6 +106,7 @@ class VideosVerticalScrollPage extends HookConsumerWidget {
             icon: Assets.svg.iconChatBack.icon(
               size: NavigationAppBar.actionButtonSide,
               color: onPrimaryAccentColor,
+              flipForRtl: true,
             ),
           ),
           onBackPress: () => context.pop(),

--- a/lib/app/router/components/navigation_app_bar/navigation_back_button.dart
+++ b/lib/app/router/components/navigation_app_bar/navigation_back_button.dart
@@ -36,6 +36,7 @@ class NavigationBackButton extends StatelessWidget {
         icon: icon ??
             Assets.svg.iconBackArrow.icon(
               size: iconSize,
+              flipForRtl: true,
             ),
       ),
     );

--- a/pubspec_overrides.yaml
+++ b/pubspec_overrides.yaml
@@ -1,5 +1,7 @@
-# melos_managed_dependency_overrides: ion_identity_client,js
+# melos_managed_dependency_overrides: ion_identity_client,js,ion_lint_rules
 dependency_overrides:
   ion_identity_client:
     path: packages/ion_identity_client
+  ion_lint_rules:
+    path: packages/ion_lint_rules
   js: ^0.7.1


### PR DESCRIPTION
## Description
- Added shadow for trending videos overlay data (icons and text);
- Shadow effect from svg icons not working in Flutter so used png instead;
- Made all icons not flip for RTL;


## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
![Simulator Screenshot - iPhone 16 Pro Max - 2025-04-03 at 10 12 03](https://github.com/user-attachments/assets/1531e2b4-38ad-4f09-a9e1-6b9f2d2dc877)

