### PR TITLE
feat: pause system playback on video unmute only

### DIFF
--- a/lib/app/features/auth/views/pages/intro_page/intro_page.dart
+++ b/lib/app/features/auth/views/pages/intro_page/intro_page.dart
@@ -18,26 +18,29 @@ class IntroPage extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     // We watch the intro page video controller here and ensure we pass the same parameters
     // (looping: true) to get the same instance of the already initialized provider from SplashPage.
-    final videoController = ref.watch(
-      videoControllerProvider(
-        VideoControllerParams(
-          sourcePath: Assets.videos.intro,
-          looping: true,
-          options: VideoPlayerOptions(mixWithOthers: true),
-        ),
-      ),
-    );
+    final videoController = ref
+        .watch(
+          videoControllerProvider(
+            VideoControllerParams(
+              sourcePath: Assets.videos.intro,
+              looping: true,
+            ),
+          ),
+        )
+        .value;
 
     // Playing the intro video as soon as the widget is built.
     // This ensures the video starts playing immediately after the page is displayed.
-    useOnInit(videoController.play);
+    useOnInit(() => videoController?.play(), [videoController]);
 
     return Scaffold(
       resizeToAvoidBottomInset: false,
       body: Stack(
         children: [
           // Fallback white background if the video isn't initialized or an error occurs.
-          if (!videoController.value.isInitialized || videoController.value.hasError)
+          if (videoController == null ||
+              !videoController.value.isInitialized ||
+              videoController.value.hasError)
             ColoredBox(
               color: Colors.white,
               child: Center(

--- a/lib/app/features/feed/create_post/views/pages/post_form_modal/components/video_preview_cover.dart
+++ b/lib/app/features/feed/create_post/views/pages/post_form_modal/components/video_preview_cover.dart
@@ -40,13 +40,15 @@ class VideoPreviewCover extends HookConsumerWidget {
       return const _VideoPlaceholder();
     }
 
-    final videoController = ref.watch(
-      videoControllerProvider(
-        VideoControllerParams(sourcePath: filePath, looping: true),
-      ),
-    );
+    final videoController = ref
+        .watch(
+          videoControllerProvider(
+            VideoControllerParams(sourcePath: filePath, looping: true),
+          ),
+        )
+        .value;
 
-    if (!videoController.value.isInitialized) {
+    if (videoController == null || !videoController.value.isInitialized) {
       return const _VideoPlaceholder();
     }
 

--- a/lib/app/features/feed/stories/hooks/use_story_video_progress.dart
+++ b/lib/app/features/feed/stories/hooks/use_story_video_progress.dart
@@ -16,7 +16,7 @@ CachedVideoPlayerPlusController? useVideoStoryProgress({
   required VoidCallback onCompleted,
 }) {
   final videoController = isVideo
-      ? ref.watch(videoControllerProvider(VideoControllerParams(sourcePath: videoUrl)))
+      ? ref.watch(videoControllerProvider(VideoControllerParams(sourcePath: videoUrl))).value
       : null;
 
   final wasCurrentRef = useRef<bool>(false);

--- a/lib/app/features/feed/stories/views/components/story_preview/media/story_video_preview.dart
+++ b/lib/app/features/feed/stories/views/components/story_preview/media/story_video_preview.dart
@@ -14,13 +14,15 @@ class StoryVideoPreview extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final videoController = ref.watch(
-      videoControllerProvider(
-        VideoControllerParams(sourcePath: path, autoPlay: true, looping: true),
-      ),
-    );
+    final videoController = ref
+        .watch(
+          videoControllerProvider(
+            VideoControllerParams(sourcePath: path, autoPlay: true, looping: true),
+          ),
+        )
+        .value;
 
-    if (!videoController.value.isInitialized) {
+    if (videoController == null || !videoController.value.isInitialized) {
       return const CenteredLoadingIndicator();
     }
 

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/video_story_viewer.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/video_story_viewer.dart
@@ -4,9 +4,7 @@ import 'package:cached_video_player_plus/cached_video_player_plus.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/progress_bar/centered_loading_indicator.dart';
-import 'package:ion/app/features/core/providers/mute_provider.c.dart';
 import 'package:ion/app/features/core/providers/video_player_provider.c.dart';
-import 'package:ion/app/hooks/use_on_init.dart';
 
 class VideoStoryViewer extends HookConsumerWidget {
   const VideoStoryViewer({
@@ -18,21 +16,17 @@ class VideoStoryViewer extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final isMuted = ref.watch(globalMuteProvider);
-    final videoController = ref.watch(
-      videoControllerProvider(
-        VideoControllerParams(sourcePath: videoPath),
-      ),
-    );
+    final videoController = ref
+        .watch(
+          videoControllerProvider(
+            VideoControllerParams(sourcePath: videoPath),
+          ),
+        )
+        .value;
 
-    if (!videoController.value.isInitialized) {
+    if (videoController == null || !videoController.value.isInitialized) {
       return const CenteredLoadingIndicator();
     }
-
-    useOnInit(
-      () => videoController.setVolume(isMuted ? 0 : 1),
-      [isMuted],
-    );
 
     final videoAspectRatio = videoController.value.aspectRatio;
 


### PR DESCRIPTION
## Description
Pause system playback only when a video in the app is unmuted. And allow it back what a vdeo in the app is muted again.
It is achieved by setting mixWithOthers to isMuted value. But that can be set only during video controller creation. So I changed videoControllerProvider to return Future<Raw<CachedVideoPlayerPlusController>> in order to return only fully baked and initialized controller and in case of recreation when globalMuteProvider is changed - keep the position and playback status of current one.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Chore

