### PR TITLE
chore: add build number to the force update version comparison

### DIFF
--- a/lib/app/features/force_update/providers/force_update_provider.c.dart
+++ b/lib/app/features/force_update/providers/force_update_provider.c.dart
@@ -33,7 +33,7 @@ class ForceUpdate extends _$ForceUpdate {
       final minVersion = await repository.getMinVersion();
 
       final appInfo = await ref.read(appInfoProvider.future);
-      final appVersion = appInfo.version;
+      final appVersion = '${appInfo.version}.${appInfo.buildNumber}';
 
       return compareVersions(appVersion, minVersion) == -1;
     } catch (error, stackTrace) {


### PR DESCRIPTION
## Description
This PR adds the app build number to the force update version comparison, so
`9.9.9` -> `9.9.9.989`
missing parts are considered `0` during the comparison, so `9.9.9` eq `9.9.9.0`

## Type of Change
- [x] Chore
