### PR TITLE
fix: seamless transition to intro video

### DIFF
--- a/lib/app/features/auth/views/pages/intro_page/intro_page.dart
+++ b/lib/app/features/auth/views/pages/intro_page/intro_page.dart
@@ -7,7 +7,6 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/button/button.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/core/providers/video_player_provider.c.dart';
-import 'package:ion/app/hooks/use_on_init.dart';
 import 'package:ion/app/router/app_routes.c.dart';
 import 'package:ion/generated/assets.gen.dart';
 
@@ -24,21 +23,11 @@ class IntroPage extends HookConsumerWidget {
             VideoControllerParams(
               sourcePath: Assets.videos.intro,
               looping: true,
+              autoPlay: true,
             ),
           ),
         )
         .value;
-
-    // Playing the intro video as soon as the widget is built.
-    // This ensures the video starts playing immediately after the page is displayed.
-    useOnInit(
-      () {
-        if (videoController?.value.isInitialized ?? false) {
-          videoController?.play();
-        }
-      },
-      [videoController],
-    );
 
     return Scaffold(
       resizeToAvoidBottomInset: false,

--- a/lib/app/features/core/views/pages/splash_page.dart
+++ b/lib/app/features/core/views/pages/splash_page.dart
@@ -37,7 +37,7 @@ class SplashPage extends HookConsumerWidget {
     // This ensures a seamless transition to the IntroPage without flickering or delays.
     ref.watch(
       videoControllerProvider(
-        VideoControllerParams(sourcePath: Assets.videos.intro, looping: true),
+        VideoControllerParams(sourcePath: Assets.videos.intro, looping: true, autoPlay: true),
       ),
     );
 

--- a/lib/app/router/app_routes.c.dart
+++ b/lib/app/router/app_routes.c.dart
@@ -297,7 +297,7 @@ class ErrorRoute extends BaseRouteData {
   routes: [...AuthRoutes.routes],
 )
 class IntroRoute extends BaseRouteData {
-  IntroRoute() : super(child: const IntroPage());
+  IntroRoute() : super(child: const IntroPage(), type: IceRouteType.singleWithoutTransition);
 }
 
 class FeedMainModalRoute extends BaseRouteData {

--- a/lib/app/router/base_route_data.dart
+++ b/lib/app/router/base_route_data.dart
@@ -14,6 +14,7 @@ import 'package:smooth_sheets/smooth_sheets.dart';
 
 enum IceRouteType {
   single,
+  singleWithoutTransition,
   bottomSheet,
   slideFromLeft,
   fade,
@@ -47,6 +48,13 @@ abstract class BaseRouteData extends GoRouteData {
             },
             child: child,
           ),
+        ),
+      IceRouteType.singleWithoutTransition => CustomTransitionPage<void>(
+          key: state.pageKey,
+          transitionDuration: Duration.zero,
+          reverseTransitionDuration: Duration.zero,
+          transitionsBuilder: (context, animation, secondaryAnimation, child) => child,
+          child: child,
         ),
       IceRouteType.bottomSheet => FadeTransitionSheetPage(child: child, state: state),
       IceRouteType.slideFromLeft => SlideFromLeftTransitionPage(child: child, state: state),


### PR DESCRIPTION
## Description
- Removed transition from splash to into screen;
- Start splash video at the same time with into one so at the moment of transition it continues playing (splash one has the same section at the beginning as the whole intro video);

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screensh

https://github.com/user-attachments/assets/1a63e0a9-05b1-493b-8187-e2b16bf7b580

ots (if applicable)

