### PR TITLE
fix: add configuration to query mailto url scheme

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -30,6 +30,11 @@
             <data android:scheme="https" />
         </intent>
 
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="mailto" />
+        </intent>
+
         <package android:name="com.google.android.apps.authenticator2" />
         <package android:name="com.azure.authenticator" />
         <package android:name="com.lastpass.authenticator" />

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -34,6 +34,7 @@
 			<string>lastpassmfa</string>
 			<string>authy</string>
 			<string>userlock</string>
+			<string>mailto</string>
 		</array>
 		<key>LSRequiresIPhoneOS</key>
 		<true />


### PR DESCRIPTION
## Description
This PR fixes the `mailto` url scheme handling on android and iOS

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
