### PR TITLE
chore: add backward compatibility for parent post lookup

### DIFF
--- a/lib/app/features/ion_connect/model/entity_data_with_parent.dart
+++ b/lib/app/features/ion_connect/model/entity_data_with_parent.dart
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: ice License 1.0
 
-import 'package:collection/collection.dart';
 import 'package:ion/app/features/ion_connect/model/related_event.c.dart';
 import 'package:ion/app/features/ion_connect/model/related_event_marker.dart';
 
@@ -8,7 +7,23 @@ mixin EntityDataWithRelatedEvents {
   List<RelatedEvent>? get relatedEvents;
 
   RelatedEvent? get parentEvent {
-    return relatedEvents?.firstWhereOrNull((event) => event.marker == RelatedEventMarker.reply);
+    if (relatedEvents == null) return null;
+
+    RelatedEvent? rootReplyId;
+    RelatedEvent? replyId;
+    for (final relatedEvent in relatedEvents!) {
+      if (relatedEvent.marker == RelatedEventMarker.reply) {
+        replyId = relatedEvent;
+        break;
+      } else if (relatedEvent.marker == RelatedEventMarker.root) {
+        rootReplyId = relatedEvent;
+      }
+    }
+    return replyId ?? rootReplyId;
+
+    //TODO: Remove code above and uncomment bottom line after release.
+    // We need to support looking for a `root` reference modifiers for backward compatibility with already created posts.
+    // return relatedEvents?.firstWhereOrNull((event) => event.marker == RelatedEventMarker.reply);
   }
 
   static List<RelatedEvent>? fromTags(Map<String, List<List<String>>> tags) {


### PR DESCRIPTION
## Description
This PR adds backward compatibility for parent post lookup - previously we had only `root` modifier for the root replies thus had to look either for `root` OR `reply` references.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [x] Chore
