### PR TITLE
fix: media attachment limits

### DIFF
--- a/lib/app/features/feed/create_post/views/pages/post_form_modal/components/create_post_bottom_panel.dart
+++ b/lib/app/features/feed/create_post/views/pages/post_form_modal/components/create_post_bottom_panel.dart
@@ -162,12 +162,16 @@ class _ActionsSection extends StatelessWidget {
   Widget build(BuildContext context) {
     final isVideo = createOption == CreatePostOption.video;
 
+    final alreadyAttachedMediaCount =
+        attachedMediaNotifier.value.length + attachedMediaLinksNotifier.value.length;
+
     return ScreenSideOffset.small(
       child: ActionsToolbar(
         actions: [
           ToolbarMediaButton(
             delegate: AttachedMediaHandler(attachedMediaNotifier),
-            maxMedia: isVideo ? 1 : ModifiablePostEntity.contentMediaLimit,
+            maxMedia:
+                isVideo ? 1 : ModifiablePostEntity.contentMediaLimit - alreadyAttachedMediaCount,
             enabled: !isVideo,
           ),
           ToolbarPollButton(


### PR DESCRIPTION
## Description
This PR fixes ability to attach more than 10 media attachments when creating or editing the post

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

