### PR TITLE
fix: bookmarks no collections layout fix

### DIFF
--- a/lib/app/features/feed/views/pages/add_bookmark_modal/add_bookmark_modal.dart
+++ b/lib/app/features/feed/views/pages/add_bookmark_modal/add_bookmark_modal.dart
@@ -48,7 +48,7 @@ class AddBookmarkModal extends ConsumerWidget {
                       ),
                       SizedBox(height: 16.0.s),
                       const HorizontalSeparator(),
-                      SizedBox(height: 16.0.s),
+                      if (collectionsDTags.isNotEmpty) SizedBox(height: 16.0.s),
                     ],
                   ),
                 ),


### PR DESCRIPTION
## Description
Fixed UI issue for bookmarks pop up when there is just a default collection

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
