### PR TITLE
fix(wallet): check if `event_id` column exists in wallets db migration

### DIFF
--- a/lib/app/features/wallets/data/database/wallets_database.c.dart
+++ b/lib/app/features/wallets/data/database/wallets_database.c.dart
@@ -103,7 +103,15 @@ class WalletsDatabase extends _$WalletsDatabase {
           await m.deleteTable(oldTransactionsTableName);
         },
         from7To8: (m, schema) async {
-          await m.addColumn(schema.transactionsTableV2, schema.transactionsTableV2.eventId);
+          final rows = await customSelect(
+            'PRAGMA table_info(${schema.transactionsTableV2.actualTableName})',
+          ).get();
+
+          final columnExists = rows.any((row) => row.data['name'] == 'event_id');
+
+          if (!columnExists) {
+            await m.addColumn(schema.transactionsTableV2, schema.transactionsTableV2.eventId);
+          }
         },
       ),
     );


### PR DESCRIPTION
## Description
This PR fixes an issue where a database migration attempted to add a column that already existed in the table, causing the migration to fail.

## Type of Change
- [x] Bug fix
