### PR TITLE
build: set rebase workflow token

### DIFF
--- a/.github/workflows/rebase.yaml
+++ b/.github/workflows/rebase.yaml
@@ -14,4 +14,5 @@ jobs:
       - uses: peter-evans/rebase@v3
         with:
           base: master
+          token: ${{ secrets.ICE_CI_CD_BOT_GH_PAT }}
           exclude-drafts: true


### PR DESCRIPTION
## Description
Use a `PAT` token, because otherwise `CI` workflow is not triggered on rebase from bot

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
