### PR TITLE
fix: keep local event message record in sync with latest data

### DIFF
--- a/lib/app/features/chat/model/database/dao/conversation_event_message_dao.c.dart
+++ b/lib/app/features/chat/model/database/dao/conversation_event_message_dao.c.dart
@@ -67,7 +67,8 @@ class ConversationEventMessageDao extends DatabaseAccessor<ChatDatabase>
       return true;
     }
 
-    return newEvent.createdAt.isAfter(existingEventMessage.createdAt);
+    return newEvent.createdAt.isAfter(existingEventMessage.createdAt) ||
+        newEvent.createdAt.isAtSameMomentAs(existingEventMessage.createdAt);
   }
 
   /// Get the creation date of the most recent event messages of specific kinds


### PR DESCRIPTION
## Description
When we create local event messages in the chat database, media files are initially saved to a local path. After we receive them from the relay, we must update them with the remote URLs.

## Additional Notes
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
