### PR TITLE
fix: attached user metadata ephemeral event

### DIFF
--- a/lib/app/features/push_notifications/providers/app_translations_provider.c.dart
+++ b/lib/app/features/push_notifications/providers/app_translations_provider.c.dart
@@ -77,6 +77,7 @@ class Translator<T extends AppConfigWithVersion> {
       refreshInterval: refreshInterval,
       parser: (data) =>
           PushNotificationTranslations.fromJson(jsonDecode(data) as Map<String, dynamic>),
+      checkVersion: true,
     );
   }
 

--- a/lib/app/features/user/providers/user_events_metadata_provider.c.dart
+++ b/lib/app/features/user/providers/user_events_metadata_provider.c.dart
@@ -2,11 +2,11 @@
 
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/exceptions/exceptions.dart';
+import 'package:ion/app/features/ion_connect/ion_connect.dart';
 import 'package:ion/app/features/ion_connect/model/event_reference.c.dart';
 import 'package:ion/app/features/ion_connect/model/events_metadata.c.dart';
 import 'package:ion/app/features/ion_connect/model/events_metadata_builder.dart';
-import 'package:ion/app/features/user/model/user_delegation.c.dart';
-import 'package:ion/app/features/user/model/user_metadata.c.dart';
+import 'package:ion/app/features/ion_connect/providers/ion_connect_notifier.c.dart';
 import 'package:ion/app/features/user/providers/user_delegation_provider.c.dart';
 import 'package:ion/app/features/user/providers/user_metadata_provider.c.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -14,26 +14,18 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'user_events_metadata_provider.c.g.dart';
 
 class UserEventsMetadataBuilder implements EventsMetadataBuilder {
-  UserEventsMetadataBuilder({
-    required UserMetadataEntity currentUserMetadata,
-    required UserDelegationEntity currentUserDelegation,
-  })  : _currentUserMetadata = currentUserMetadata,
-        _currentUserDelegation = currentUserDelegation;
+  UserEventsMetadataBuilder(List<EventMessage> metadataEvents) : _metadataEvents = metadataEvents;
 
-  final UserMetadataEntity _currentUserMetadata;
-  final UserDelegationEntity _currentUserDelegation;
+  final List<EventMessage> _metadataEvents;
 
   @override
   Future<List<EventsMetadata>> buildMetadata(List<EventReference> eventReferences) async {
     return [
-      EventsMetadata(
-        eventReferences: eventReferences,
-        metadata: await _currentUserMetadata.toEntityEventMessage(),
-      ),
-      EventsMetadata(
-        eventReferences: eventReferences,
-        metadata: await _currentUserDelegation.toEntityEventMessage(),
-      ),
+      for (final event in _metadataEvents)
+        EventsMetadata(
+          eventReferences: eventReferences,
+          metadata: event,
+        ),
     ];
   }
 }
@@ -47,11 +39,20 @@ Future<UserEventsMetadataBuilder> userEventsMetadataBuilder(Ref ref) async {
     ref.watch(currentUserMetadataProvider.future),
     ref.watch(currentUserDelegationProvider.future),
   ).wait;
+  final ionConnectNotifier = ref.watch(ionConnectNotifierProvider.notifier);
+
   if (currentUserMetadata == null || currentUserDelegation == null) {
     throw UserEventsMetadataBuilderException();
   }
+
   return UserEventsMetadataBuilder(
-    currentUserMetadata: currentUserMetadata,
-    currentUserDelegation: currentUserDelegation,
+    await Future.wait([
+      // Do not use `toEntityEventMessage` for UserMetadataEntity because
+      // recent changes removed some fields from MediaAttachment and now
+      // toEntityEventMessage produces an event message that is not equal to original event.
+      // TODO: use toEntityEventMessage after the release
+      ionConnectNotifier.sign(currentUserMetadata.data),
+      Future.value(currentUserDelegation.toEntityEventMessage()),
+    ]),
   );
 }


### PR DESCRIPTION
## Description
This PR fixes `toEntityEventMessage` for ephemeral user metadata event

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

