### PR TITLE
fix: take only language code when building translations url

### DIFF
--- a/lib/app/features/push_notifications/providers/app_translations_provider.c.dart
+++ b/lib/app/features/push_notifications/providers/app_translations_provider.c.dart
@@ -72,7 +72,7 @@ class Translator<T extends AppConfigWithVersion> {
     final refreshInterval = Duration(minutes: cacheMinutes).inMilliseconds;
     return translations[locale] =
         await _translationsRepository.getConfig<PushNotificationTranslations>(
-      'ion-app_push-notifications_translations_$locale',
+      'ion-app_push-notifications_translations_${locale.languageCode}',
       cacheStrategy: AppConfigCacheStrategy.file,
       refreshInterval: refreshInterval,
       parser: (data) =>


### PR DESCRIPTION
## Description
This PR fixes the push translations url building, previously it was `en_US`, but we need only `en`

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore