### PR TITLE
fix: add timestamp field to WhoCanReplyEventSetting

### DIFF
--- a/lib/app/features/ion_connect/model/event_setting.c.dart
+++ b/lib/app/features/ion_connect/model/event_setting.c.dart
@@ -47,7 +47,7 @@ class WhoCanReplyEventSetting with _$WhoCanReplyEventSetting implements EventSet
     }
 
     final values = tag[2].split(',').map(WhoCanReplySettingsOption.fromTagValue).toSet();
-    final timestamp = int.tryParse(tag[3]) ?? 0;
+    final timestamp = int.parse(tag[3]);
     return WhoCanReplyEventSetting(values: values, timestamp: timestamp);
   }
 


### PR DESCRIPTION
## Description
Add timestamp for toTag to fix signature issue

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
