### PR TITLE
fix: send read status for the latest received message

### DIFF
--- a/lib/app/features/chat/providers/conversation_messages_provider.c.dart
+++ b/lib/app/features/chat/providers/conversation_messages_provider.c.dart
@@ -22,9 +22,9 @@ class ConversationMessages extends _$ConversationMessages {
 
     final stream = ref.watch(conversationMessageDaoProvider).getMessages(conversationId);
 
-    final subscription = stream.listen((event) async {
+    final subscription = stream.listen((event) {
       final messages = event.entries.map((e) => e.value).expand((e) => e).toList();
-      await sendReadStatus(messages);
+      _sendReadStatus(messages);
     });
 
     ref.onDispose(subscription.cancel);
@@ -32,7 +32,7 @@ class ConversationMessages extends _$ConversationMessages {
     return stream;
   }
 
-  Future<void> sendReadStatus(List<EventMessage> messages) async {
+  Future<void> _sendReadStatus(List<EventMessage> messages) async {
     final currentUserMasterPubkey = ref.watch(currentPubkeySelectorProvider);
 
     if (currentUserMasterPubkey == null) {


### PR DESCRIPTION
## Description
This PR fix addresses a scenario where, if a user sends a message outside the messages screen, the app was attempting to mark the sent message as read. Instead, we need to send the read status for the most recently received message.

## Additional Notes
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
