### PR TITLE
fix: validate referral code only when provided during profile setup

### DIFF
--- a/lib/app/features/auth/views/pages/fill_profile/fill_profile.dart
+++ b/lib/app/features/auth/views/pages/fill_profile/fill_profile.dart
@@ -73,7 +73,9 @@ class FillProfile extends HookConsumerWidget {
         }
         ref.read(onboardingDataProvider.notifier).name = nickname.value;
         ref.read(onboardingDataProvider.notifier).displayName = name.value;
-        ref.read(onboardingDataProvider.notifier).referralName = referral.value;
+        if (referral.value.isNotEmpty) {
+          ref.read(onboardingDataProvider.notifier).referralName = referral.value;
+        }
         if (context.mounted) {
           await SelectLanguagesRoute().push<void>(context);
         }


### PR DESCRIPTION
## Description
- Validate referral code only when provided during profile setup
- Only set referral name if value is not empty during profile fill

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore