### PR TITLE
fix: add padding to NetworkListView

### DIFF
--- a/lib/app/features/wallets/views/pages/coins_flow/network_list/network_list_view.dart
+++ b/lib/app/features/wallets/views/pages/coins_flow/network_list/network_list_view.dart
@@ -107,20 +107,23 @@ class NetworkListView extends ConsumerWidget {
             ),
           ),
           Flexible(
-            child: ScreenSideOffset.small(
-              child: coinsState.maybeMap(
-                data: (data) => _NetworksList(
-                  itemCount: data.value.length,
-                  itemBuilder: (BuildContext context, int index) {
-                    final coin = data.value[index];
-                    return NetworkItem(
-                      coinInWallet: coin,
-                      network: coin.coin.network,
-                      onTap: () => onTap(coin.coin.network),
-                    );
-                  },
+            child: Padding(
+              padding: EdgeInsetsDirectional.only(bottom: 32.0.s),
+              child: ScreenSideOffset.small(
+                child: coinsState.maybeMap(
+                  data: (data) => _NetworksList(
+                    itemCount: data.value.length,
+                    itemBuilder: (BuildContext context, int index) {
+                      final coin = data.value[index];
+                      return NetworkItem(
+                        coinInWallet: coin,
+                        network: coin.coin.network,
+                        onTap: () => onTap(coin.coin.network),
+                      );
+                    },
+                  ),
+                  orElse: () => const _LoadingState(),
                 ),
-                orElse: () => const _LoadingState(),
               ),
             ),
           ),


### PR DESCRIPTION
## Description
Fix bottom padding of "Choose network" modal

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
before:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/9e19174e-280a-4209-abc5-516f11f271fc" />
after:
<img width="359" alt="image" src="https://github.com/user-attachments/assets/e23d9a05-ad19-41fe-9f22-f153504f422f" />

