### PR TITLE
fix: JSON serialization in notification service

### DIFF
--- a/ios/NotificationServiceExtension/Translation/Entities/IonConnectGiftWrapEntity.swift
+++ b/ios/NotificationServiceExtension/Translation/Entities/IonConnectGiftWrapEntity.swift
@@ -54,12 +54,10 @@ struct IonConnectGiftWrapEntity: IonConnectEntity {
             throw IncorrectEventKindException(eventMessage.id, kind: kind)
         }
 
-        let masterPubkey = try eventMessage.masterPubkey()
-
         return IonConnectGiftWrapEntity(
             id: eventMessage.id,
             pubkey: eventMessage.pubkey,
-            masterPubkey: masterPubkey,
+            masterPubkey: eventMessage.pubkey,
             signature: eventMessage.sig ?? "",
             createdAt: eventMessage.createdAt,
             data: IonConnectGiftWrapData.fromEventMessage(eventMessage)

--- a/ios/NotificationServiceExtension/Translation/Events/EventMessage.swift
+++ b/ios/NotificationServiceExtension/Translation/Events/EventMessage.swift
@@ -72,7 +72,7 @@ struct EventMessage: Decodable {
         guard
             let jsonData = try? JSONSerialization.data(
                 withJSONObject: eventData,
-                options: []
+                options: [.withoutEscapingSlashes]
             ),
             let jsonString = String(data: jsonData, encoding: .utf8)
         else {


### PR DESCRIPTION
## Description
- Fix signature validation by fixing json serialization
- Fix `GenericRepostData `
- Fix `IonConnectGiftWrapEntity`

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
