### PR TITLE
fix(chat): update shared story message to conditionally display sender/receiver label

### DIFF
--- a/lib/app/features/chat/views/components/message_items/message_types/post_message/shared_story_message.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/post_message/shared_story_message.dart
@@ -6,6 +6,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/auth/providers/auth_provider.c.dart';
 import 'package:ion/app/features/chat/e2ee/providers/e2ee_delete_event_provider.c.dart';
+import 'package:ion/app/features/chat/hooks/use_has_reaction.dart';
 import 'package:ion/app/features/chat/views/components/message_items/message_item_wrapper/message_item_wrapper.dart';
 import 'package:ion/app/features/chat/views/components/message_items/message_reactions/message_reactions.dart';
 import 'package:ion/app/features/chat/views/components/message_items/message_types/text_message/text_message.dart';
@@ -74,6 +75,9 @@ class SharedStoryMessage extends HookConsumerWidget {
       },
     );
 
+    final isReplyToStory =
+        useHasReaction(replyEventMessage, ref) || replyEventMessage.content.isNotEmpty;
+
     return Container(
       margin: margin,
       child: Align(
@@ -91,7 +95,7 @@ class SharedStoryMessage extends HookConsumerWidget {
               child: Column(
                 crossAxisAlignment: isMe ? CrossAxisAlignment.end : CrossAxisAlignment.start,
                 children: [
-                  _SenderReceiverLabel(isMe: isMe),
+                  if (isReplyToStory) _SenderReceiverLabel(isMe: isMe),
                   if (storyUrl.isNotEmpty && !storyExpired && !storyDeleted)
                     _StoryPreviewImage(
                       isMe: isMe,


### PR DESCRIPTION
## Description
This PR fix shows the sender/receiver label when a user replies with a reaction or text message; otherwise, it does not display for sharing.

## Additional Notes
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
