### PR TITLE
fix: made closable by swipe down all modals from settings

### DIFF
--- a/lib/app/features/auth/views/components/user_data_inputs/general_user_data_input.dart
+++ b/lib/app/features/auth/views/components/user_data_inputs/general_user_data_input.dart
@@ -69,7 +69,7 @@ class GeneralUserDataInput extends HookWidget {
       isLive: isLive,
       verified: isValid.value,
       onTapOutside: (_) => FocusManager.instance.primaryFocus?.unfocus(),
-      suffixIcon: isValid.value && showNoErrorsIndicator
+      suffixIcon: isValid.value && showNoErrorsIndicator && errorText == null
           ? TextInputIcons(
               icons: [Assets.svg.iconBlockCheckboxOn.icon()],
             )

--- a/lib/app/features/core/views/pages/language_selector_page.dart
+++ b/lib/app/features/core/views/pages/language_selector_page.dart
@@ -46,57 +46,55 @@ class LanguageSelectorPage extends HookConsumerWidget {
     final mayContinue = selectedLanguages.isNotEmpty;
 
     return SheetContent(
-      body: Column(
-        children: [
-          appBar ?? NavigationAppBar.modal(),
-          AuthHeader(
-            title: title,
-            description: description,
+      body: CustomScrollView(
+        slivers: [
+          SliverToBoxAdapter(
+            child: appBar ?? NavigationAppBar.modal(),
           ),
-          SizedBox(height: 26.0.s),
-          Expanded(
-            child: CustomScrollView(
-              slivers: [
-                CollapsingAppBar(
-                  topOffset: 8.0.s,
-                  height: SearchInput.height,
-                  child: ScreenSideOffset.small(
-                    child: SearchInput(
-                      onTextChanged: (String value) => searchQuery.value = value,
-                    ),
-                  ),
-                ),
-                SliverList.separated(
-                  itemCount: languages.length,
-                  separatorBuilder: (BuildContext _, int __) => SizedBox(
-                    height: 12.0.s,
-                  ),
-                  itemBuilder: (BuildContext context, int index) {
-                    final language = languages[index];
-                    return LanguageListItem(
-                      language: language,
-                      isSelected: selectedLanguages.contains(language.isoCode),
-                      onTap: () {
-                        toggleLanguageSelection(language.isoCode);
-                      },
-                    );
-                  },
-                ),
-                SliverPadding(
-                  padding: EdgeInsetsDirectional.only(
-                    bottom: 16.0.s + (mayContinue ? 0 : MediaQuery.paddingOf(context).bottom),
-                  ),
-                ),
-              ],
+          SliverToBoxAdapter(
+            child: AuthHeader(
+              title: title,
+              description: description,
+            ),
+          ),
+          SliverToBoxAdapter(
+            child: SizedBox(height: 26.0.s),
+          ),
+          CollapsingAppBar(
+            topOffset: 8.0.s,
+            height: SearchInput.height,
+            child: ScreenSideOffset.small(
+              child: SearchInput(
+                onTextChanged: (String value) => searchQuery.value = value,
+              ),
+            ),
+          ),
+          SliverList.separated(
+            itemCount: languages.length,
+            separatorBuilder: (BuildContext _, int __) => SizedBox(height: 12.0.s),
+            itemBuilder: (BuildContext context, int index) {
+              final language = languages[index];
+              return LanguageListItem(
+                language: language,
+                isSelected: selectedLanguages.contains(language.isoCode),
+                onTap: () => toggleLanguageSelection(language.isoCode),
+              );
+            },
+          ),
+          SliverPadding(
+            padding: EdgeInsetsDirectional.only(
+              bottom: 16.0.s + (mayContinue ? 0 : MediaQuery.paddingOf(context).bottom),
             ),
           ),
           if (mayContinue && continueButton != null) ...[
-            const HorizontalSeparator(),
-            SizedBox(height: 16.0.s),
-            ScreenSideOffset.small(
-              child: continueButton!,
+            const SliverToBoxAdapter(child: HorizontalSeparator()),
+            SliverToBoxAdapter(child: SizedBox(height: 16.0.s)),
+            SliverToBoxAdapter(
+              child: ScreenSideOffset.small(child: continueButton!),
             ),
-            SizedBox(height: 8.0.s + MediaQuery.paddingOf(context).bottom),
+            SliverToBoxAdapter(
+              child: SizedBox(height: 8.0.s + MediaQuery.paddingOf(context).bottom),
+            ),
           ],
         ],
       ),

--- a/lib/app/features/protect_account/secure_account/views/pages/secure_account_options_page.dart
+++ b/lib/app/features/protect_account/secure_account/views/pages/secure_account_options_page.dart
@@ -34,72 +34,74 @@ class SecureAccountOptionsPage extends HookConsumerWidget {
     });
 
     return SheetContent(
-      body: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          NavigationAppBar.modal(
-            title: Text(locale.protect_account_header_security),
-            actions: const [
-              NavigationCloseButton(),
-            ],
-          ),
-          SizedBox(height: 36.0.s),
-          ScreenSideOffset.small(
-            child: Column(
-              children: [
-                Padding(
-                  padding: EdgeInsets.symmetric(horizontal: 24.0.s),
-                  child: InfoCard(
-                    iconAsset: Assets.svg.actionWalletSecureaccount,
-                    title: locale.protect_account_title_secure_account,
-                    description: locale.protect_account_description_secure_account_2fa,
-                  ),
-                ),
-                SizedBox(height: 32.0.s),
-                SecureAccountOption(
-                  title: locale.two_fa_option_backup,
-                  icon: Assets.svg.iconProtectwalletIcloud.icon(
-                    color: context.theme.appColors.primaryAccent,
-                  ),
-                  onTap: () => BackupOptionsRoute().push<void>(context),
-                  isEnabled: securityMethods?.isBackupEnabled ?? false,
-                  isLoading: isLoading,
-                ),
-                SizedBox(height: 12.0.s),
-                SecureAccountOption(
-                  title: locale.two_fa_option_email,
-                  icon: Assets.svg.iconFieldEmail.icon(
-                    color: context.theme.appColors.primaryAccent,
-                  ),
-                  onTap: () => _onEmailPressed(context, securityMethods),
-                  isEnabled: securityMethods?.isEmailEnabled ?? false,
-                  isLoading: isLoading,
-                ),
-                SizedBox(height: 12.0.s),
-                SecureAccountOption(
-                  title: locale.two_fa_option_authenticator,
-                  icon: Assets.svg.iconLoginAuthcode.icon(
-                    color: context.theme.appColors.primaryAccent,
-                  ),
-                  isEnabled: securityMethods?.isAuthenticatorEnabled ?? false,
-                  isLoading: isLoading,
-                  onTap: () => _onAuthenticatorPressed(context, securityMethods),
-                ),
-                SizedBox(height: 12.0.s),
-                SecureAccountOption(
-                  title: locale.two_fa_option_phone,
-                  icon: Assets.svg.iconFieldPhone.icon(
-                    color: context.theme.appColors.primaryAccent,
-                  ),
-                  onTap: () => _onPhonePressed(context, securityMethods),
-                  isEnabled: securityMethods?.isPhoneEnabled ?? false,
-                  isLoading: isLoading,
-                ),
-                ScreenBottomOffset(margin: 36.0.s),
+      body: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            NavigationAppBar.modal(
+              title: Text(locale.protect_account_header_security),
+              actions: const [
+                NavigationCloseButton(),
               ],
             ),
-          ),
-        ],
+            SizedBox(height: 36.0.s),
+            ScreenSideOffset.small(
+              child: Column(
+                children: [
+                  Padding(
+                    padding: EdgeInsets.symmetric(horizontal: 24.0.s),
+                    child: InfoCard(
+                      iconAsset: Assets.svg.actionWalletSecureaccount,
+                      title: locale.protect_account_title_secure_account,
+                      description: locale.protect_account_description_secure_account_2fa,
+                    ),
+                  ),
+                  SizedBox(height: 32.0.s),
+                  SecureAccountOption(
+                    title: locale.two_fa_option_backup,
+                    icon: Assets.svg.iconProtectwalletIcloud.icon(
+                      color: context.theme.appColors.primaryAccent,
+                    ),
+                    onTap: () => BackupOptionsRoute().push<void>(context),
+                    isEnabled: securityMethods?.isBackupEnabled ?? false,
+                    isLoading: isLoading,
+                  ),
+                  SizedBox(height: 12.0.s),
+                  SecureAccountOption(
+                    title: locale.two_fa_option_email,
+                    icon: Assets.svg.iconFieldEmail.icon(
+                      color: context.theme.appColors.primaryAccent,
+                    ),
+                    onTap: () => _onEmailPressed(context, securityMethods),
+                    isEnabled: securityMethods?.isEmailEnabled ?? false,
+                    isLoading: isLoading,
+                  ),
+                  SizedBox(height: 12.0.s),
+                  SecureAccountOption(
+                    title: locale.two_fa_option_authenticator,
+                    icon: Assets.svg.iconLoginAuthcode.icon(
+                      color: context.theme.appColors.primaryAccent,
+                    ),
+                    isEnabled: securityMethods?.isAuthenticatorEnabled ?? false,
+                    isLoading: isLoading,
+                    onTap: () => _onAuthenticatorPressed(context, securityMethods),
+                  ),
+                  SizedBox(height: 12.0.s),
+                  SecureAccountOption(
+                    title: locale.two_fa_option_phone,
+                    icon: Assets.svg.iconFieldPhone.icon(
+                      color: context.theme.appColors.primaryAccent,
+                    ),
+                    onTap: () => _onPhonePressed(context, securityMethods),
+                    isEnabled: securityMethods?.isPhoneEnabled ?? false,
+                    isLoading: isLoading,
+                  ),
+                  ScreenBottomOffset(margin: 36.0.s),
+                ],
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/app/features/settings/views/account_settings_modal.dart
+++ b/lib/app/features/settings/views/account_settings_modal.dart
@@ -35,75 +35,77 @@ class AccountSettingsModal extends HookConsumerWidget {
     final primaryColor = context.theme.appColors.primaryAccent;
 
     return SheetContent(
-      body: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          NavigationAppBar.modal(
-            title: Text(context.i18n.common_account),
-            actions: const [NavigationCloseButton()],
-          ),
-          ScreenSideOffset.small(
-            child: SeparatedColumn(
-              separator: SizedBox(height: 9.0.s),
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                ModalActionButton(
-                  icon: Assets.svg.iconProfileUser.icon(color: primaryColor),
-                  label: context.i18n.settings_profile_edit,
-                  onTap: () => ProfileEditRoute().go(context),
-                ),
-                ModalActionButton(
-                  icon: Assets.svg.iconProfileBlockUser.icon(color: primaryColor),
-                  label: context.i18n.settings_blocked_users,
-                  onTap: () => BlockedUsersRoute().push<void>(context),
-                ),
-                ModalActionButton(
-                  icon: Assets.svg.iconSelectLanguage.icon(color: primaryColor),
-                  label: context.i18n.settings_app_language,
-                  trailing: Text(
-                    ref.watch(localePreferredLanguagesProvider).first.name,
-                    style: context.theme.appTextThemes.caption.copyWith(color: primaryColor),
-                  ),
-                  onTap: () => AppLanguagesRoute().push<void>(context),
-                ),
-                contentLangsAsync.maybeWhen(
-                  orElse: () => const ItemLoadingState(),
-                  data: (_) => ModalActionButton(
-                    icon: Assets.svg.iconSelectLanguage.icon(color: primaryColor),
-                    label: context.i18n.settings_content_language,
-                    trailing: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        if (contentLanguages.length > 1)
-                          _RemainingLanguagesLabel(value: contentLanguages.length)
-                        else if (contentLanguages.isNotEmpty)
-                          Text(
-                            Language.fromIsoCode(contentLanguages.first)?.name ??
-                                contentLanguages.first,
-                            style:
-                                context.theme.appTextThemes.caption.copyWith(color: primaryColor),
-                          ),
-                      ],
-                    ),
-                    onTap: () => ContentLanguagesRoute().push<void>(context),
-                  ),
-                ),
-                ModalActionButton(
-                  icon: Assets.svg.iconBlockDelete.icon(
-                    color: context.theme.appColors.attentionRed,
-                  ),
-                  label: context.i18n.settings_delete,
-                  onTap: () => showSimpleBottomSheet<void>(
-                    context: context,
-                    isDismissible: false,
-                    child: const ConfirmDeleteModal(),
-                  ),
-                ),
-              ],
+      body: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            NavigationAppBar.modal(
+              title: Text(context.i18n.common_account),
+              actions: const [NavigationCloseButton()],
             ),
-          ),
-          ScreenBottomOffset(margin: 32.0.s),
-        ],
+            ScreenSideOffset.small(
+              child: SeparatedColumn(
+                separator: SizedBox(height: 9.0.s),
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  ModalActionButton(
+                    icon: Assets.svg.iconProfileUser.icon(color: primaryColor),
+                    label: context.i18n.settings_profile_edit,
+                    onTap: () => ProfileEditRoute().go(context),
+                  ),
+                  ModalActionButton(
+                    icon: Assets.svg.iconProfileBlockUser.icon(color: primaryColor),
+                    label: context.i18n.settings_blocked_users,
+                    onTap: () => BlockedUsersRoute().push<void>(context),
+                  ),
+                  ModalActionButton(
+                    icon: Assets.svg.iconSelectLanguage.icon(color: primaryColor),
+                    label: context.i18n.settings_app_language,
+                    trailing: Text(
+                      ref.watch(localePreferredLanguagesProvider).first.name,
+                      style: context.theme.appTextThemes.caption.copyWith(color: primaryColor),
+                    ),
+                    onTap: () => AppLanguagesRoute().push<void>(context),
+                  ),
+                  contentLangsAsync.maybeWhen(
+                    orElse: () => const ItemLoadingState(),
+                    data: (_) => ModalActionButton(
+                      icon: Assets.svg.iconSelectLanguage.icon(color: primaryColor),
+                      label: context.i18n.settings_content_language,
+                      trailing: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          if (contentLanguages.length > 1)
+                            _RemainingLanguagesLabel(value: contentLanguages.length)
+                          else if (contentLanguages.isNotEmpty)
+                            Text(
+                              Language.fromIsoCode(contentLanguages.first)?.name ??
+                                  contentLanguages.first,
+                              style:
+                                  context.theme.appTextThemes.caption.copyWith(color: primaryColor),
+                            ),
+                        ],
+                      ),
+                      onTap: () => ContentLanguagesRoute().push<void>(context),
+                    ),
+                  ),
+                  ModalActionButton(
+                    icon: Assets.svg.iconBlockDelete.icon(
+                      color: context.theme.appColors.attentionRed,
+                    ),
+                    label: context.i18n.settings_delete,
+                    onTap: () => showSimpleBottomSheet<void>(
+                      context: context,
+                      isDismissible: false,
+                      child: const ConfirmDeleteModal(),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            ScreenBottomOffset(margin: 32.0.s),
+          ],
+        ),
       ),
     );
   }

--- a/lib/app/features/settings/views/privacy_settings_modal.dart
+++ b/lib/app/features/settings/views/privacy_settings_modal.dart
@@ -35,48 +35,51 @@ class PrivacySettingsModal extends ConsumerWidget {
         UserVisibilityPrivacyOption.fromWhoCanSetting(metadata.data.whoCanInviteYouToGroups);
 
     return SheetContent(
-      body: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          NavigationAppBar.modal(
-            title: Text(context.i18n.settings_privacy),
-            actions: const [
-              NavigationCloseButton(),
-            ],
-          ),
-          ScreenSideOffset.small(
-            child: ScreenBottomOffset(
-              margin: 32.0.s,
-              child: SeparatedColumn(
-                mainAxisSize: MainAxisSize.min,
-                separator: SelectableOptionsGroup.separator,
-                children: [
-                  SelectableOptionsGroup(
-                    title: context.i18n.privacy_group_wallet_address_title,
-                    selected: [walletPrivacy],
-                    options: WalletAddressPrivacyOption.values,
-                    onSelected: (option) => ref
-                        .read(updateUserMetadataNotifierProvider.notifier)
-                        .publishWallets(option),
-                  ),
-                  SelectableOptionsGroup(
-                    title: context.i18n.privacy_group_who_can_message_you_title,
-                    selected: [messagingPrivacy],
-                    options: UserVisibilityPrivacyOption.values,
-                    onSelected: (option) =>
-                        _onMessagingPrivacyOptionSelected(ref, metadata, option),
-                  ),
-                  SelectableOptionsGroup(
-                    title: context.i18n.privacy_group_who_can_invite_you_title,
-                    selected: [invitingPrivacy],
-                    options: UserVisibilityPrivacyOption.values,
-                    onSelected: (option) => _onInvitingPrivacyOptionSelected(ref, metadata, option),
-                  ),
-                ],
+      body: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            NavigationAppBar.modal(
+              title: Text(context.i18n.settings_privacy),
+              actions: const [
+                NavigationCloseButton(),
+              ],
+            ),
+            ScreenSideOffset.small(
+              child: ScreenBottomOffset(
+                margin: 32.0.s,
+                child: SeparatedColumn(
+                  mainAxisSize: MainAxisSize.min,
+                  separator: SelectableOptionsGroup.separator,
+                  children: [
+                    SelectableOptionsGroup(
+                      title: context.i18n.privacy_group_wallet_address_title,
+                      selected: [walletPrivacy],
+                      options: WalletAddressPrivacyOption.values,
+                      onSelected: (option) => ref
+                          .read(updateUserMetadataNotifierProvider.notifier)
+                          .publishWallets(option),
+                    ),
+                    SelectableOptionsGroup(
+                      title: context.i18n.privacy_group_who_can_message_you_title,
+                      selected: [messagingPrivacy],
+                      options: UserVisibilityPrivacyOption.values,
+                      onSelected: (option) =>
+                          _onMessagingPrivacyOptionSelected(ref, metadata, option),
+                    ),
+                    SelectableOptionsGroup(
+                      title: context.i18n.privacy_group_who_can_invite_you_title,
+                      selected: [invitingPrivacy],
+                      options: UserVisibilityPrivacyOption.values,
+                      onSelected: (option) =>
+                          _onInvitingPrivacyOptionSelected(ref, metadata, option),
+                    ),
+                  ],
+                ),
               ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/app/features/settings/views/push_notifications_settings.dart
+++ b/lib/app/features/settings/views/push_notifications_settings.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/button/button.dart';
 import 'package:ion/app/components/list_item/list_item.dart';
-import 'package:ion/app/components/screen_offset/screen_bottom_offset.dart';
 import 'package:ion/app/components/screen_offset/screen_side_offset.dart';
 import 'package:ion/app/components/separated/separated_column.dart';
 import 'package:ion/app/extensions/extensions.dart';
@@ -32,79 +31,79 @@ class PushNotificationsSettings extends ConsumerWidget {
     final hasNotificationsPermission = hasPermissionOnDeviceLevel && !suspended;
 
     return SheetContent(
-      body: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          NavigationAppBar.modal(
-            title: Text(context.i18n.settings_push_notifications),
-            actions: const [
-              NavigationCloseButton(),
-            ],
+      body: CustomScrollView(
+        slivers: [
+          SliverPersistentHeader(
+            pinned: true,
+            delegate: _NavBarDelegate(
+              child: NavigationAppBar.modal(
+                title: Text(context.i18n.settings_push_notifications),
+                actions: const [NavigationCloseButton()],
+              ),
+            ),
           ),
-          Expanded(
-            child: ScreenBottomOffset(
-              margin: 40.0.s,
-              child: SingleChildScrollView(
-                child: ScreenSideOffset.small(
-                  child: SeparatedColumn(
-                    separator: SelectableOptionsGroup.separator,
-                    children: [
-                      _DevicePermissionButton(
-                        hasPermission: hasNotificationsPermission,
-                        hasPermissionOnDeviceLevel: hasPermissionOnDeviceLevel,
-                        onChangeAppLevelPermission:
-                            ref.read(selectedPushCategoriesProvider.notifier).toggleSuspended,
+          SliverPadding(
+            padding: EdgeInsetsDirectional.only(bottom: 40.0.s),
+            sliver: SliverToBoxAdapter(
+              child: ScreenSideOffset.small(
+                child: SeparatedColumn(
+                  separator: SelectableOptionsGroup.separator,
+                  children: [
+                    _DevicePermissionButton(
+                      hasPermission: hasNotificationsPermission,
+                      hasPermissionOnDeviceLevel: hasPermissionOnDeviceLevel,
+                      onChangeAppLevelPermission:
+                          ref.read(selectedPushCategoriesProvider.notifier).toggleSuspended,
+                    ),
+                    SelectableOptionsGroup(
+                      title: context.i18n.push_notification_social_group_title,
+                      selected: _filterSelectedOptions(
+                        SocialNotificationOption.values,
+                        selected: selectedCategories,
                       ),
-                      SelectableOptionsGroup(
-                        title: context.i18n.push_notification_social_group_title,
-                        selected: _filterSelectedOptions(
-                          SocialNotificationOption.values,
-                          selected: selectedCategories,
-                        ),
-                        options: SocialNotificationOption.values,
-                        onSelected: (option) => ref
-                            .read(selectedPushCategoriesProvider.notifier)
-                            .toggleCategory(option.category),
-                        enabled: hasNotificationsPermission,
+                      options: SocialNotificationOption.values,
+                      onSelected: (option) => ref
+                          .read(selectedPushCategoriesProvider.notifier)
+                          .toggleCategory(option.category),
+                      enabled: hasNotificationsPermission,
+                    ),
+                    SelectableOptionsGroup(
+                      title: context.i18n.push_notification_chat_group_title,
+                      selected: _filterSelectedOptions(
+                        ChatNotificationOption.values,
+                        selected: selectedCategories,
                       ),
-                      SelectableOptionsGroup(
-                        title: context.i18n.push_notification_chat_group_title,
-                        selected: _filterSelectedOptions(
-                          ChatNotificationOption.values,
-                          selected: selectedCategories,
-                        ),
-                        options: ChatNotificationOption.values,
-                        onSelected: (option) => ref
-                            .read(selectedPushCategoriesProvider.notifier)
-                            .toggleCategory(option.category),
-                        enabled: hasNotificationsPermission,
+                      options: ChatNotificationOption.values,
+                      onSelected: (option) => ref
+                          .read(selectedPushCategoriesProvider.notifier)
+                          .toggleCategory(option.category),
+                      enabled: hasNotificationsPermission,
+                    ),
+                    SelectableOptionsGroup(
+                      title: context.i18n.push_notification_wallet_group_title,
+                      selected: _filterSelectedOptions(
+                        WalletNotificationOption.values,
+                        selected: selectedCategories,
                       ),
-                      SelectableOptionsGroup(
-                        title: context.i18n.push_notification_wallet_group_title,
-                        selected: _filterSelectedOptions(
-                          WalletNotificationOption.values,
-                          selected: selectedCategories,
-                        ),
-                        options: WalletNotificationOption.values,
-                        onSelected: (option) => ref
-                            .read(selectedPushCategoriesProvider.notifier)
-                            .toggleCategory(option.category),
-                        enabled: hasNotificationsPermission,
+                      options: WalletNotificationOption.values,
+                      onSelected: (option) => ref
+                          .read(selectedPushCategoriesProvider.notifier)
+                          .toggleCategory(option.category),
+                      enabled: hasNotificationsPermission,
+                    ),
+                    SelectableOptionsGroup(
+                      title: context.i18n.push_notification_system_group_title,
+                      selected: _filterSelectedOptions(
+                        SystemNotificationOption.values,
+                        selected: selectedCategories,
                       ),
-                      SelectableOptionsGroup(
-                        title: context.i18n.push_notification_system_group_title,
-                        selected: _filterSelectedOptions(
-                          SystemNotificationOption.values,
-                          selected: selectedCategories,
-                        ),
-                        options: SystemNotificationOption.values,
-                        onSelected: (option) => ref
-                            .read(selectedPushCategoriesProvider.notifier)
-                            .toggleCategory(option.category),
-                        enabled: hasNotificationsPermission,
-                      ),
-                    ],
-                  ),
+                      options: SystemNotificationOption.values,
+                      onSelected: (option) => ref
+                          .read(selectedPushCategoriesProvider.notifier)
+                          .toggleCategory(option.category),
+                      enabled: hasNotificationsPermission,
+                    ),
+                  ],
                 ),
               ),
             ),
@@ -120,6 +119,29 @@ class PushNotificationsSettings extends ConsumerWidget {
   }) {
     return options.where((option) => selected.contains(option.category)).toList();
   }
+}
+
+class _NavBarDelegate extends SliverPersistentHeaderDelegate {
+  _NavBarDelegate({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, double shrinkOffset, bool overlaps) {
+    return Material(
+      elevation: overlaps ? 4 : 0,
+      child: child,
+    );
+  }
+
+  @override
+  double get maxExtent => NavigationAppBar.modalHeaderHeight;
+
+  @override
+  double get minExtent => NavigationAppBar.modalHeaderHeight;
+
+  @override
+  bool shouldRebuild(covariant SliverPersistentHeaderDelegate oldDelegate) => false;
 }
 
 class _DevicePermissionButton extends StatelessWidget {


### PR DESCRIPTION
## Description
- Made all modal from profile settings closable by pull down;
- Don't show green checkmark for inputs if error text is passed;

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Chore
