### PR TITLE
fix: make media picker work in different contexts

### DIFF
--- a/lib/app/router/media_picker_routes.dart
+++ b/lib/app/router/media_picker_routes.dart
@@ -20,7 +20,7 @@ class MediaPickerRoute extends BaseRouteData {
             maxVideoDurationInSeconds: maxVideoDurationInSeconds,
             showCameraCell: showCameraCell,
           ),
-          type: IceRouteType.bottomSheet,
+          type: IceRouteType.simpleModalSheet,
         );
 
   final int? maxSelection;
@@ -35,7 +35,7 @@ class AlbumSelectionRoute extends BaseRouteData {
     required this.mediaPickerType,
   }) : super(
           child: AlbumSelectionPage(type: mediaPickerType),
-          type: IceRouteType.bottomSheet,
+          type: IceRouteType.simpleModalSheet,
         );
 
   final MediaPickerType mediaPickerType;


### PR DESCRIPTION
## Description
The issue is that MediaPickerRoute and AlbumSelectionRoute are using IceRouteType.bottomSheet, which requires a NavigationSheet context that they are not guaranteed to have.  

## Task ID
ION-2926

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
