### PR TITLE
fix: media picker showing duplicates when given only limited permission

### DIFF
--- a/lib/app/features/gallery/providers/gallery_provider.c.dart
+++ b/lib/app/features/gallery/providers/gallery_provider.c.dart
@@ -75,9 +75,13 @@ class GalleryNotifier extends _$GalleryNotifier {
     )
         .listen((media) {
       final currentState = state.valueOrNull;
+      final existingMedia = currentState?.mediaData ?? [];
+      final existingMediaPaths = existingMedia.map((m) => m.path).toSet();
+      final newMedia = media.where((m) => !existingMediaPaths.contains(m.path)).toList();
+
       state = AsyncValue.data(
         GalleryState(
-          mediaData: [...(currentState?.mediaData ?? []), ...media],
+          mediaData: [...existingMedia, ...newMedia],
           currentPage: currentState?.currentPage ?? 0,
           hasMore: media.isNotEmpty,
           type: type,


### PR DESCRIPTION
## Description
Media not checked for duplication

## Task ID
ION-2926

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
