### PR TITLE
fix: profiling not working due to signature mismatch

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -84,6 +84,9 @@ android {
         debug {
             signingConfig signingConfigs.release
         }
+        profile {
+            signingConfig signingConfigs.release
+        }
         release {
             signingConfig signingConfigs.release
         }


### PR DESCRIPTION
## Description
Could not log in during profiling (signature mismatch)

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
