### PR TITLE
fix: manage coins loader padding

### DIFF
--- a/lib/app/features/wallets/views/pages/wallet_page/components/coins/coins_tab.dart
+++ b/lib/app/features/wallets/views/pages/wallet_page/components/coins/coins_tab.dart
@@ -67,7 +67,7 @@ class CoinsTab extends ConsumerWidget {
   }
 }
 
-class _CoinsTabBody extends ConsumerWidget {
+class _CoinsTabBody extends StatelessWidget {
   const _CoinsTabBody({
     required this.itemCount,
     required this.itemBuilder,
@@ -77,7 +77,7 @@ class _CoinsTabBody extends ConsumerWidget {
   final NullableIndexedWidgetBuilder itemBuilder;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     return SliverMainAxisGroup(
       slivers: [
         SliverList.separated(


### PR DESCRIPTION
## Description
Fix manage coins loader padding

## Additional Notes

## Task ID

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
