### PR TITLE
fix: exclude videos posts from profile page posts tab

### DIFF
--- a/lib/app/features/feed/providers/user_posts_data_source_provider.c.dart
+++ b/lib/app/features/feed/providers/user_posts_data_source_provider.c.dart
@@ -32,6 +32,7 @@ List<EntitiesDataSource>? userPostsDataSource(Ref ref, String pubkey) {
     ).extensions,
     ReferencesSearchExtension(contain: false),
     ExpirationSearchExtension(expiration: false),
+    VideosSearchExtension(contain: false),
   ]).toString();
 
   return [


### PR DESCRIPTION
## Description
This PR excludes posts with videos from profile page's posts tab, so that it is only displayed on `videos` tab

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
<!-- Add corresponding task ID here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
