### PR TITLE
fix: use the correct route on tap on Receive button on the Coin details page

### DIFF
--- a/lib/app/features/wallets/views/pages/coins_flow/coin_details/components/balance/balance.dart
+++ b/lib/app/features/wallets/views/pages/coins_flow/coin_details/components/balance/balance.dart
@@ -33,7 +33,7 @@ class Balance extends ConsumerWidget {
             child: BalanceActions(
               onReceive: () {
                 ref.read(receiveCoinsFormControllerProvider.notifier).setCoin(coinsGroup);
-                CoinReceiveRoute().push<void>(context);
+                NetworkSelectReceiveRoute().push<void>(context);
               },
               onNeedToEnable2FA: () => SecureAccountModalRoute().push<void>(context),
               onSend: () {


### PR DESCRIPTION
## Task ID
ION-3016

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
https://github.com/user-attachments/assets/cfbb773d-a857-4ce7-a196-5862046c25a2

