### PR TITLE
fix(chat): hide quoted article event's footer buttons in shared post chat message

### DIFF
--- a/lib/app/features/chat/views/components/message_items/message_types/post_message/shared_post_message.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/post_message/shared_post_message.dart
@@ -128,6 +128,7 @@ class SharedPostMessage extends HookConsumerWidget {
                 accentTheme: isMe,
                 footer: const SizedBox.shrink(),
                 eventReference: postEntity.toEventReference(),
+                quotedEventFooter: const SizedBox.shrink(),
               ),
             ),
           Padding(

--- a/lib/app/features/feed/views/components/article/article.dart
+++ b/lib/app/features/feed/views/components/article/article.dart
@@ -38,12 +38,14 @@ class Article extends ConsumerWidget {
     required EventReference eventReference,
     Widget? header,
     bool accentTheme = false,
+    Widget? footer,
   }) {
     return Article(
       header: header,
       showActionButtons: false,
       accentTheme: accentTheme,
       eventReference: eventReference,
+      footer: footer,
     );
   }
 

--- a/lib/app/features/feed/views/components/post/post.dart
+++ b/lib/app/features/feed/views/components/post/post.dart
@@ -38,6 +38,7 @@ class Post extends ConsumerWidget {
     this.headerOffset,
     this.header,
     this.footer,
+    this.quotedEventFooter,
     this.onDelete,
     this.accentTheme = false,
     this.isTextSelectable = false,
@@ -56,6 +57,7 @@ class Post extends ConsumerWidget {
   final double? headerOffset;
   final Widget? header;
   final Widget? footer;
+  final Widget? quotedEventFooter;
   final TimestampFormat timeFormat;
   final VoidCallback? onDelete;
   final bool isTextSelectable;
@@ -104,6 +106,7 @@ class Post extends ConsumerWidget {
                   accentTheme: accentTheme,
                   eventReference: quotedEventReference,
                   header: accentTheme && header != null ? header : null,
+                  footer: quotedEventFooter,
                 ),
               SizedBox(height: 8.0.s),
               footer ?? CounterItemsFooter(eventReference: eventReference),
@@ -168,11 +171,13 @@ class _QuotedEvent extends StatelessWidget {
     required this.eventReference,
     this.header,
     this.accentTheme = false,
+    this.footer,
   });
 
   final Widget? header;
   final bool accentTheme;
   final EventReference eventReference;
+  final Widget? footer;
 
   @override
   Widget build(BuildContext context) {
@@ -189,6 +194,7 @@ class _QuotedEvent extends StatelessWidget {
           header: header,
           accentTheme: accentTheme,
           eventReference: eventReference,
+          footer: footer,
         ),
       ),
     );
@@ -343,11 +349,13 @@ final class _QuotedArticle extends StatelessWidget {
     required this.eventReference,
     this.header,
     this.accentTheme = false,
+    this.footer,
   });
 
   final Widget? header;
   final bool accentTheme;
   final EventReference eventReference;
+  final Widget? footer;
 
   @override
   Widget build(BuildContext context) {
@@ -361,6 +369,7 @@ final class _QuotedArticle extends StatelessWidget {
             header: header,
             accentTheme: accentTheme,
             eventReference: eventReference,
+            footer: footer,
           ),
         ),
       ),


### PR DESCRIPTION
## Description
This PR fixes hiding the quoted article event's footer buttons in shared post chat messages to match Figma.

## Additional Notes
N/A

## Task ID
ION-2982

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<img width="180" alt="image" src="https://github.com/user-attachments/assets/02809ea8-0789-4066-be96-53ec5c80f5a4">
