### PR TITLE
fix: feed interests config sync

### DIFF
--- a/lib/app/features/feed/providers/feed_user_interests_provider.r.dart
+++ b/lib/app/features/feed/providers/feed_user_interests_provider.r.dart
@@ -62,7 +62,7 @@ class FeedUserInterests extends _$FeedUserInterests {
     }
     return ref
         .read(userPreferencesServiceProvider(identityKeyName: identityKeyName))
-        .setValue(_persistanceKey, jsonEncode(interests.categories));
+        .setValue(_persistanceKey, jsonEncode(interests.toJson()));
   }
 
   Future<FeedInterests> _getRemoteState(FeedType feedType, {bool force = false}) async {


### PR DESCRIPTION
## Description
This PR fixes incorrect feed interests config encoding - it didn't encode the version and `mergedState != localState` always returned `false`.

## Task ID
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
