### PR TITLE
fix: likes sync issue

### DIFF
--- a/lib/app/features/chat/views/components/message_items/replied_message_info/replied_message_info.dart
+++ b/lib/app/features/chat/views/components/message_items/replied_message_info/replied_message_info.dart
@@ -51,8 +51,7 @@ class RepliedMessageInfo extends HookConsumerWidget {
                   child: IonConnectNetworkImage(
                     authorPubkey: repliedMessage.eventMessage.masterPubkey,
                     width: 30.0.s,
-                    imageUrl:
-                        repliedMessage.medias.first.thumb ?? repliedMessage.medias.first.url,
+                    imageUrl: repliedMessage.medias.first.thumb ?? repliedMessage.medias.first.url,
                     borderRadius: BorderRadius.circular(8.0.s),
                     fit: BoxFit.fitWidth,
                   ),

--- a/lib/app/features/optimistic_ui/features/likes/post_like_provider.r.dart
+++ b/lib/app/features/optimistic_ui/features/likes/post_like_provider.r.dart
@@ -3,6 +3,7 @@
 import 'package:collection/collection.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/features/auth/providers/auth_provider.m.dart';
+import 'package:ion/app/features/feed/data/models/entities/event_count_result_data.f.dart';
 import 'package:ion/app/features/feed/data/models/entities/reaction_data.f.dart';
 import 'package:ion/app/features/feed/providers/counters/like_reaction_provider.r.dart';
 import 'package:ion/app/features/feed/providers/counters/likes_count_provider.r.dart';
@@ -93,5 +94,12 @@ class ToggleLikeNotifier extends _$ToggleLikeNotifier {
     );
 
     await service.dispatch(ToggleLikeIntent(), current);
+
+    ref.read(ionConnectCacheProvider.notifier).remove(
+          EventCountResultEntity.cacheKeyBuilder(
+            key: eventReference.toString(),
+            type: EventCountResultType.reactions,
+          ),
+        );
   }
 }


### PR DESCRIPTION
## Description
Fixed a corner case in a post likes counter sync.
Here is the flow:
- Like a post with 0 likes and you will see results through optimistic UI;
- Make pull to refresh for that post and new data is fetched including likes counter entity - so you see the correct result now from real data;
- Press like button again to remove you like from the post - you will see 0 likes immediately thanks to optimistic UI;
- Make pull to refresh for that post and new data is fetched including likes counter entity - now you will see post has 1 like. That is because optimistic UI is reset on pull to refresh but cached entity with previous likes counter is not replaced by new one because the post now has no likes so no entity is returned on pull to refresh and we reuse the old cached one on UI and display 1 like for the post;

So added cache cleaning for the post likes entity on like toggle;

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)

https://github.com/user-attachments/assets/8f660a2b-3bbc-440f-bd3b-410d3782a061


