### PR TITLE
fix: feed top area not clickable

### DIFF
--- a/lib/app/features/feed/views/pages/feed_page/components/feed_controls/components/feed_navigation/feed_navigation.dart
+++ b/lib/app/features/feed/views/pages/feed_page/components/feed_controls/components/feed_navigation/feed_navigation.dart
@@ -19,20 +19,23 @@ class FeedNavigation extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ScreenSideOffset.small(
-      child: Row(
-        children: [
-          Expanded(
-            child: GestureDetector(
-              behavior: HitTestBehavior.opaque,
-              onTap: () => FeedSimpleSearchRoute().push<void>(context),
-              child: const IgnorePointer(child: SearchInput()),
+      child: Padding(
+        padding: EdgeInsetsDirectional.only(top: FeedNotificationsButton.counterOffset),
+        child: Row(
+          children: [
+            Expanded(
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: () => FeedSimpleSearchRoute().push<void>(context),
+                child: const IgnorePointer(child: SearchInput()),
+              ),
             ),
-          ),
-          SizedBox(width: 12.0.s),
-          const FeedNotificationsButton(),
-          SizedBox(width: 12.0.s),
-          FeedFiltersMenuButton(scrollController: scrollController),
-        ],
+            SizedBox(width: 12.0.s),
+            const FeedNotificationsButton(),
+            SizedBox(width: 12.0.s),
+            FeedFiltersMenuButton(scrollController: scrollController),
+          ],
+        ),
       ),
     );
   }

--- a/lib/app/features/feed/views/pages/feed_page/components/feed_controls/components/feed_navigation/feed_notifications_button.dart
+++ b/lib/app/features/feed/views/pages/feed_page/components/feed_controls/components/feed_navigation/feed_notifications_button.dart
@@ -11,6 +11,8 @@ import 'package:ion/generated/assets.gen.dart';
 class FeedNotificationsButton extends ConsumerWidget {
   const FeedNotificationsButton({super.key});
 
+  static double get counterOffset => 5.0.s;
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Stack(
@@ -22,7 +24,11 @@ class FeedNotificationsButton extends ConsumerWidget {
             color: context.theme.appColors.primaryText,
           ),
         ),
-        PositionedDirectional(top: -5.0.s, end: -5.0.s, child: const _UnreadCounter()),
+        PositionedDirectional(
+          top: -counterOffset,
+          end: -counterOffset,
+          child: const _UnreadCounter(),
+        ),
       ],
     );
   }

--- a/lib/app/features/feed/views/pages/feed_page/components/feed_controls/feed_controls.dart
+++ b/lib/app/features/feed/views/pages/feed_page/components/feed_controls/feed_controls.dart
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:flutter/material.dart';
-import 'package:ion/app/extensions/num.dart';
 import 'package:ion/app/features/feed/views/pages/feed_page/components/feed_controls/components/feed_navigation/feed_navigation.dart';
+import 'package:ion/app/features/feed/views/pages/feed_page/components/feed_controls/components/feed_navigation/feed_notifications_button.dart';
+import 'package:ion/app/router/components/navigation_button/navigation_button.dart';
 
 class FeedControls extends StatelessWidget {
   const FeedControls({
@@ -12,7 +13,7 @@ class FeedControls extends StatelessWidget {
 
   final ScrollController? scrollController;
 
-  static double get height => 40.0.s;
+  static double get height => NavigationButton.defaultSize + FeedNotificationsButton.counterOffset;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/app/features/feed/views/pages/feed_page/feed_page.dart
+++ b/lib/app/features/feed/views/pages/feed_page/feed_page.dart
@@ -15,6 +15,7 @@ import 'package:ion/app/features/feed/providers/feed_posts_provider.r.dart';
 import 'package:ion/app/features/feed/providers/feed_trending_videos_provider.r.dart';
 import 'package:ion/app/features/feed/stories/providers/feed_stories_provider.r.dart';
 import 'package:ion/app/features/feed/views/pages/feed_page/components/article_categories_menu/article_categories_menu.dart';
+import 'package:ion/app/features/feed/views/pages/feed_page/components/feed_controls/components/feed_navigation/feed_notifications_button.dart';
 import 'package:ion/app/features/feed/views/pages/feed_page/components/feed_controls/feed_controls.dart';
 import 'package:ion/app/features/feed/views/pages/feed_page/components/feed_posts_list/feed_posts_list.dart';
 import 'package:ion/app/features/feed/views/pages/feed_page/components/stories/stories.dart';
@@ -61,6 +62,7 @@ class FeedPage extends HookConsumerWidget {
           return PullToRefreshBuilder(
             sliverAppBar: CollapsingAppBar(
               height: FeedControls.height,
+              topOffset: ScreenTopOffset.defaultMargin - FeedNotificationsButton.counterOffset,
               child: FeedControls(scrollController: scrollController),
             ),
             slivers: slivers,


### PR DESCRIPTION
## Description
Fixed feed top area (search and nav buttons) non clickable.
Also fixed unread pushes counter flushing at top during scrolling.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)

https://github.com/user-attachments/assets/dede4ffb-608e-460d-9a6f-46e3f8818ae3


