### PR TITLE
fix: make reply input field in post details page scrollable

### DIFF
--- a/lib/app/components/text_editor/text_editor.dart
+++ b/lib/app/components/text_editor/text_editor.dart
@@ -33,6 +33,7 @@ class TextEditor extends ConsumerStatefulWidget {
     this.autoFocus = true,
     this.scrollController,
     this.media,
+    this.scrollable = false,
   }) : super(key: key);
 
   final QuillController controller;
@@ -41,6 +42,8 @@ class TextEditor extends ConsumerStatefulWidget {
   final bool autoFocus;
   final ScrollController? scrollController;
   final Map<String, MediaAttachment>? media;
+  final bool scrollable;
+
   @override
   TextEditorState createState() => TextEditorState();
 }
@@ -108,7 +111,7 @@ class TextEditorState extends ConsumerState<TextEditor> {
           attribute,
           isEditing: true,
         ),
-        scrollable: false,
+        scrollable: widget.scrollable,
       ),
     );
   }

--- a/lib/app/features/feed/create_post/views/components/reply_input_field/reply_input_field.dart
+++ b/lib/app/features/feed/create_post/views/components/reply_input_field/reply_input_field.dart
@@ -144,6 +144,7 @@ class ReplyInputField extends HookConsumerWidget {
                                 autoFocus: false,
                                 placeholder: context.i18n.post_reply_hint,
                                 key: textEditorKey,
+                                scrollable: true,
                               ),
                             ),
                             if (hasFocus.value)


### PR DESCRIPTION
## Description
This PR fixes an issue where reply input was limited to 3 lines but not scrollable, so any text longer than 3 lines overflowed the widget.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
<!-- Add corresponding task ID here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
