### PR TITLE
fix: cancel button now properly closes both cancel modal and post creation modal

### DIFF
--- a/lib/app/features/feed/views/pages/cancel_creation_modal/cancel_creation_modal.dart
+++ b/lib/app/features/feed/views/pages/cancel_creation_modal/cancel_creation_modal.dart
@@ -61,7 +61,10 @@ class CancelCreationModal extends ConsumerWidget {
                   label: Text(
                     context.i18n.button_cancel,
                   ),
-                  onPressed: onCancel,
+                  onPressed: () {
+                    onCancel();
+                    context.pop();
+                  },
                   minimumSize: buttonMinimalSize,
                   backgroundColor: context.theme.appColors.attentionRed,
                 ),


### PR DESCRIPTION
## Description
Updated the cancel button's onPressed handler to automatically close the modal after invoking the onCancel function.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
2960

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
