### PR TITLE
fix: nickname taken error for current nickname in profile edit flow

### DIFF
--- a/lib/app/features/user/pages/profile_edit_page/profile_edit_page.dart
+++ b/lib/app/features/user/pages/profile_edit_page/profile_edit_page.dart
@@ -50,13 +50,15 @@ class ProfileEditPage extends HookConsumerWidget {
     final debouncedNickname = useDebounced(nickname.value.trim(), const Duration(seconds: 1));
     useOnInit(
       () {
-        if (debouncedNickname != null && validateNickname(debouncedNickname, context) == null) {
+        if (debouncedNickname != null &&
+            validateNickname(debouncedNickname, context) == null &&
+            debouncedNickname != userMetadata.data.name) {
           ref
               .read(userNicknameNotifierProvider.notifier)
               .verifyNicknameAvailability(nickname: debouncedNickname);
         }
       },
-      [debouncedNickname, context],
+      [debouncedNickname, context, userMetadata.data.name],
     );
 
     final verifyNicknameErrorMessage = useVerifyNicknameAvailabilityErrorMessage(ref);


### PR DESCRIPTION
## Description
Fixed nickname taken error for current nickname in profile edit flow

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if appli
Before the fix


https://github.com/user-attachments/assets/2b0f0b3b-be34-4a08-bdb6-ff4df3e3fac9



after the fix


https://github.com/user-attachments/assets/15209add-b6db-482c-a19c-50d45d42b25e



