### PR TITLE
fix: remove height from mentions font style

### DIFF
--- a/lib/app/components/text_editor/components/custom_blocks/text_editor_profile_block/profile_block.dart
+++ b/lib/app/components/text_editor/components/custom_blocks/text_editor_profile_block/profile_block.dart
@@ -42,7 +42,6 @@ class ProfileBlock extends ConsumerWidget {
         '@${metadata.data.name}',
         style: context.theme.appTextThemes.caption.copyWith(
           color: context.theme.appColors.primaryAccent,
-          height: 1.3,
           fontWeight: FontWeight.normal,
           decoration: TextDecoration.none,
         ),


### PR DESCRIPTION
## Description
This PR fixes the aligment of mentions blocks inside posts bodies.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
<!-- Add corresponding task ID here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
![ScreenShot 2025-07-03 at 11 25 06@2x](https://github.com/user-attachments/assets/bd04abfa-d463-4e35-89d2-cc503bd4d76f)

