### PR TITLE
fix: clear related pubkeys for article soft delete

### DIFF
--- a/lib/app/features/feed/create_article/providers/create_article_provider.r.dart
+++ b/lib/app/features/feed/create_article/providers/create_article_provider.r.dart
@@ -154,6 +154,7 @@ class CreateArticle extends _$CreateArticle {
         image: null,
         textContent: '',
         relatedHashtags: [],
+        relatedPubkeys: [],
         media: {},
         colorLabel: null,
         settings: null,


### PR DESCRIPTION
## Description
This PR fixes an issue where related pubkeys where not cleared during article delete.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
<!-- Add corresponding task ID here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
