### PR TITLE
fix: remove trailing comma in E2EDecryptionService initialization

### DIFF
--- a/ios/NotificationServiceExtension/Translation/NotificationTranslationService.swift
+++ b/ios/NotificationServiceExtension/Translation/NotificationTranslationService.swift
@@ -25,7 +25,7 @@ class NotificationTranslationService {
         if let pubkey = storage.getCurrentPubkey(), let currentIdentityKeyName = storage.getCurrentIdentityKeyName() {
             self.e2eDecryptionService = E2EDecryptionService(
                 keychainService: KeychainService(currentIdentityKeyName: currentIdentityKeyName),
-                pubkey: pubkey,
+                pubkey: pubkey
             )
         } else {
             self.e2eDecryptionService = nil


### PR DESCRIPTION
## Description
Remove trailing comma

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
