### PR TITLE
fix: image story controls bottom padding

### DIFF
--- a/lib/app/features/feed/stories/views/components/story_viewer/components/core/story_content.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/core/story_content.dart
@@ -42,29 +42,24 @@ class StoryContent extends HookConsumerWidget {
     return Stack(
       fit: StackFit.expand,
       children: [
-        Stack(
-          fit: StackFit.expand,
-          children: [
-            Align(
-              widthFactor: 1,
-              heightFactor: 1,
-              child: Container(
-                decoration: BoxDecoration(
-                  borderRadius: isKeyboardVisible
-                      ? BorderRadiusDirectional.only(
-                          topStart: Radius.circular(borderRadius),
-                          topEnd: Radius.circular(borderRadius),
-                        )
-                      : BorderRadius.circular(borderRadius),
-                ),
-                clipBehavior: Clip.hardEdge,
-                child: StoryViewerContent(
-                  post: story,
-                  viewerPubkey: viewerPubkey,
-                ),
-              ),
+        Align(
+          widthFactor: 1,
+          heightFactor: 1,
+          child: Container(
+            decoration: BoxDecoration(
+              borderRadius: isKeyboardVisible
+                  ? BorderRadiusDirectional.only(
+                      topStart: Radius.circular(borderRadius),
+                      topEnd: Radius.circular(borderRadius),
+                    )
+                  : BorderRadius.circular(borderRadius),
             ),
-          ],
+            clipBehavior: Clip.hardEdge,
+            child: StoryViewerContent(
+              post: story,
+              viewerPubkey: viewerPubkey,
+            ),
+          ),
         ),
         StoryViewerHeader(currentPost: story),
         _StoryControlsPanel(

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/image_story_viewer.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/image_story_viewer.dart
@@ -43,9 +43,11 @@ class ImageStoryViewer extends ConsumerWidget {
           }
         });
 
-        return Image(
-          image: imageProvider,
-          fit: hasQuotedPost ? BoxFit.contain : BoxFit.cover,
+        return SizedBox.expand(
+          child: Image(
+            image: imageProvider,
+            fit: hasQuotedPost ? BoxFit.contain : BoxFit.cover,
+          ),
         );
       },
     );


### PR DESCRIPTION
## Description
This PR fixes an issue where image stories didn't take the whole available vertical space, causing the controls on it to look like they have smaller padding.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
3053

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
![ScreenShot 2025-07-04 at 12 15 18@2x](https://github.com/user-attachments/assets/ba602aac-cdee-4f86-9119-bffe4af9fd42)
![ScreenShot 2025-07-04 at 12 15 29@2x](https://github.com/user-attachments/assets/c79ce019-28ad-4370-a653-902ed13b8c06)
