### PR TITLE
fix: feed events filter

### DIFF
--- a/lib/app/features/feed/providers/feed_data_source_builders.dart
+++ b/lib/app/features/feed/providers/feed_data_source_builders.dart
@@ -222,18 +222,11 @@ EntitiesDataSource buildStoriesDataSource({
 
   return EntitiesDataSource(
     actionSource: actionSource,
-    entityFilter: (entity) {
-      // TODO:uncomment when stories are reworked
-      // if (entity.masterPubkey == currentPubkey) {
-      //   return false;
-      // }
-
-      if (authors != null && !authors.contains(entity.masterPubkey)) {
-        return false;
-      }
-
-      return entity is ModifiablePostEntity && entity.data.parentEvent == null;
-    },
+    entityFilter: (entity) =>
+        (authors == null || authors.contains(entity.masterPubkey)) &&
+        (entity is ModifiablePostEntity &&
+            entity.data.parentEvent == null &&
+            entity.data.expiration != null),
     requestFilters: [
       RequestFilter(
         kinds: const [ModifiablePostEntity.kind],


### PR DESCRIPTION
## Description
This PR fixes events filter - check if arrived events are not from the current user to skip events that are returned as dependencies (repost / reply from the current user).

## Task ID
3159-3160-3163

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
