### PR TITLE
fix: double loader indicator shown during pull-to-refresh in reply list

### DIFF
--- a/lib/app/components/scroll_view/load_more_builder.dart
+++ b/lib/app/components/scroll_view/load_more_builder.dart
@@ -80,6 +80,12 @@ class LoadMoreBuilder extends HookWidget {
     void Function() loadMore,
   ) {
     final metrics = notification.metrics;
+
+    // Do not trigger loadMore if the list is not scrollable at all.
+    if (!metrics.hasPixels || metrics.maxScrollExtent == 0.0) {
+      return false;
+    }
+
     final loadMoreOffset = this.loadMoreOffset ?? metrics.viewportDimension;
     if (metrics.maxScrollExtent - metrics.pixels <= loadMoreOffset) {
       loadMore();


### PR DESCRIPTION
## Description
Fixed an issue where both pull-to-refresh and load-more indicators were displayed simultaneously

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
<!-- Add corresponding task ID here. -->

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
