### PR TITLE
chore: avoid rebuilding listeners on unrelated state updates

### DIFF
--- a/lib/app/features/core/providers/ion_connect_media_url_fallback_provider.r.dart
+++ b/lib/app/features/core/providers/ion_connect_media_url_fallback_provider.r.dart
@@ -35,7 +35,8 @@ class IONConnectMediaUrlFallback extends _$IONConnectMediaUrlFallback {
     final assetUri = Uri.parse(mediaUrl);
     final fallbackUrl = assetUri.replace(host: userRelayUri.host).toString();
 
-    state = {...state, mediaUrl: fallbackUrl};
+    state[mediaUrl] = fallbackUrl;
+    ref.notifyListeners();
 
     return fallbackUrl;
   }

--- a/lib/app/features/feed/providers/counters/reposted_events_notifier.r.dart
+++ b/lib/app/features/feed/providers/counters/reposted_events_notifier.r.dart
@@ -33,10 +33,8 @@ class RepostedEventsNotifier extends _$RepostedEventsNotifier {
     final subscription = ref.watch(ionConnectCacheStreamProvider).listen((entity) {
       final userRepostData = _getCurrentUserRepostData(entity, currentPubkey: currentPubkey);
       if (userRepostData != null) {
-        state = {
-          ...state,
-          userRepostData.postReference: userRepostData.repostReference,
-        };
+        state[userRepostData.postReference] = userRepostData.repostReference;
+        ref.notifyListeners();
       }
     });
 

--- a/lib/app/features/ion_connect/providers/ion_connect_cache.r.dart
+++ b/lib/app/features/ion_connect/providers/ion_connect_cache.r.dart
@@ -46,7 +46,8 @@ class IonConnectCache extends _$IonConnectCache {
       createdAt: DateTime.now(),
     );
 
-    state = {...state, entity.cacheKey: entry};
+    state[entity.cacheKey] = entry;
+    ref.notifyListeners();
 
     _ionConnectCacheStreamController.sink.add(entity);
 
@@ -56,7 +57,8 @@ class IonConnectCache extends _$IonConnectCache {
   }
 
   void remove(String key) {
-    state = {...state}..remove(key);
+    state.remove(key);
+    ref.notifyListeners();
   }
 }
 


### PR DESCRIPTION
## Description
Avoid rebuilding dependents of Map-based providers on unrelated updates

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [X] Chore

## Screenshots (if applicable)
Before:
<img width="643" alt="image" src="https://github.com/user-attachments/assets/fff71b7f-a149-493d-bdd7-8f5c26cd698e" />

After:
<img width="646" alt="image" src="https://github.com/user-attachments/assets/333539c6-bfaa-4deb-b184-6b9a427d8fbe" />

