### PR TITLE
fix: text is cut for some posts in feed with show more

### DIFF
--- a/lib/app/features/feed/views/components/post/components/post_body/post_body.dart
+++ b/lib/app/features/feed/views/components/post/components/post_body/post_body.dart
@@ -4,6 +4,7 @@ import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_quill/flutter_quill.dart';
+import 'package:flutter_quill/quill_delta.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/text_editor/text_editor_preview.dart';
 import 'package:ion/app/components/text_editor/utils/is_attributed_operation.dart';
@@ -93,23 +94,18 @@ class PostBody extends HookConsumerWidget {
 
     return LayoutBuilder(
       builder: (context, constraints) {
-        // Ensure content delta ends with a newline to satisfy flutter_quill assertion
-        final deltaForMeasurement = content;
-        if (deltaForMeasurement.isNotEmpty) {
-          final lastOp = deltaForMeasurement.operations.last;
-          if (!(lastOp.data is String && (lastOp.data! as String).endsWith('\n'))) {
-            deltaForMeasurement.insert('\n');
-          }
-        }
-        final maxHeight = maxLines == null
-            ? null
-            : _calculateMaxHeight(
-                context,
-                text: Document.fromDelta(deltaForMeasurement).toPlainText(),
-                style: context.theme.appTextThemes.body2,
-                maxWidth: constraints.maxWidth,
-              );
+        final truncResult = maxLines != null
+            ? _truncateForMaxLines(
+                content,
+                context.theme.appTextThemes.body2,
+                constraints.maxWidth,
+                maxLines!,
+              )
+            : _TruncationResult(delta: content, hasOverflow: false);
+        final displayDelta = truncResult.delta;
+        final hasOverflow = truncResult.hasOverflow;
 
+        // Render preview with truncated content
         return Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
@@ -118,24 +114,19 @@ class PostBody extends HookConsumerWidget {
               child: Column(
                 children: [
                   if (showTextContent)
-                    ClipRect(
-                      child: SizedBox(
-                        height: maxHeight,
-                        child: TextEditorPreview(
-                          scrollable: false,
-                          content: content,
-                          customStyles: accentTheme
-                              ? textEditorStyles(
-                                  context,
-                                  color: context.theme.appColors.onPrimaryAccent,
-                                )
-                              : null,
-                          enableInteractiveSelection: isTextSelectable,
-                          tagsColor: accentTheme ? context.theme.appColors.lightBlue : null,
-                        ),
-                      ),
+                    TextEditorPreview(
+                      scrollable: false,
+                      content: displayDelta,
+                      customStyles: accentTheme
+                          ? textEditorStyles(
+                              context,
+                              color: context.theme.appColors.onPrimaryAccent,
+                            )
+                          : null,
+                      enableInteractiveSelection: isTextSelectable,
+                      tagsColor: accentTheme ? context.theme.appColors.lightBlue : null,
                     ),
-                  if (maxHeight != null)
+                  if (hasOverflow)
                     Align(
                       alignment: AlignmentDirectional.centerStart,
                       child: Text(
@@ -194,22 +185,79 @@ class PostBody extends HookConsumerWidget {
     return null;
   }
 
-  double? _calculateMaxHeight(
-    BuildContext context, {
-    required String text,
-    required TextStyle style,
-    required double maxWidth,
-  }) {
-    final textPainter = TextPainter(
-      text: TextSpan(text: text, style: style),
-      maxLines: maxLines,
-      textScaler: MediaQuery.textScalerOf(context),
+  Delta _truncateDelta(Delta original, int maxChars) {
+    final truncated = Delta();
+    var consumed = 0;
+    for (final op in original.toList()) {
+      final data = op.data;
+      if (data is String) {
+        if (consumed >= maxChars) break;
+        final remaining = maxChars - consumed;
+        if (data.length <= remaining) {
+          truncated.push(op);
+          consumed += data.length;
+        } else {
+          truncated.insert(data.substring(0, remaining), op.attributes);
+          break;
+        }
+      } else {
+        // preserve embeds until overflow
+        if (consumed < maxChars) {
+          truncated.push(op);
+        }
+      }
+    }
+    return truncated;
+  }
+
+  _TruncationResult _truncateForMaxLines(
+    Delta content,
+    TextStyle style,
+    double maxWidth,
+    int maxLines,
+  ) {
+    // Ensure content ends with a newline for proper measurement
+    final contentForLayout = content;
+    if (contentForLayout.isNotEmpty) {
+      final lastOp = contentForLayout.operations.last;
+      if (lastOp.data is String && !(lastOp.data! as String).endsWith('\n')) {
+        contentForLayout.insert('\n');
+      }
+    }
+
+    final plainText = Document.fromDelta(contentForLayout).toPlainText();
+    final painter = TextPainter(
+      text: TextSpan(text: plainText, style: style),
       textDirection: TextDirection.ltr,
+      maxLines: maxLines - 1,
     )..layout(maxWidth: maxWidth);
 
-    if (textPainter.didExceedMaxLines) {
-      return textPainter.height;
+    // If text fits, return original
+    if (!painter.didExceedMaxLines) {
+      return _TruncationResult(delta: content, hasOverflow: false);
     }
-    return null;
+
+    // Find position at the end of the visible text region
+    final yOffset = painter.height - 0.1;
+    final textPosition = painter.getPositionForOffset(Offset(maxWidth, yOffset));
+    final truncateOffset = textPosition.offset;
+
+    // Truncate content and ensure newline at end
+    final truncated = _truncateDelta(content, truncateOffset);
+    if (truncated.isNotEmpty) {
+      final lastOp = truncated.operations.last;
+      if (lastOp.data is String && !(lastOp.data! as String).endsWith('\n')) {
+        truncated.insert('\n');
+      }
+    }
+
+    return _TruncationResult(delta: truncated, hasOverflow: true);
   }
+}
+
+class _TruncationResult {
+  _TruncationResult({required this.delta, required this.hasOverflow});
+
+  final Delta delta;
+  final bool hasOverflow;
 }


### PR DESCRIPTION
## Description
Fixed text is cut for some posts in feed with show more. Before it was view box boundaries for view more posts which lead to text cut issue in some cases. I switched to showing a portion of text (so content is updated not the view box limited) 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)

![Simulator Screenshot - iPhone 16 Pro Max - 2025-07-07 at 20 09 30](https://github.com/user-attachments/assets/6683cd09-5d70-4bee-af63-28af5cd0a291)
