### PR TITLE
fix: the list of chains is empty

### DIFF
--- a/lib/app/features/wallets/data/repository/networks_repository.r.dart
+++ b/lib/app/features/wallets/data/repository/networks_repository.r.dart
@@ -42,6 +42,8 @@ class NetworksRepository {
     return _networksDao.getByFilters(tiers: tiers).then((networks) => networks.toConvertedList());
   }
 
+  Future<List<NetworkData>> getNftNetworks() => getByFilters(tiers: [1]);
+
   Future<List<NetworkData>> getAll() {
     return _networksDao.getAll().then((networks) => networks.toConvertedList());
   }

--- a/lib/app/features/wallets/providers/networks_provider.r.dart
+++ b/lib/app/features/wallets/providers/networks_provider.r.dart
@@ -25,8 +25,7 @@ Future<List<NetworkData>> networksByTier(Ref ref, {required int tier}) {
 
 @riverpod
 Future<List<NetworkData>> networksWithNft(Ref ref) {
-  // Only tier 1 networks support NFTs
-  return ref.watch(networksRepositoryProvider).getByFilters(tiers: [1]);
+  return ref.watch(networksRepositoryProvider).getNftNetworks();
 }
 
 @riverpod


### PR DESCRIPTION
## Description
Fixes the empty NFT networks list in network selection by pre-loading all networks, that support NFT.

## Task ID
ION-3182

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
