### PR TITLE
fix: fallback to add new delegation if restore device keypair fails

### DIFF
--- a/lib/app/features/auth/views/pages/link_new_device/link_new_device_dialog.dart
+++ b/lib/app/features/auth/views/pages/link_new_device/link_new_device_dialog.dart
@@ -135,6 +135,9 @@ class LinkNewDeviceDialog extends HookConsumerWidget {
         child: child,
       ),
     );
+    if (ref.read(restoreDeviceKeypairNotifierProvider).hasError) {
+      return _addDelegation(ref);
+    }
   }
 
   Future<void> _addDelegation(WidgetRef ref) async {

--- a/lib/app/features/ion_connect/providers/restore_device_keypair_notifier.r.dart
+++ b/lib/app/features/ion_connect/providers/restore_device_keypair_notifier.r.dart
@@ -37,6 +37,8 @@ class RestoreDeviceKeypairNotifier extends _$RestoreDeviceKeypairNotifier {
           throw DeviceKeypairRestoreException('Could not extract file ID from device keypair URL');
         }
 
+        final encryptedData = await DeviceKeypairUtils.downloadEncryptedKeypair(fileId, ref);
+
         final deviceKey = await DeviceKeypairUtils.findOrCreateDeviceKey(
           ref: ref,
           signer: signer,
@@ -47,7 +49,6 @@ class RestoreDeviceKeypairNotifier extends _$RestoreDeviceKeypairNotifier {
           signer: signer,
         );
 
-        final encryptedData = await DeviceKeypairUtils.downloadEncryptedKeypair(fileId, ref);
         final decryptedPrivateKey = await DeviceKeypairUtils.decryptDeviceKeypair(
           encryptedData,
           derivation.output,


### PR DESCRIPTION
## Description
Fallback to add new delegation if restore device keypair flow fails.
Now if it fails user gets stuck

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
