### PR TITLE
fix: discover creators screen is empty

### DIFF
--- a/lib/app/features/auth/views/components/auth_scrolled_body/auth_scrolled_body.dart
+++ b/lib/app/features/auth/views/components/auth_scrolled_body/auth_scrolled_body.dart
@@ -91,7 +91,7 @@ class AuthScrollContainer extends HookWidget {
               toolbarHeight: NavigationAppBar.modalHeaderHeight,
               pinned: true,
             ),
-            if (children.isEmpty)
+            if (children.isEmpty && slivers.isEmpty)
               SliverFillRemaining(
                 hasScrollBody: false,
                 child: Center(


### PR DESCRIPTION
## Description
Fixed empty discover creators screen issue

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

