### PR TITLE
fix: do not filter out current user events, handle reposts corner case

### DIFF
--- a/lib/app/exceptions/exceptions.dart
+++ b/lib/app/exceptions/exceptions.dart
@@ -602,8 +602,3 @@ class NoAvailableInterests extends IONException {
           'No available interests for relay: $relayUrl, modifier: $modifier',
         );
 }
-
-class FailedToFindMainEvent extends IONException {
-  FailedToFindMainEvent({required dynamic response})
-      : super(10121, 'Failed to find main event from $response');
-}

--- a/lib/app/features/feed/providers/feed_following_content_provider.m.dart
+++ b/lib/app/features/feed/providers/feed_following_content_provider.m.dart
@@ -306,13 +306,10 @@ class FeedFollowingContent extends _$FeedFollowingContent implements PagedNotifi
     }
 
     final entities = await ionConnectNotifier
-        .requestEntities(
-          requestMessage,
-          actionSource: dataSource.actionSource,
-        )
+        .requestEntities(requestMessage, actionSource: dataSource.actionSource)
         .toList();
 
-    return filterMainEntity(response: entities, dataSource: dataSource);
+    return dataSource.responseFilter?.call(entities).first;
   }
 
   Stream<IonConnectEntity> _requestEntitiesByReferences({

--- a/lib/app/features/feed/providers/feed_for_you_content_provider.m.dart
+++ b/lib/app/features/feed/providers/feed_for_you_content_provider.m.dart
@@ -451,13 +451,10 @@ class FeedForYouContent extends _$FeedForYouContent implements PagedNotifier {
     }
 
     final entities = await ionConnectNotifier
-        .requestEntities(
-          requestMessage,
-          actionSource: dataSource.actionSource,
-        )
+        .requestEntities(requestMessage, actionSource: dataSource.actionSource)
         .toList();
 
-    return filterMainEntity(response: entities, dataSource: dataSource);
+    return dataSource.responseFilter?.call(entities).first;
   }
 
   EntitiesDataSource _getDataSource({

--- a/lib/app/features/ion_connect/providers/entities_paged_data_provider.m.dart
+++ b/lib/app/features/ion_connect/providers/entities_paged_data_provider.m.dart
@@ -57,6 +57,7 @@ class EntitiesDataSource with _$EntitiesDataSource {
     required List<RequestFilter> requestFilters,
     required bool Function(IonConnectEntity entity) entityFilter,
     bool Function(IonConnectEntity entity)? pagedFilter,
+    List<IonConnectEntity> Function(List<IonConnectEntity> entities)? responseFilter,
   }) = _EntitiesDataSource;
 }
 


### PR DESCRIPTION
## Description
This PR fixes the issue on feed when the app filters out all events from the current user, that leads to an issue when we receive our event, filter returns null, we stop querying the data source assuming that we don't have events left. 

## Task ID
ION-3213

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
