### PR TITLE
fix: transactions details padding

### DIFF
--- a/lib/app/features/wallets/views/pages/transaction_details/transaction_details.dart
+++ b/lib/app/features/wallets/views/pages/transaction_details/transaction_details.dart
@@ -76,7 +76,6 @@ class TransactionDetailsPage extends ConsumerWidget {
                 children: [
                   ScreenSideOffset.small(
                     child: SingleChildScrollView(
-                      padding: EdgeInsetsDirectional.only(top: 10.0.s),
                       child: Column(
                         children: [
                           transactionData.assetData.maybeMap(
@@ -120,7 +119,7 @@ class TransactionDetailsPage extends ConsumerWidget {
                               ),
                             ],
                           ),
-                          SizedBox(height: 16.0.s),
+                          SizedBox(height: 12.0.s),
                           TransactionParticipant(
                             address: participantAddress,
                             transactionType: transactionData.type,
@@ -143,7 +142,7 @@ class TransactionDetailsPage extends ConsumerWidget {
                             ),
                           ...transactionData.assetData.maybeMap(
                                 coin: (coin) => [
-                                  SizedBox(height: 16.0.s),
+                                  SizedBox(height: 12.0.s),
                                   ListItem.textWithIcon(
                                     title: Text(locale.wallet_asset),
                                     value: coin.coinsGroup.abbreviation,


### PR DESCRIPTION
## Description
Fix transactions details padding

## Task ID
3276

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<img width="300" height="581" alt="image" src="https://github.com/user-attachments/assets/64149d16-a150-4dcf-a362-c9f12328acab" />
