### PR TITLE
fix: media permission required for viewing own stories

### DIFF
--- a/lib/app/features/feed/views/pages/feed_page/components/stories/components/current_user_avatar_with_permission.dart
+++ b/lib/app/features/feed/views/pages/feed_page/components/stories/components/current_user_avatar_with_permission.dart
@@ -27,26 +27,32 @@ class CurrentUserAvatarWithPermission extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    if (hasStories) {
+      return StoryItemContent(
+        pubkey: pubkey,
+        name: context.i18n.common_you,
+        gradient: gradient,
+        isViewed: isViewed,
+        onTap: () =>
+            StoryViewerRoute(pubkey: pubkey, showOnlySelectedUser: true).push<void>(context),
+      );
+    }
+
     return PermissionAwareWidget(
       permissionType: Permission.camera,
       requestId: 'story_record',
       onGrantedPredicate: () =>
           GoRouter.of(context).state.fullPath?.startsWith(FeedRoute().location) ?? false,
-      onGranted: () => hasStories
-          ? StoryViewerRoute(pubkey: pubkey, showOnlySelectedUser: true).push<void>(context)
-          : StoryRecordRoute().push<void>(context),
+      onGranted: () => StoryRecordRoute().push<void>(context),
       requestDialog: const PermissionRequestSheet(permission: Permission.camera),
       settingsDialog: SettingsRedirectSheet.fromType(context, Permission.camera),
       builder: (context, onPressed) {
-        return GestureDetector(
+        return StoryItemContent(
+          pubkey: pubkey,
+          name: context.i18n.common_you,
+          gradient: gradient,
+          isViewed: isViewed,
           onTap: onPressed,
-          child: StoryItemContent(
-            pubkey: pubkey,
-            name: context.i18n.common_you,
-            gradient: gradient,
-            isViewed: isViewed,
-            onTap: onPressed,
-          ),
         );
       },
     );


### PR DESCRIPTION
## Description
It used permission aware widget for both cases: post a story and view own stories

## Task ID
ION-3261

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

