### PR TITLE
fix: ownership check happening for mock users

### DIFF
--- a/lib/app/components/list_item/badges_user_list_item.dart
+++ b/lib/app/components/list_item/badges_user_list_item.dart
@@ -24,6 +24,7 @@ class BadgesUserListItem extends ConsumerWidget {
     this.iceBadge = false,
     this.isSelected = false,
     this.avatarSize,
+    this.isOwnershipIgnored = false,
     super.key,
   });
 
@@ -42,6 +43,7 @@ class BadgesUserListItem extends ConsumerWidget {
   final VoidCallback? onTap;
   final bool iceBadge;
   final bool isSelected;
+  final bool isOwnershipIgnored;
   final double? avatarSize;
 
   @override
@@ -53,7 +55,7 @@ class BadgesUserListItem extends ConsumerWidget {
     return ListItem.user(
       pubkey: pubkey,
       title: title,
-      subtitle: isNicknameProven
+      subtitle: isNicknameProven || isOwnershipIgnored
           ? subtitle
           : Row(
               mainAxisSize: MainAxisSize.min,

--- a/lib/app/features/auth/views/pages/turn_on_notifications/notification_list_item.dart
+++ b/lib/app/features/auth/views/pages/turn_on_notifications/notification_list_item.dart
@@ -28,6 +28,7 @@ class NotificationListItem extends StatelessWidget {
       padding: EdgeInsets.symmetric(horizontal: 43.0.s),
       child: BadgesUserListItem(
         pubkey: '',
+        isOwnershipIgnored: true,
         // that is a mock notification
         title: Text(
           title,


### PR DESCRIPTION
## Description
Fixes issue when ownership check is done for mock user cards shown on notification permission prompt screen

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/058a4708-d6d0-4345-abc0-16b248cced10" />
<img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/9ec92ab3-e635-4478-bacc-493a7bc2ac39" />

