### PR TITLE
fix: video playback not paused properly

### DIFF
--- a/lib/app/features/feed/stories/hooks/use_story_video_playback.dart
+++ b/lib/app/features/feed/stories/hooks/use_story_video_playback.dart
@@ -31,7 +31,7 @@ void useStoryVideoPlayback({
   useEffect(
     () {
       if (!isCurrent) completedSent.value = false;
-      return null;
+      return () => _post(controller.pause);
     },
     [isCurrent],
   );

--- a/lib/app/features/video/views/pages/video_page.dart
+++ b/lib/app/features/video/views/pages/video_page.dart
@@ -155,7 +155,6 @@ class VideoPage extends HookConsumerWidget {
     return VisibilityDetector(
       key: ValueKey(videoUrl),
       onVisibilityChanged: (info) {
-        if (!context.mounted) return;
         if (info.visibleFraction <= 0.5) {
           if (playerController.value.isInitialized && playerController.value.isPlaying) {
             playerController.pause();

--- a/lib/app/hooks/use_route_presence.dart
+++ b/lib/app/hooks/use_route_presence.dart
@@ -13,7 +13,10 @@ void useRoutePresence({
   void Function()? onBecameActive,
 }) {
   final context = useContext();
-  final router = GoRouter.of(context);
+  final router = GoRouter.maybeOf(context);
+  if (router == null) {
+    return;
+  }
   final state = router.state;
   final fullPath = useState(state.fullPath);
   final fullPathRef = useRef(state.fullPath);


### PR DESCRIPTION
## Description
- Fixed video playback not always paused on unmounting and continues playback in the background;
- Fixed router not found issue for lib/app/hooks/use_route_presence.dart

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
