### PR TITLE
fix: text line height lost + adjusted the body line height

### DIFF
--- a/lib/app/theme/app_text_themes.dart
+++ b/lib/app/theme/app_text_themes.dart
@@ -23,22 +23,23 @@ class AppTextThemesExtension extends ThemeExtension<AppTextThemesExtension> {
   });
 
   factory AppTextThemesExtension.fromTemplate(TemplateTextThemes textThemes) {
+    final defaults = AppTextThemesExtension.defaultTextThemes();
     return AppTextThemesExtension(
-      headline1: TemplateTextStyle.fromTemplate(textThemes.headline1),
-      headline2: TemplateTextStyle.fromTemplate(textThemes.headline2),
-      title: TemplateTextStyle.fromTemplate(textThemes.title),
-      subtitle: TemplateTextStyle.fromTemplate(textThemes.subtitle),
-      subtitle2: TemplateTextStyle.fromTemplate(textThemes.subtitle2),
-      subtitle3: TemplateTextStyle.fromTemplate(textThemes.subtitle3),
-      body: TemplateTextStyle.fromTemplate(textThemes.body),
-      body2: TemplateTextStyle.fromTemplate(textThemes.body2),
-      caption: TemplateTextStyle.fromTemplate(textThemes.caption),
-      caption2: TemplateTextStyle.fromTemplate(textThemes.caption2),
-      caption3: TemplateTextStyle.fromTemplate(textThemes.caption3),
-      caption4: TemplateTextStyle.fromTemplate(textThemes.caption4),
-      caption5: TemplateTextStyle.fromTemplate(textThemes.caption5),
-      caption6: TemplateTextStyle.fromTemplate(textThemes.caption6),
-      notificationCaption: TemplateTextStyle.fromTemplate(textThemes.notificationCaption),
+      headline1: TemplateTextStyle.fromTemplate(textThemes.headline1, defaultStyle: defaults.headline1),
+      headline2: TemplateTextStyle.fromTemplate(textThemes.headline2, defaultStyle: defaults.headline2),
+      title: TemplateTextStyle.fromTemplate(textThemes.title, defaultStyle: defaults.title),
+      subtitle: TemplateTextStyle.fromTemplate(textThemes.subtitle, defaultStyle: defaults.subtitle),
+      subtitle2: TemplateTextStyle.fromTemplate(textThemes.subtitle2, defaultStyle: defaults.subtitle2),
+      subtitle3: TemplateTextStyle.fromTemplate(textThemes.subtitle3, defaultStyle: defaults.subtitle3),
+      body: TemplateTextStyle.fromTemplate(textThemes.body, defaultStyle: defaults.body),
+      body2: TemplateTextStyle.fromTemplate(textThemes.body2, defaultStyle: defaults.body2),
+      caption: TemplateTextStyle.fromTemplate(textThemes.caption, defaultStyle: defaults.caption),
+      caption2: TemplateTextStyle.fromTemplate(textThemes.caption2, defaultStyle: defaults.caption2),
+      caption3: TemplateTextStyle.fromTemplate(textThemes.caption3, defaultStyle: defaults.caption3),
+      caption4: TemplateTextStyle.fromTemplate(textThemes.caption4, defaultStyle: defaults.caption4),
+      caption5: TemplateTextStyle.fromTemplate(textThemes.caption5, defaultStyle: defaults.caption5),
+      caption6: TemplateTextStyle.fromTemplate(textThemes.caption6, defaultStyle: defaults.caption6),
+      notificationCaption: TemplateTextStyle.fromTemplate(textThemes.notificationCaption, defaultStyle: defaults.notificationCaption),
     );
   }
 
@@ -50,8 +51,8 @@ class AppTextThemesExtension extends ThemeExtension<AppTextThemesExtension> {
       subtitle: TextStyle(fontSize: 15, fontWeight: FontWeight.w600),
       subtitle2: TextStyle(fontSize: 15, fontWeight: FontWeight.w500),
       subtitle3: TextStyle(fontSize: 14, fontWeight: FontWeight.w500),
-      body: TextStyle(fontSize: 13, height: 1.38, fontWeight: FontWeight.w600),
-      body2: TextStyle(fontSize: 13, fontWeight: FontWeight.w400),
+      body: TextStyle(fontSize: 13, height: 1.37, fontWeight: FontWeight.w600),
+      body2: TextStyle(fontSize: 13, height: 1.37, fontWeight: FontWeight.w400),
       caption: TextStyle(fontSize: 12, fontWeight: FontWeight.w500),
       caption2: TextStyle(fontSize: 12, fontWeight: FontWeight.w400),
       caption3: TextStyle(fontSize: 11, height: 1.63, fontWeight: FontWeight.w400),
@@ -145,11 +146,11 @@ class AppTextThemesExtension extends ThemeExtension<AppTextThemesExtension> {
 }
 
 class TemplateTextStyle extends TextStyle {
-  static TextStyle fromTemplate(TemplateTextTheme theme) {
+  static TextStyle fromTemplate(TemplateTextTheme theme, {TextStyle? defaultStyle}) {
     return TextStyle(
-      fontSize: theme.fontSize,
-      fontWeight: theme.fontWeight,
-      height: theme.height,
+      fontSize: theme.fontSize ?? defaultStyle?.fontSize,
+      fontWeight: theme.fontWeight ?? defaultStyle?.fontWeight,
+      height: theme.height ?? defaultStyle?.height,
       fontFamily: 'NotoSans',
       letterSpacing: 0,
     );


### PR DESCRIPTION
## Additional Notes
Seems like Flutter is rounding up `TextStyle.height`, so effectively 1.375 becomes 1.37, and 1.368 becomes 1.36, so I am not sure if it possible to make that pixel perfect.

## Task ID
ION-3279

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
Comparing the app against the design:
Before:
<img width="1186" height="384" alt="image" src="https://github.com/user-attachments/assets/c8071ebf-635e-4575-9420-636ecc4aac76" />
After:
<img width="1169" height="331" alt="image" src="https://github.com/user-attachments/assets/6f5b8bd4-e837-4ee1-81d6-c8eb8ba20599" />

