### PR TITLE
fix: post shared to story user info skeleton loader

### DIFF
--- a/lib/app/features/chat/views/pages/share_via_message_modal/components/share_options.dart
+++ b/lib/app/features/chat/views/pages/share_via_message_modal/components/share_options.dart
@@ -136,6 +136,8 @@ class ShareOptions extends HookConsumerWidget {
         ionConnectEntityWithCountersProvider(eventReference: eventReference),
       );
 
+      final userMetadata = ref.read(cachedUserMetadataProvider(eventReference.masterPubkey));
+
       // ignore: scoped_providers_should_specify_dependencies
       final postWidget = ProviderScope(
         overrides: [
@@ -148,7 +150,11 @@ class ShareOptions extends HookConsumerWidget {
             eventReference: eventReference,
           ).overrideWithValue(postEntityAsyncValue),
           // ignore: scoped_providers_should_specify_dependencies
-          userMetadataProvider(eventReference.masterPubkey),
+          if (userMetadata != null)
+            ionConnectCachedEntityProvider(eventReference: userMetadata.toEventReference())
+                .overrideWithValue(
+              userMetadata,
+            ),
         ],
         child: SharePostToStoryContent(
           eventReference: eventReference,


### PR DESCRIPTION
## Description
This PR fixes an issue where any post shared to story ended up with the user info on it loading

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
<!-- Add corresponding task ID here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
![first](https://github.com/user-attachments/assets/f51b87e4-1f49-40a1-99b5-33001fb9ba99)

