### PR TITLE
fix: video preview button paddings

### DIFF
--- a/lib/app/components/video_preview/video_preview.dart
+++ b/lib/app/components/video_preview/video_preview.dart
@@ -152,10 +152,11 @@ class VideoPreview extends HookConsumerWidget {
           if (controller != null && controller.value.isInitialized)
             PositionedDirectional(
               bottom: 12.0.s,
-              start: 5.0.s,
-              end: 5.0.s,
+              start: 12.0.s,
+              end: 12.0.s,
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                crossAxisAlignment: CrossAxisAlignment.end,
                 children: [
                   _VideoDurationLabel(controller: controller),
                   _MuteButton(
@@ -186,7 +187,7 @@ class _VideoDurationLabel extends StatelessWidget {
         final remaining = controller.value.duration - value.position;
 
         return Container(
-          padding: EdgeInsets.symmetric(horizontal: 4.0.s, vertical: 1.0.s),
+          padding: EdgeInsets.symmetric(horizontal: 4.0.s),
           decoration: BoxDecoration(
             color: context.theme.appColors.backgroundSheet.withValues(alpha: 0.7),
             borderRadius: BorderRadius.circular(6.0.s),


### PR DESCRIPTION
## Description
- changed paddings to match the design

## Additional Notes
- I've kept the duration formatting logic even though it is not consistent with design, as it [seems to be done on purpose](https://github.com/ice-blockchain/ion-app/blob/02ffbf6d2de31c52f53f4c7c30bcf16cc3e1782a/lib/app/utils/date.dart#L51)

## Task ID
ION-3218

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
app vs design
<img width="886" height="134" alt="image" src="https://github.com/user-attachments/assets/0b028376-4b6d-447b-9a29-984a836da2ea" />
