### PR TITLE
fix: stacktrace lost on DecodeException

### DIFF
--- a/packages/ion_identity_client/lib/src/core/network/network_exception.dart
+++ b/packages/ion_identity_client/lib/src/core/network/network_exception.dart
@@ -45,5 +45,5 @@ class DecodeException extends NetworkException {
   final StackTrace stackTrace;
 
   @override
-  String toString() => 'DecodeException: Failed to decode response - $error';
+  String toString() => 'DecodeException: Failed to decode response - $error\n$stackTrace';
 }


### PR DESCRIPTION
## Description
Stacktrace is lost on DecodeException, this fixes that

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
