### PR TITLE
fix: prevent loading notification from getting stuck on error

### DIFF
--- a/lib/app/components/global_notification_bar/providers/global_notification_notifier_provider.r.dart
+++ b/lib/app/components/global_notification_bar/providers/global_notification_notifier_provider.r.dart
@@ -36,7 +36,7 @@ class GlobalNotificationNotifier extends _$GlobalNotificationNotifier {
     _hideTimer?.cancel();
 
     if (!isPermanent) {
-      _hideTimer = Timer(_notificationDuration, hide);
+      _hideTimer = Timer(_notificationDuration - GlobalNotificationBar.animationDuration, hide);
     }
   }
 


### PR DESCRIPTION
## Description
This PR fixes an issue where the loading notification could remain stuck if an error occurs. Now, errors during the notification process are handled properly, so the loading indicator will always close as expected.

The current `show` function runs after a 500 ms delay. If an error happens during this delay, the hide function is called to clear the notification. However, the delayed show action can still run afterward, causing the loading notification to get stuck on the screen.

## Additional Notes
N/A

## Task ID
<!-- Add corresponding task ID here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)

