### PR TITLE
fix: link attribute regex pattern

### DIFF
--- a/lib/app/services/text_parser/model/text_matcher.dart
+++ b/lib/app/services/text_parser/model/text_matcher.dart
@@ -24,11 +24,25 @@ class UrlMatcher extends TextMatcher {
   const UrlMatcher();
 
   @override
-  String get pattern => r'\b(?:(?:[a-z][a-z0-9+\-.]*):\/\/|www\.)' // scheme:// or www.
+  String get pattern => r'\b(?:'
+      // scheme or www with host (fallback allowed)
+      '(?:'
+      r'(?:[a-z][a-z0-9+\-.]*):\/\/' // scheme://
+      r'|www\.' // or www.
+      ')'
       r'(?:[^@\s]+@)?' // optional auth
-      r'(?:(?:(?!-)[A-Za-z0-9-]+(?<!-)\.)+[A-Za-z0-9-]{2,}|(?!-)[A-Za-z0-9-]{2,}(?<!-))' // host
+      r'(?:(?:(?!-)[A-Za-z0-9-]+(?<!-)\.)+' // labels with dots
+      '(?:com|net|org|info|biz|gov|edu|mil|int|arpa|io|ai|app|dev|xyz|online|site|tech|blog|store|news|shop|club|us|uk|ca|de|fr|cn|jp|ru|br|in|au|es|it|nl|se|no|fi|dk|be|ch|at|pl|cz|sk|pt|gr|tr|kr|sg|hk|tw|mx|ar|za)' // explicit TLD list
+      '|(?!-)[A-Za-z0-9-]{2,}(?<!-))' // or fallback host (like localhost)
+      '|'
+      // bare domain with explicit TLD only
+      r'(?:[A-Za-z0-9-]+\.)+' // labels with dots
+      '(?:com|net|org|info|biz|gov|edu|mil|int|arpa|io|ai|app|dev|xyz|online|site|tech|blog|store|news|shop|club|us|uk|ca|de|fr|cn|jp|ru|br|in|au|es|it|nl|se|no|fi|dk|be|ch|at|pl|cz|sk|pt|gr|tr|kr|sg|hk|tw|mx|ar|za)' // explicit TLD list
+      ')'
       r'(?::\d{2,5})?' // optional port
-      r'(?:\/[^\s!?.,;:]*[A-Za-z0-9\/])?'; // optional path ending in slash or alnum
+      r'(?:\/[^\s!?.,;:]*[A-Za-z0-9\/])?' // optional path
+      r'(?:\?[^\s!?.,;:]*[A-Za-z0-9%_=&-])?' // optional query params ending in valid char
+      r'\b'; // word boundary
 }
 
 class CashtagMatcher extends TextMatcher {

--- a/test/services/text_parser/text_parser_test.dart
+++ b/test/services/text_parser/text_parser_test.dart
@@ -69,10 +69,10 @@ void main() {
     });
 
     test('should not parse as URLs any text with dot', () {
-      final results = parser.parse('Some dummy text.To test links');
+      final results = parser.parse('Some dummy text.To test links.to test links');
 
       expect(results.length, equals(1));
-      expect(results[0].text, equals('Some dummy text.To test links'));
+      expect(results[0].text, equals('Some dummy text.To test links.to test links'));
     });
 
     test('should parse www-prefixed URLs correctly', () {
@@ -109,11 +109,27 @@ void main() {
       expect(results.length, 2);
     });
 
-    test('should not parse URLs without protocol or www prefix', () {
-      final results = parser.parse('Check example.com and foo.bar');
+    test('should parse URLs with query params correctly', () {
+      final results = parser.parse('Login at http://pass@example.com/files?q=test');
 
-      expect(results.length, equals(1));
-      expect(results[0].text, equals('Check example.com and foo.bar'));
+      expect(results.length, equals(2));
+      expect(results[0].text, equals('Login at '));
+      expect(results[1].text, equals('http://pass@example.com/files?q=test'));
+      expect(results[1].matcher, isA<UrlMatcher>());
+
+      expect(results.length, 2);
+    });
+
+    test('should parse URLs with query params correctly', () {
+      final results = parser.parse('Visit http://pass@example.com/files?q=test.no questions');
+
+      expect(results.length, equals(3));
+      expect(results[0].text, equals('Visit '));
+      expect(results[1].text, equals('http://pass@example.com/files?q=test'));
+      expect(results[1].matcher, isA<UrlMatcher>());
+      expect(results[2].text, equals('.no questions'));
+
+      expect(results.length, 3);
     });
 
     test('should parse mixed content correctly', () {
@@ -172,6 +188,23 @@ void main() {
         () => TextParser(matchers: const {}),
         throwsA(isA<AssertionError>()),
       );
+    });
+
+    test('should parse bare domain with TLD correctly', () {
+      final results = parser.parse('Visit ice.io for info');
+
+      expect(results.length, equals(3));
+      expect(results[0].text, equals('Visit '));
+      expect(results[1].text, equals('ice.io'));
+      expect(results[1].matcher, isA<UrlMatcher>());
+      expect(results[2].text, equals(' for info'));
+    });
+
+    test('should not parse valid bare domain with TLD but followed by extra symbols', () {
+      final results = parser.parse('Visit ice.ion for info');
+
+      expect(results.length, equals(1));
+      expect(results[0].text, equals('Visit ice.ion for info'));
     });
   });
 }


### PR DESCRIPTION
## Description
- Fixed link attribute regex pattern to recognize links like ice.io and at the time ice.but is not a valid link;
- Fixed quill editor issue when you type a valid link like ice.io and a link attribute is already applied to it then you continue typing and ice.ion is not a valid link already so you end up with ice.io part marked as link and n is not but actually link attribute should be removed from ice.io part

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore


https://github.com/user-attachments/assets/72c54c72-2ae7-4040-8183-566a3b685282



