### PR TITLE
fix: shared message user info padding

### DIFF
--- a/lib/app/features/chat/views/components/message_items/message_types/post_message/shared_post_message.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/post_message/shared_post_message.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:ion/app/components/screen_offset/screen_side_offset.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/auth/providers/auth_provider.m.dart';
 import 'package:ion/app/features/chat/model/message_list_item.f.dart';
@@ -85,15 +86,20 @@ class SharedPostMessage extends HookConsumerWidget {
           contentAsPlainText.isEmpty ? context.i18n.post_page_title : contentAsPlainText,
     );
 
-    final userInfo = UserInfo(
-      accentTheme: isMe,
-      createdAt: createdAt,
-      pubkey: postEntity.masterPubkey,
-      textStyle: isMe
-          ? context.theme.appTextThemes.caption.copyWith(
-              color: context.theme.appColors.onPrimaryAccent,
-            )
-          : null,
+    final userInfo = Padding(
+      padding: EdgeInsetsDirectional.only(
+        start: ScreenSideOffset.defaultSmallMargin,
+      ),
+      child: UserInfo(
+        accentTheme: isMe,
+        createdAt: createdAt,
+        pubkey: postEntity.masterPubkey,
+        textStyle: isMe
+            ? context.theme.appTextThemes.caption.copyWith(
+                color: context.theme.appColors.onPrimaryAccent,
+              )
+            : null,
+      ),
     );
     return MessageItemWrapper(
       isMe: isMe,


### PR DESCRIPTION
## Description
This PR fixes the left padding for the user info widget in shared messages

## Task ID
ION-3425

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<img width="180" height="1092" alt="Screenshot 2025-07-29 at 22 34 50" src="https://github.com/user-attachments/assets/6bf498d4-cf02-4d1d-8f93-63f2b13d39cb" />

