### PR TITLE
fix: article add link flow

### DIFF
--- a/lib/app/features/feed/views/components/toolbar_buttons/toolbar_link_button.dart
+++ b/lib/app/features/feed/views/components/toolbar_buttons/toolbar_link_button.dart
@@ -6,6 +6,7 @@ import 'package:flutter_quill/flutter_quill.dart';
 import 'package:ion/app/components/text_editor/utils/quill_style_manager.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/feed/views/components/actions_toolbar_button/actions_toolbar_button.dart';
+import 'package:ion/app/services/text_parser/model/text_matcher.dart';
 import 'package:ion/app/utils/text_input_formatters.dart';
 import 'package:ion/generated/assets.gen.dart';
 
@@ -14,6 +15,7 @@ class ToolbarLinkButton extends HookWidget {
     required this.textEditorController,
     super.key,
   });
+
   final QuillController textEditorController;
 
   @override
@@ -21,11 +23,31 @@ class ToolbarLinkButton extends HookWidget {
     final styleManager =
         useMemoized(() => QuillStyleManager(textEditorController), [textEditorController]);
 
+    final selectionState = useState<TextSelection>(textEditorController.selection);
+    useEffect(
+      () {
+        void handleSelectionChange() {
+          selectionState.value = textEditorController.selection;
+        }
+
+        textEditorController.addListener(handleSelectionChange);
+        return () => textEditorController.removeListener(handleSelectionChange);
+      },
+      [textEditorController],
+    );
+    final selection = selectionState.value;
+
+    final hasNonWhitespaceSelection = textEditorController.document
+        .toPlainText()
+        .substring(selection.start, selection.end)
+        .trim()
+        .isNotEmpty;
+
     return ActionsToolbarButton(
       icon: Assets.svg.iconArticleLink,
+      enabled: hasNonWhitespaceSelection,
       onPressed: () async {
         final localContext = context;
-
         String? existingLink;
         final linkAttribute =
             textEditorController.getSelectionStyle().attributes[Attribute.link.key];
@@ -41,7 +63,10 @@ class ToolbarLinkButton extends HookWidget {
         if (!localContext.mounted) return;
 
         if (resultLink != null) {
-          styleManager.toggleLinkStyle(resultLink);
+          final url = resultLink.trim();
+          if (RegExp(const UrlMatcher().pattern).hasMatch(url)) {
+            styleManager.toggleLinkStyle(url);
+          }
         }
       },
     );
@@ -52,23 +77,28 @@ class ToolbarLinkButton extends HookWidget {
     String? initialValue,
   }) {
     final linkController = TextEditingController(text: initialValue ?? '');
+    final linkFocusNode = FocusNode();
 
     return showCupertinoDialog<String>(
       context: context,
-      builder: (context) {
+      builder: (dialogContext) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          linkFocusNode.requestFocus();
+        });
         return CupertinoAlertDialog(
-          title: Text(context.i18n.toolbar_link_title),
+          title: Text(dialogContext.i18n.toolbar_link_title),
           content: Column(
             children: [
               const SizedBox(height: 10),
               CupertinoTextField(
                 controller: linkController,
-                placeholder: context.i18n.toolbar_link_placeholder,
-                placeholderStyle: context.theme.appTextThemes.body2.copyWith(
-                  color: context.theme.appColors.tertararyText,
+                focusNode: linkFocusNode,
+                placeholder: dialogContext.i18n.toolbar_link_placeholder,
+                placeholderStyle: dialogContext.theme.appTextThemes.body2.copyWith(
+                  color: dialogContext.theme.appColors.tertararyText,
                 ),
-                style: context.theme.appTextThemes.body2.copyWith(
-                  color: context.theme.appColors.primaryText,
+                style: dialogContext.theme.appTextThemes.body2.copyWith(
+                  color: dialogContext.theme.appColors.primaryText,
                 ),
                 inputFormatters: [
                   emojiRestrictionFormatter(),
@@ -79,20 +109,20 @@ class ToolbarLinkButton extends HookWidget {
           actions: [
             CupertinoDialogAction(
               child: Text(
-                context.i18n.button_cancel,
-                style: TextStyle(color: context.theme.appColors.primaryAccent),
+                dialogContext.i18n.button_cancel,
+                style: TextStyle(color: dialogContext.theme.appColors.primaryAccent),
               ),
               onPressed: () {
-                Navigator.of(context).pop();
+                Navigator.of(dialogContext).pop();
               },
             ),
             CupertinoDialogAction(
               child: Text(
-                context.i18n.button_link,
-                style: TextStyle(color: context.theme.appColors.primaryAccent),
+                dialogContext.i18n.button_link,
+                style: TextStyle(color: dialogContext.theme.appColors.primaryAccent),
               ),
               onPressed: () {
-                Navigator.of(context).pop(linkController.text.trim());
+                Navigator.of(dialogContext).pop(linkController.text.trim());
               },
             ),
           ],


### PR DESCRIPTION
## Description
- fixed add link flow for article and enforced its logic to following
1. if no selection in the editor or selected text is just whitespaces - should be inactive;
2. if user presses context.i18n.button_link button -> verify that entered value is a valid link and then assign a link attribute to the selected text with this newly entered link;
3. if you select existing link - initialValue should be set to it

- fixed issue when after entering an autolink (which is not manual but automatically detected in the editor) then add link flow couldn't focus the input;
- auto focus input for add link pop up;

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)


https://github.com/user-attachments/assets/5c2f3aff-f6d2-4417-abcc-2844fea579e8

