### PR TITLE
fix: remove redundant file deletion and add logging for media decryption errors

### DIFF
--- a/lib/app/services/media_service/media_encryption_service.m.dart
+++ b/lib/app/services/media_service/media_encryption_service.m.dart
@@ -14,6 +14,7 @@ import 'package:ion/app/features/core/providers/ion_connect_media_url_fallback_p
 import 'package:ion/app/features/ion_connect/model/media_attachment.dart';
 import 'package:ion/app/services/compressors/brotli_compressor.r.dart';
 import 'package:ion/app/services/file_cache/ion_file_cache_manager.r.dart';
+import 'package:ion/app/services/logger/logger.dart';
 import 'package:ion/app/services/media_service/media_service.m.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -77,8 +78,6 @@ class MediaEncryptionService {
 
         final fileExtension = attachment.mimeType.split('/').last;
 
-        //remove the file from storage
-        await file.delete();
         await fileCacheService.removeFile(url);
 
         if (attachment.mediaType == MediaType.unknown) {
@@ -100,9 +99,11 @@ class MediaEncryptionService {
           return decryptedFile;
         }
       } else {
+        Logger.error('Media does not have a valid encryption prop');
         throw FailedToDecryptFileException();
       }
-    } catch (e) {
+    } catch (e, st) {
+      Logger.error(e, stackTrace: st);
       throw FailedToDecryptFileException();
     }
   }


### PR DESCRIPTION
## Description
This PR fixes a bug where the chat media file was attempted to be deleted after it had already been removed by the fileCacheService. It is redundant because [flutter_cache_manager](https://github.com/Baseflow/flutter_cache_manager/blob/develop/flutter_cache_manager/lib/src/cache_store.dart#L188) already delete it.

## Additional Notes
N/A

## Task ID
3446-3444

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<img width="280" height="2992" alt="Screenshot_1753957309" src="https://github.com/user-attachments/assets/98c3ce9c-ce13-445f-9c60-77aa94161b60" />


