### PR TITLE
fix: send file metadata only to own relays during the post/article creation

### DIFF
--- a/lib/app/features/feed/create_article/providers/create_article_provider.r.dart
+++ b/lib/app/features/feed/create_article/providers/create_article_provider.r.dart
@@ -300,17 +300,16 @@ class CreateArticle extends _$CreateArticle {
 
     final articleEvent = await ionNotifier.sign(articleData);
     final fileEvents = await Future.wait(files.map(ionNotifier.sign));
-    final eventsToPublish = [...fileEvents, articleEvent];
 
     final pubkeysToPublish = mentions.map((mention) => mention.value).toSet();
 
     final userEventsMetadataBuilder = await ref.read(userEventsMetadataBuilderProvider.future);
 
     await Future.wait([
-      ionNotifier.sendEvents(eventsToPublish),
+      ionNotifier.sendEvents([...fileEvents, articleEvent]),
       for (final pubkey in pubkeysToPublish)
-        ionNotifier.sendEvents(
-          eventsToPublish,
+        ionNotifier.sendEvent(
+          articleEvent,
           actionSource: ActionSourceUser(pubkey),
           metadataBuilders: [userEventsMetadataBuilder],
           cache: false,

--- a/lib/app/features/feed/create_post/providers/create_post_notifier.m.dart
+++ b/lib/app/features/feed/create_post/providers/create_post_notifier.m.dart
@@ -286,7 +286,6 @@ class CreatePostNotifier extends _$CreatePostNotifier {
 
     final postEvent = await ionNotifier.sign(postData);
     final fileEvents = await Future.wait(files.map(ionNotifier.sign));
-    final eventsToPublish = [...fileEvents, postEvent];
 
     final pubkeysToPublish = mentions.map((mention) => mention.value).toSet();
     final metadataBuilders = <EventsMetadataBuilder>[];
@@ -318,10 +317,10 @@ class CreatePostNotifier extends _$CreatePostNotifier {
     metadataBuilders.add(userEventsMetadataBuilder);
 
     await Future.wait([
-      ionNotifier.sendEvents(eventsToPublish),
+      ionNotifier.sendEvents([...fileEvents, postEvent]),
       for (final pubkey in pubkeysToPublish)
-        ref.read(ionConnectNotifierProvider.notifier).sendEvents(
-              eventsToPublish,
+        ref.read(ionConnectNotifierProvider.notifier).sendEvent(
+              postEvent,
               actionSource: ActionSourceUser(pubkey),
               metadataBuilders: metadataBuilders,
               cache: false,


### PR DESCRIPTION
## Description
This PR fixes an issue when the app were sending `1063` to the "other" user relays as well. Need to send only to own relays. 

## Task ID
ION-3392

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
