### PR TITLE
fix: add authenticator options padding

### DIFF
--- a/lib/app/features/protect_account/authenticator/views/pages/setup_authenticator/authenticator_setup_options_page.dart
+++ b/lib/app/features/protect_account/authenticator/views/pages/setup_authenticator/authenticator_setup_options_page.dart
@@ -64,13 +64,15 @@ class AuthenticatorSetupOptionsPage extends StatelessWidget {
                           itemBuilder: (context, index) {
                             final type = authenticatorTypes[index];
 
-                            return Padding(
-                              padding: EdgeInsetsDirectional.only(bottom: 12.0.s),
-                              child: SecureAccountOption(
-                                isEnabled: false,
-                                title: type.getDisplayName(context),
-                                icon: type.iconAsset.icon(),
-                                onTap: () => _onOptionTap(type),
+                            return ScreenSideOffset.small(
+                              child: Padding(
+                                padding: EdgeInsetsDirectional.only(bottom: 12.0.s),
+                                child: SecureAccountOption(
+                                  isEnabled: false,
+                                  title: type.getDisplayName(context),
+                                  icon: type.iconAsset.icon(),
+                                  onTap: () => _onOptionTap(type),
+                                ),
                               ),
                             );
                           },


### PR DESCRIPTION
## Description
This PR adds a missing padding to authenticator options in security menu.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
<!-- Add corresponding task ID here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
