### PR TITLE
fix: use current user ranked relevant relays for the for-you feed sources

### DIFF
--- a/lib/app/features/feed/providers/feed_for_you_content_provider.m.dart
+++ b/lib/app/features/feed/providers/feed_for_you_content_provider.m.dart
@@ -286,14 +286,19 @@ class FeedForYouContent extends _$FeedForYouContent implements PagedNotifier {
   }
 
   Future<List<String>> _getDataSourceRelays() {
-    return ref.read(relevantCurrentUserRelaysProvider.future);
+    return ref.read(rankedRelevantCurrentUserRelaysUrlsProvider.future);
   }
 
+  /// Refreshes the pagination state for the given modifier.
+  ///
+  /// This is used to ensure that the pagination state is up-to-date before making requests.
+  ///
+  /// Data source relays are changed dynamically depending on the ping responses
+  ///   of the current user relevant relays and runtime conditions.
+  /// For the articles, user can select and unselect the interested categories.
+  ///
+  /// This method must be called on every request iteration.
   Future<void> _refreshModifierPagination({required FeedModifier modifier}) async {
-    // For any other feed type except articles, pagination can't be changed.
-    // For Articles, user can select or unselect some topics, so we need to refresh the pagination
-    if (feedType != FeedType.article && state.modifiersPagination[modifier] != null) return;
-
     final dataSourceRelays = await _getDataSourceRelays();
 
     final interests = await _getInterestsForModifier(modifier);


### PR DESCRIPTION
## Description
This PR changes the relays that are used to query content on for-you feed from `current-user-relevant-relays` to `current-user-ranked-relevant-relays`. The difference is that the latter excludes unreachable relays. That should fix the slow feed when some relays from the list are unreachable.

## Task ID
ION-3455

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [] Chore
