### PR TITLE
fix: reduce chat open lag and prevent false empty message state

### DIFF
--- a/lib/app/features/chat/e2ee/views/pages/one_to_one_messages_page.dart
+++ b/lib/app/features/chat/e2ee/views/pages/one_to_one_messages_page.dart
@@ -144,7 +144,7 @@ class _MessagesList extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     if (conversationId == null) {
       return Expanded(
-        child: Container(
+        child: ColoredBox(
           color: context.theme.appColors.primaryBackground,
         ),
       );
@@ -162,7 +162,7 @@ class _MessagesList extends ConsumerWidget {
           return OneToOneMessageList(messages);
         },
         orElse: () {
-          return Container(
+          return ColoredBox(
             color: context.theme.appColors.primaryBackground,
           );
         },

--- a/lib/app/features/chat/e2ee/views/pages/one_to_one_messages_page.dart
+++ b/lib/app/features/chat/e2ee/views/pages/one_to_one_messages_page.dart
@@ -143,7 +143,11 @@ class _MessagesList extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     if (conversationId == null) {
-      return const Expanded(child: E2eeConversationEmptyView());
+      return Expanded(
+        child: Container(
+          color: context.theme.appColors.primaryBackground,
+        ),
+      );
     }
 
     final messages =
@@ -157,7 +161,11 @@ class _MessagesList extends ConsumerWidget {
           }
           return OneToOneMessageList(messages);
         },
-        orElse: E2eeConversationEmptyView.new,
+        orElse: () {
+          return Container(
+            color: context.theme.appColors.primaryBackground,
+          );
+        },
       ),
     );
   }


### PR DESCRIPTION
## Description
This PR addresses two main issues on the chat screen for both iOS and Android:

- Reduces UI lag when opening chat by offloading blocking logic ( text parsing) to background isolates.
- Fixes the incorrect appearance of an empty state when messages exist

## Additional Notes
N/A

## Task ID
3490

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)


