### PR TITLE
fix: use cached Firebase config when writeRelay is null

### DIFF
--- a/lib/app/features/push_notifications/providers/relay_firebase_app_config_provider.m.dart
+++ b/lib/app/features/push_notifications/providers/relay_firebase_app_config_provider.m.dart
@@ -39,9 +39,14 @@ class RelayFirebaseAppConfig extends _$RelayFirebaseAppConfig {
 
     final relayUrls = [for (final userRelay in userRelays) userRelay.url];
 
+    // Use cached config if:
+    // 1. We have a saved config
+    // 2. The saved relay is still in user's relay list
+    // 3. writeRelay is null (at startup) OR matches the saved relay
+    // This prevents circular dependency when writeRelay is null at app startup
     if (savedConfig != null &&
         relayUrls.contains(savedConfig.relayUrl) &&
-        writeRelay == savedConfig.relayUrl) {
+        (writeRelay == null || writeRelay == savedConfig.relayUrl)) {
       return savedConfig;
     }
 


### PR DESCRIPTION
## Description
Fix Circular Dependency in Firebase Config Providers

## Task ID
ION-3524

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
