### PR TITLE
fix: back button not shown on profiles

### DIFF
--- a/lib/app/features/user/pages/profile_page/profile_page.dart
+++ b/lib/app/features/user/pages/profile_page/profile_page.dart
@@ -149,7 +149,7 @@ class ProfilePage extends HookConsumerWidget {
             Opacity(
               opacity: opacity,
               child: NavigationAppBar(
-                showBackButton: false,
+                showBackButton: showBackButton,
                 useScreenTopOffset: true,
                 scrollController: scrollController,
                 horizontalPadding: 0,


### PR DESCRIPTION
## Description
It was not shown because on Profile page back button is a part of the page, not the app bar

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<img width="1170" height="2532" alt="simulator_screenshot_F25DDBFB-A253-4BB5-A1B1-3467647ED8DB" src="https://github.com/user-attachments/assets/1bb76b69-0f80-4ac4-9349-d91a47483311" />

