### PR TITLE
fix: keeps ToggleLikeNotifier alive when refreshing page

### DIFF
--- a/lib/app/features/optimistic_ui/features/likes/post_like_provider.r.dart
+++ b/lib/app/features/optimistic_ui/features/likes/post_like_provider.r.dart
@@ -90,7 +90,9 @@ class ToggleLikeNotifier extends _$ToggleLikeNotifier {
   final _processingOperations = <String>{};
 
   @override
-  void build() {}
+  void build() {
+    keepAliveWhenAuthenticated(ref);
+  }
 
   Future<void> toggle(EventReference eventReference) async {
     final key = eventReference.toString();


### PR DESCRIPTION
## Description
ToggleLikeNotifier was recreated every time the post page was refreshed. 


## Task ID
ION-3534

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)


https://github.com/user-attachments/assets/3508bac4-5925-4253-a2ed-12b5495fb8e9


