### PR TITLE
fix: load icon from CoinGroup in MoneyMessage

### DIFF
--- a/lib/app/features/chat/e2ee/providers/coin_group_provider.r.dart
+++ b/lib/app/features/chat/e2ee/providers/coin_group_provider.r.dart
@@ -10,8 +10,8 @@ part 'coin_group_provider.r.g.dart';
 
 /// Provider to find CoinGroup by asset ID across all wallet views
 @riverpod
-Future<CoinsGroup?> coinGroupByAssetId(Ref ref, String? assetId) async {
-  if (assetId == null || assetId.isEmpty) {
+Future<CoinsGroup?> coinGroupByCoinId(Ref ref, String? coinId) async {
+  if (coinId == null || coinId.isEmpty) {
     return null;
   }
 
@@ -22,6 +22,6 @@ Future<CoinsGroup?> coinGroupByAssetId(Ref ref, String? assetId) async {
   final allCoinGroups = walletViews.expand((view) => view.coinGroups);
 
   return allCoinGroups.firstWhereOrNull(
-    (cg) => cg.coins.any((c) => c.coin.id == assetId),
+    (cg) => cg.coins.any((c) => c.coin.id == coinId),
   );
 }

--- a/lib/app/features/chat/views/components/message_items/message_types/money_message/money_message.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/money_message/money_message.dart
@@ -3,6 +3,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:ion/app/components/coins/coin_icon.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/extensions/object.dart';
 import 'package:ion/app/features/auth/providers/auth_provider.m.dart';
@@ -23,7 +24,6 @@ import 'package:ion/app/features/wallets/model/entities/wallet_asset_entity.f.da
 import 'package:ion/app/features/wallets/model/network_data.f.dart';
 import 'package:ion/app/features/wallets/providers/coins_provider.r.dart';
 import 'package:ion/app/features/wallets/providers/networks_provider.r.dart';
-import 'package:ion/app/features/wallets/views/components/network_icon_widget.dart';
 import 'package:ion/app/features/wallets/views/utils/crypto_formatter.dart';
 import 'package:ion/app/utils/num.dart';
 
@@ -115,7 +115,6 @@ class _RequestedMoneyMessage extends ConsumerWidget {
         eventMessage: eventMessage,
       ),
       onTapReply: onTapReply,
-      assetId: assetId,
     );
   }
 }
@@ -147,7 +146,6 @@ class _SentMoneyMessage extends ConsumerWidget {
     final asset = transactionData.cryptoAsset.mapOrNull(coin: (asset) => asset);
 
     final coin = asset?.coin;
-    final assetId = asset?.coin.id;
 
     final amount = asset?.amount ?? 0.0;
     final equivalentUsd = asset?.amountUSD ?? 0.0;
@@ -164,7 +162,6 @@ class _SentMoneyMessage extends ConsumerWidget {
       eventId: eventReference.eventId,
       button: ViewTransactionButton(transactionData: transactionData),
       onTapReply: onTapReply,
-      assetId: assetId,
     );
   }
 }
@@ -182,7 +179,6 @@ class _MoneyMessageContent extends HookConsumerWidget {
     required this.button,
     required this.margin,
     this.onTapReply,
-    this.assetId,
   });
 
   final bool isMe;
@@ -196,11 +192,10 @@ class _MoneyMessageContent extends HookConsumerWidget {
   final String eventId;
   final Widget button;
   final VoidCallback? onTapReply;
-  final String? assetId;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final coinGroup = ref.watch(coinGroupByAssetIdProvider(assetId)).valueOrNull;
+    final coinGroup = ref.watch(coinGroupByCoinIdProvider(coin?.id)).valueOrNull;
 
     final textColor = switch (isMe) {
       true => context.theme.appColors.onPrimaryAccent,
@@ -249,13 +244,7 @@ class _MoneyMessageContent extends HookConsumerWidget {
               SizedBox(height: 10.0.s),
               Row(
                 children: [
-                  ClipRRect(
-                    borderRadius: BorderRadius.circular(10.0.s),
-                    child: NetworkIconWidget(
-                      imageUrl: coinGroup?.iconUrl ?? coin?.iconUrl ?? '',
-                      size: 36.0.s,
-                    ),
-                  ),
+                  CoinIconWidget.big(coinGroup?.iconUrl ?? coin?.iconUrl ?? ''),
                   SizedBox(width: 8.0.s),
                   _AmountDisplay(
                     amount: amount,


### PR DESCRIPTION
## Description

The previous implementation showed incorrect icons for money messages because it used the generic network image instead of the user-specific coin group icon. Money messages should display the same icon that users see for their coins in their wallet, providing visual consistency across the app.

- Updated `MoneyMessage` to display `CoinGroup.iconUrl` instead of `network.image`
- Created new provider `coinGroupByAssetIdProvider` to find the correct coin group across all wallet views

## Task ID
ION-3550

## Type of Change
- [x] Bug fix

## Screenshots

Notice the same network (TRON), but different icon (TRX and BTT)
<img width="350" alt="image" src="https://github.com/user-attachments/assets/82a58fc2-ea83-4337-8efd-395fecbd003e" />

