### PR TITLE
feat: fetch missing entities on 21750 event

### DIFF
--- a/lib/app/features/ion_connect/model/event_reference.f.dart
+++ b/lib/app/features/ion_connect/model/event_reference.f.dart
@@ -43,6 +43,8 @@ abstract class EventReference {
 
   String get masterPubkey;
 
+  int? get kind;
+
   String encode();
 
   List<String> toTag();

--- a/lib/app/features/ion_connect/model/events_metadata.f.dart
+++ b/lib/app/features/ion_connect/model/events_metadata.f.dart
@@ -3,21 +3,70 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:collection/collection.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:ion/app/exceptions/exceptions.dart';
 import 'package:ion/app/features/ion_connect/ion_connect.dart';
 import 'package:ion/app/features/ion_connect/model/event_reference.f.dart';
 import 'package:ion/app/features/ion_connect/model/event_serializable.dart';
+import 'package:ion/app/features/ion_connect/model/ion_connect_entity.dart';
 
 part 'events_metadata.f.freezed.dart';
 
 @freezed
-class EventsMetadata with _$EventsMetadata implements EventSerializable {
-  const factory EventsMetadata({
+class EventsMetadataEntity with IonConnectEntity, ImmutableEntity, _$EventsMetadataEntity {
+  const factory EventsMetadataEntity({
+    required String id,
+    required String pubkey,
+    required String masterPubkey,
+    required String signature,
+    required int createdAt,
+    required EventsMetadataData data,
+  }) = _EventsMetadataEntity;
+
+  const EventsMetadataEntity._();
+
+  factory EventsMetadataEntity.fromEventMessage(EventMessage eventMessage) {
+    if (eventMessage.kind != kind) {
+      throw IncorrectEventKindException(eventMessage.id, kind: kind);
+    }
+
+    return EventsMetadataEntity(
+      id: eventMessage.id,
+      pubkey: eventMessage.pubkey,
+      masterPubkey: eventMessage.pubkey,
+      signature: eventMessage.sig!,
+      createdAt: eventMessage.createdAt,
+      data: EventsMetadataData.fromEventMessage(eventMessage),
+    );
+  }
+
+  static const int kind = 21750;
+}
+
+@freezed
+class EventsMetadataData with _$EventsMetadataData implements EventSerializable {
+  const factory EventsMetadataData({
     required List<EventReference> eventReferences,
     required EventMessage metadata,
-  }) = _EventsMetadata;
+  }) = _EventsMetadataData;
 
-  const EventsMetadata._();
+  const EventsMetadataData._();
+
+  factory EventsMetadataData.fromEventMessage(EventMessage eventMessage) {
+    return EventsMetadataData(
+      eventReferences: eventMessage.tags
+          .where(
+            (tag) =>
+                tag[0] == ReplaceableEventReference.tagName ||
+                tag[0] == ImmutableEventReference.tagName,
+          )
+          .map(EventReference.fromTag)
+          .toList(),
+      metadata:
+          EventMessage.fromPayloadJson(jsonDecode(eventMessage.content) as Map<String, dynamic>),
+    );
+  }
 
   /// https://github.com/ice-blockchain/subzero/blob/master/.ion-connect-protocol/ICIP-01.md#special-ephemeral-event-for-embedding-other-non-ephemeral-events
   @override
@@ -29,7 +78,7 @@ class EventsMetadata with _$EventsMetadata implements EventSerializable {
     return EventMessage.fromData(
       signer: signer,
       createdAt: createdAt,
-      kind: kind,
+      kind: EventsMetadataEntity.kind,
       content: jsonEncode(metadata.toJson().last),
       tags: [
         ...tags,
@@ -38,5 +87,18 @@ class EventsMetadata with _$EventsMetadata implements EventSerializable {
     );
   }
 
-  static const int kind = 21750;
+  EventReference? get metadataEventReference {
+    // TODO: Handle cases other than `p` tag
+    final tags = groupBy(metadata.tags, (tag) => tag[0]);
+    final kind = metadata.kind;
+    final masterPubkey = tags['p']?.first[1];
+    if (masterPubkey == null) {
+      return null;
+    }
+
+    return ReplaceableEventReference(
+      masterPubkey: masterPubkey,
+      kind: kind,
+    );
+  }
 }

--- a/lib/app/features/ion_connect/model/events_metadata_builder.dart
+++ b/lib/app/features/ion_connect/model/events_metadata_builder.dart
@@ -4,5 +4,5 @@ import 'package:ion/app/features/ion_connect/model/event_reference.f.dart';
 import 'package:ion/app/features/ion_connect/model/events_metadata.f.dart';
 
 abstract class EventsMetadataBuilder {
-  Future<List<EventsMetadata>> buildMetadata(List<EventReference> eventReferences);
+  Future<List<EventsMetadataData>> buildMetadata(List<EventReference> eventReferences);
 }

--- a/lib/app/features/ion_connect/providers/ion_connect_event_parser.r.dart
+++ b/lib/app/features/ion_connect/providers/ion_connect_event_parser.r.dart
@@ -17,6 +17,7 @@ import 'package:ion/app/features/feed/data/models/entities/repost_data.f.dart';
 import 'package:ion/app/features/feed/polls/models/poll_vote.f.dart';
 import 'package:ion/app/features/ion_connect/ion_connect.dart';
 import 'package:ion/app/features/ion_connect/model/deletion_request.f.dart';
+import 'package:ion/app/features/ion_connect/model/events_metadata.f.dart';
 import 'package:ion/app/features/ion_connect/model/file_metadata.f.dart';
 import 'package:ion/app/features/ion_connect/model/ion_connect_entity.dart';
 import 'package:ion/app/features/ion_connect/model/ion_connect_gift_wrap.f.dart';
@@ -77,6 +78,7 @@ class EventParser {
       ProfileBadgesEntity.kind => ProfileBadgesEntity.fromEventMessage(eventMessage),
       BadgeAwardEntity.kind => BadgeAwardEntity.fromEventMessage(eventMessage),
       PollVoteEntity.kind => PollVoteEntity.fromEventMessage(eventMessage),
+      EventsMetadataEntity.kind => EventsMetadataEntity.fromEventMessage(eventMessage),
       _ => throw UnknownEventException(eventId: eventMessage.id, kind: eventMessage.kind)
     };
   }

--- a/lib/app/features/user/providers/user_events_metadata_provider.r.dart
+++ b/lib/app/features/user/providers/user_events_metadata_provider.r.dart
@@ -19,10 +19,10 @@ class UserEventsMetadataBuilder implements EventsMetadataBuilder {
   final List<EventMessage> _metadataEvents;
 
   @override
-  Future<List<EventsMetadata>> buildMetadata(List<EventReference> eventReferences) async {
+  Future<List<EventsMetadataData>> buildMetadata(List<EventReference> eventReferences) async {
     return [
       for (final event in _metadataEvents)
-        EventsMetadata(
+        EventsMetadataData(
           eventReferences: eventReferences,
           metadata: event,
         ),

--- a/lib/app/features/user/providers/verified_user_events_metadata_provider.r.dart
+++ b/lib/app/features/user/providers/verified_user_events_metadata_provider.r.dart
@@ -19,12 +19,12 @@ class VerifiedUserEventsMetadataBuilder implements EventsMetadataBuilder {
   final VerifiedBadgeEntities _verifiedBadgeData;
 
   @override
-  Future<List<EventsMetadata>> buildMetadata(List<EventReference> eventReferences) async {
-    final result = <EventsMetadata>[];
+  Future<List<EventsMetadataData>> buildMetadata(List<EventReference> eventReferences) async {
+    final result = <EventsMetadataData>[];
 
     if (_verifiedBadgeData.awardEntity != null) {
       result.add(
-        EventsMetadata(
+        EventsMetadataData(
           eventReferences: eventReferences,
           metadata: await _verifiedBadgeData.awardEntity!.toEntityEventMessage(),
         ),
@@ -32,7 +32,7 @@ class VerifiedUserEventsMetadataBuilder implements EventsMetadataBuilder {
     }
     if (_verifiedBadgeData.definitionEntity != null) {
       result.add(
-        EventsMetadata(
+        EventsMetadataData(
           eventReferences: eventReferences,
           metadata: await _verifiedBadgeData.definitionEntity!.toEntityEventMessage(),
         ),

--- a/packages/ion_identity_client/lib/src/core/service_locator/ion_identity_clients/users_client_service_locator.dart
+++ b/packages/ion_identity_client/lib/src/core/service_locator/ion_identity_clients/users_client_service_locator.dart
@@ -9,6 +9,8 @@ import 'package:ion_identity_client/src/users/get_content_creators/content_creat
 import 'package:ion_identity_client/src/users/get_content_creators/data_sources/get_content_creators_data_source.dart';
 import 'package:ion_identity_client/src/users/ion_connect_indexers/data_sources/ion_connect_indexers_data_source.dart';
 import 'package:ion_identity_client/src/users/ion_connect_indexers/get_user_connect_indexers_service.dart';
+import 'package:ion_identity_client/src/users/ion_connect_relays/data_sources/ion_connect_relays_data_source.dart';
+import 'package:ion_identity_client/src/users/ion_connect_relays/ion_connect_relays_service.dart';
 import 'package:ion_identity_client/src/users/ion_identity_users.dart';
 import 'package:ion_identity_client/src/users/search_users_social_profile/data_sources/search_users_social_profile_data_source.dart';
 import 'package:ion_identity_client/src/users/search_users_social_profile/search_users_social_profile_service.dart';
@@ -37,6 +39,10 @@ class UsersClientServiceLocator {
       IONIdentityUsers(
         username,
         _userDetails(
+          username: username,
+          config: config,
+        ),
+        _ionConnectRelays(
           username: username,
           config: config,
         ),
@@ -78,6 +84,18 @@ class UsersClientServiceLocator {
       UserDetailsService(
         username,
         UserDetailsDataSource(
+          IONIdentityServiceLocator.networkClient(config: config),
+          IONIdentityServiceLocator.tokenStorage(),
+        ),
+      );
+
+  IONConnectRelaysService _ionConnectRelays({
+    required String username,
+    required IONIdentityConfig config,
+  }) =>
+      IONConnectRelaysService(
+        username,
+        IONConnectRelaysDataSource(
           IONIdentityServiceLocator.networkClient(config: config),
           IONIdentityServiceLocator.tokenStorage(),
         ),

--- a/packages/ion_identity_client/lib/src/users/ion_connect_relays/data_sources/ion_connect_relays_data_source.dart
+++ b/packages/ion_identity_client/lib/src/users/ion_connect_relays/data_sources/ion_connect_relays_data_source.dart
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:ion_identity_client/ion_identity.dart';
+import 'package:ion_identity_client/src/core/network/network_client.dart';
+import 'package:ion_identity_client/src/core/network/utils.dart';
+import 'package:ion_identity_client/src/core/storage/token_storage.dart';
+import 'package:ion_identity_client/src/core/types/request_headers.dart';
+
+class IONConnectRelaysDataSource {
+  IONConnectRelaysDataSource(
+      this._networkClient,
+      this._tokenStorage,
+      );
+
+  final NetworkClient _networkClient;
+  final TokenStorage _tokenStorage;
+
+  static const basePath = '/v1/users';
+
+  Future<List<UserRelaysInfo>> fetchIONConnectRelays({
+    required String username,
+    required List<String> masterPubkeys,
+  }) async {
+    final token = _tokenStorage.getToken(username: username);
+    if (token == null) {
+      throw const UnauthenticatedException();
+    }
+
+    final response = await _networkClient.get(
+      '$basePath/ion-connect-relays',
+      queryParams: {
+        'masterPubkey': masterPubkeys,
+      },
+      headers: RequestHeaders.getAuthorizationHeaders(
+        username: username,
+        token: token.token,
+      ),
+      decoder: (result) => parseList(result, fromJson: UserRelaysInfo.fromJson),
+    );
+
+    return response;
+  }
+}

--- a/packages/ion_identity_client/lib/src/users/ion_connect_relays/ion_connect_relays_service.dart
+++ b/packages/ion_identity_client/lib/src/users/ion_connect_relays/ion_connect_relays_service.dart
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:ion_identity_client/ion_identity.dart';
+import 'package:ion_identity_client/src/users/ion_connect_relays/data_sources/ion_connect_relays_data_source.dart';
+
+class IONConnectRelaysService {
+  IONConnectRelaysService(
+    this.username,
+    this._dataSource,
+  );
+
+  final String username;
+  final IONConnectRelaysDataSource _dataSource;
+
+  Future<List<UserRelaysInfo>> relays({
+    required List<String> masterPubkeys,
+  }) async =>
+      _dataSource.fetchIONConnectRelays(
+        username: username,
+        masterPubkeys: masterPubkeys,
+      );
+}

--- a/packages/ion_identity_client/lib/src/users/ion_identity_users.dart
+++ b/packages/ion_identity_client/lib/src/users/ion_identity_users.dart
@@ -5,6 +5,7 @@ import 'package:ion_identity_client/src/auth/services/extract_user_id/extract_us
 import 'package:ion_identity_client/src/users/available_ion_connect_relays/available_ion_connect_relays_service.dart';
 import 'package:ion_identity_client/src/users/get_content_creators/content_creators_service.dart';
 import 'package:ion_identity_client/src/users/ion_connect_indexers/get_user_connect_indexers_service.dart';
+import 'package:ion_identity_client/src/users/ion_connect_relays/ion_connect_relays_service.dart';
 import 'package:ion_identity_client/src/users/search_users_social_profile/search_users_social_profile_service.dart';
 import 'package:ion_identity_client/src/users/set_ion_connect_relays/set_ion_connect_relays_service.dart';
 import 'package:ion_identity_client/src/users/update_user_social_profile/update_user_social_profile_service.dart';
@@ -15,6 +16,7 @@ class IONIdentityUsers {
   const IONIdentityUsers(
     this.username,
     this._getUserDetailsService,
+    this._ionConnectRelaysService,
     this._ionConnectIndexersService,
     this._setIONConnectRelaysService,
     this._ionConnectContentCreatorsService,
@@ -27,6 +29,7 @@ class IONIdentityUsers {
 
   final String username;
   final UserDetailsService _getUserDetailsService;
+  final IONConnectRelaysService _ionConnectRelaysService;
   final IONConnectIndexersService _ionConnectIndexersService;
   final IONConnectContentCreatorsService _ionConnectContentCreatorsService;
   final NicknameAvailabilityService _nicknameAvailabilityService;
@@ -45,6 +48,11 @@ class IONIdentityUsers {
     required String userId,
   }) async =>
       _getUserDetailsService.details(userId: userId);
+
+  Future<List<UserRelaysInfo>> ionConnectRelays({
+    required List<String> masterPubkeys,
+  }) async =>
+      _ionConnectRelaysService.relays(masterPubkeys: masterPubkeys);
 
   Future<List<String>> ionConnectIndexers({
     required String userId,


### PR DESCRIPTION
## Description
This PR adds a logic to refetch missing events on correct relays when previously chosen relay informs the app the requested event is missing, by a 21750 placeholder event.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
<!-- Add corresponding task ID here. -->

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
