### PR TITLE
fix: intro and splash video fixes

### DIFF
--- a/lib/app/features/auth/views/pages/intro_page/intro_page.dart
+++ b/lib/app/features/auth/views/pages/intro_page/intro_page.dart
@@ -2,11 +2,11 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/button/button.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/core/providers/video_player_provider.r.dart';
+import 'package:ion/app/hooks/use_auto_play.dart';
 import 'package:ion/app/router/app_routes.gr.dart';
 import 'package:ion/generated/assets.gen.dart';
 import 'package:video_player/video_player.dart';
@@ -26,16 +26,7 @@ class IntroPage extends HookConsumerWidget {
         ),
       ),
     );
-
-    useEffect(
-      () {
-        videoControllerProviderState.valueOrNull?.play();
-        return () {
-          videoControllerProviderState.valueOrNull?.pause();
-        };
-      },
-      [videoControllerProviderState.valueOrNull],
-    );
+    useAutoPlay(videoControllerProviderState.valueOrNull);
 
     final videoController = videoControllerProviderState.valueOrNull;
 

--- a/lib/app/features/chat/views/pages/chat_media_page/components/chat_media_page_view.dart
+++ b/lib/app/features/chat/views/pages/chat_media_page/components/chat_media_page_view.dart
@@ -18,6 +18,7 @@ import 'package:ion/app/features/ion_connect/model/media_attachment.dart';
 import 'package:ion/app/features/video/views/components/video_progress.dart';
 import 'package:ion/app/features/video/views/components/video_slider.dart';
 import 'package:ion/app/features/video/views/pages/video_page.dart';
+import 'package:ion/app/hooks/use_auto_play.dart';
 import 'package:ion/app/services/file_cache/ion_file_cache_manager.r.dart';
 import 'package:ion/app/utils/url.dart';
 
@@ -131,16 +132,7 @@ class _ChatMediaItem extends HookConsumerWidget {
             ),
           )
           .valueOrNull;
-
-      useEffect(
-        () {
-          playerController?.play();
-          return () {
-            playerController?.pause();
-          };
-        },
-        [playerController],
-      );
+      useAutoPlay(playerController);
 
       return Stack(
         children: [

--- a/lib/app/features/core/views/pages/splash_page.dart
+++ b/lib/app/features/core/views/pages/splash_page.dart
@@ -9,6 +9,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/core/providers/splash_provider.r.dart';
 import 'package:ion/app/features/core/providers/video_player_provider.r.dart';
+import 'package:ion/app/hooks/use_auto_play.dart';
 import 'package:ion/app/hooks/use_on_init.dart';
 import 'package:ion/generated/assets.gen.dart';
 import 'package:video_player/video_player.dart';
@@ -30,24 +31,23 @@ class SplashPage extends HookConsumerWidget {
       ),
     );
 
-    useEffect(
-      () {
-        splashVideoControllerState.valueOrNull?.play();
-        return () {
-          splashVideoControllerState.valueOrNull?.pause();
-        };
-      },
-      [splashVideoControllerState.valueOrNull],
-    );
+    useAutoPlay(splashVideoControllerState.valueOrNull);
 
     final splashVideoController = splashVideoControllerState.valueOrNull;
 
     // We watch the intro video controller here to initialize the intro video in advance.
     // This ensures a seamless transition to the IntroPage without flickering or delays.
-    ref.watch(
+    final intoVideoControllerState = ref.watch(
       videoControllerProvider(
         VideoControllerParams(sourcePath: Assets.videos.intro, looping: true),
       ),
+    );
+    useEffect(
+      () {
+        intoVideoControllerState.valueOrNull?.play();
+        return null;
+      },
+      [intoVideoControllerState],
     );
 
     useEffect(

--- a/lib/app/features/feed/stories/views/components/story_preview/media/story_video_preview.dart
+++ b/lib/app/features/feed/stories/views/components/story_preview/media/story_video_preview.dart
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:flutter/material.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/progress_bar/centered_loading_indicator.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/core/providers/video_player_provider.r.dart';
+import 'package:ion/app/hooks/use_auto_play.dart';
 import 'package:video_player/video_player.dart';
 
 class StoryVideoPreview extends HookConsumerWidget {
@@ -22,16 +22,7 @@ class StoryVideoPreview extends HookConsumerWidget {
           ),
         )
         .valueOrNull;
-
-    useEffect(
-      () {
-        videoController?.play();
-        return () {
-          videoController?.pause();
-        };
-      },
-      [videoController],
-    );
+    useAutoPlay(videoController);
 
     if (videoController == null || !videoController.value.isInitialized) {
       return const CenteredLoadingIndicator();

--- a/lib/app/features/video/views/pages/video_page.dart
+++ b/lib/app/features/video/views/pages/video_page.dart
@@ -14,6 +14,7 @@ import 'package:ion/app/features/video/views/components/video_progress.dart';
 import 'package:ion/app/features/video/views/components/video_slider.dart';
 import 'package:ion/app/features/video/views/components/video_thumbnail_preview.dart';
 import 'package:ion/app/features/video/views/hooks/use_video_ended.dart';
+import 'package:ion/app/hooks/use_auto_play.dart';
 import 'package:ion/app/hooks/use_route_presence.dart';
 import 'package:ion/generated/assets.gen.dart';
 import 'package:video_player/video_player.dart';
@@ -70,20 +71,7 @@ class VideoPage extends HookConsumerWidget {
               ),
             )
             .valueOrNull;
-
-    useEffect(
-      () {
-        if (this.playerController == null) {
-          playerController?.play();
-        }
-        return () {
-          if (this.playerController == null) {
-            playerController?.pause();
-          }
-        };
-      },
-      [this.playerController, playerController],
-    );
+    useAutoPlay(this.playerController == null ? playerController : null);
 
     if (playerController == null || !playerController.value.isInitialized) {
       final thumbnailAspectRatio = aspectRatio ?? 16 / 9;

--- a/lib/app/hooks/use_auto_play.dart
+++ b/lib/app/hooks/use_auto_play.dart
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:video_player/video_player.dart';
+
+void useAutoPlay(VideoPlayerController? controller) {
+  useEffect(
+    () {
+      controller?.play();
+      return () {
+        controller?.pause();
+      };
+    },
+    [controller],
+  );
+}

--- a/lib/app/router/providers/go_router_provider.r.dart
+++ b/lib/app/router/providers/go_router_provider.r.dart
@@ -54,8 +54,8 @@ GoRouter goRouter(Ref ref) {
       }
 
       if (isInitInProgress || !isSplashAnimationCompleted) {
-        // Redirect if app is not initialized yet
-        return SplashRoute().location;
+        // Redirect if app is not initialized yet, but avoid re-entering Splash when already there
+        return isOnSplash ? null : SplashRoute().location;
       }
 
       return _mainRedirect(location: state.matchedLocation, ref: ref);


### PR DESCRIPTION
## Description
- Fixed issue when for unauthorised users into video starts from the beginning after the splash one. it has the same segment at the beginning which supposed to be skipped for smooth transition;
- Fixed issue when splash video is played twice in some cases;
- Added useAutoPlay to reduce code duplication; 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Chore

