### PR TITLE
fix: reduce logging for ION content NFT collection 404

### DIFF
--- a/lib/app/features/core/providers/dio_provider.r.dart
+++ b/lib/app/features/core/providers/dio_provider.r.dart
@@ -8,6 +8,18 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'dio_provider.r.g.dart';
 
+const List<Duration> _defaultRetryDelays = <Duration>[
+  Duration(milliseconds: 200),
+  Duration(milliseconds: 400),
+  Duration(milliseconds: 600),
+  Duration(milliseconds: 800),
+  Duration(seconds: 1),
+  Duration(seconds: 2),
+  Duration(seconds: 3),
+  Duration(seconds: 4),
+  Duration(seconds: 5),
+];
+
 @riverpod
 Dio dio(Ref ref) {
   final dio = Dio();
@@ -18,24 +30,19 @@ Dio dio(Ref ref) {
     dio.interceptors.add(logger);
   }
 
-  const retryDelays = [
-    Duration(milliseconds: 200),
-    Duration(milliseconds: 400),
-    Duration(milliseconds: 600),
-    Duration(milliseconds: 800),
-    Duration(seconds: 1),
-    Duration(seconds: 2),
-    Duration(seconds: 3),
-    Duration(seconds: 4),
-    Duration(seconds: 5),
-  ];
-  dio.interceptors.add(
-    RetryInterceptor(
-      dio: dio,
-      retries: retryDelays.length,
-      retryDelays: retryDelays,
-    ),
-  );
+  final retry = createDefaultRetryInterceptor(dio);
+  dio.interceptors.add(retry);
 
   return dio;
+}
+
+RetryInterceptor createDefaultRetryInterceptor(
+  Dio dio, {
+  List<Duration> retryDelays = _defaultRetryDelays,
+}) {
+  return RetryInterceptor(
+    dio: dio,
+    retries: _defaultRetryDelays.length,
+    retryDelays: _defaultRetryDelays,
+  );
 }

--- a/lib/app/features/feed/nft/data/repositories/nft_identity_repository.r.dart
+++ b/lib/app/features/feed/nft/data/repositories/nft_identity_repository.r.dart
@@ -2,9 +2,9 @@
 
 import 'package:dio/dio.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:ion/app/features/core/providers/dio_provider.r.dart';
 import 'package:ion/app/features/core/providers/env_provider.r.dart';
 import 'package:ion/app/features/feed/nft/model/nft_collection_data.f.dart';
+import 'package:ion/app/features/feed/nft/providers/nft_identity_dio_provider.r.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'nft_identity_repository.r.g.dart';
@@ -18,10 +18,9 @@ NftIdentityRepository nftIdentityRepository(Ref ref) {
   final env = ref.watch(envProvider.notifier);
   final baseUrl = env.get<String>(EnvVariable.NFT_IDENTITY_BASE_URL);
 
-  return NftIdentityRepository(
-    baseUrl,
-    ref.watch(dioProvider),
-  );
+  final dio = ref.watch(nftIdentityDioProvider);
+
+  return NftIdentityRepository(baseUrl, dio);
 }
 
 class NftIdentityRepository {

--- a/lib/app/features/feed/nft/providers/nft_identity_dio_provider.r.dart
+++ b/lib/app/features/feed/nft/providers/nft_identity_dio_provider.r.dart
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:dio/dio.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:ion/app/features/core/providers/dio_provider.r.dart';
+import 'package:ion/app/services/logger/logger.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'nft_identity_dio_provider.r.g.dart';
+
+@Riverpod(keepAlive: true)
+Dio nftIdentityDio(Ref ref) {
+  final dio = Dio();
+
+  final logger = Logger.talkerDioLogger!;
+  logger.settings = logger.settings.copyWith(
+    errorFilter: (exception) {
+      final status = exception.response?.statusCode;
+      if (status == 404) {
+        return false;
+      }
+      return true;
+    },
+  );
+  dio.interceptors.add(logger);
+
+  final retry = createDefaultRetryInterceptor(dio);
+  dio.interceptors.add(retry);
+
+  return dio;
+}

--- a/lib/app/features/feed/nft/sync/nft_collection_sync_controller.r.dart
+++ b/lib/app/features/feed/nft/sync/nft_collection_sync_controller.r.dart
@@ -78,6 +78,8 @@ class NftCollectionSyncController {
     } catch (e, st) {
       if (e is DioException && CancelToken.isCancel(e)) {
         Logger.log('Sync cancelled');
+      } else if (e is DioException && e.response?.statusCode == 404) {
+        Logger.log('NFT collection not available yet; will retry');
       } else {
         Logger.log('Failed to sync NFT collection: $e', error: e, stackTrace: st);
       }


### PR DESCRIPTION
## Description
This PR reduces amount of logs for ION content NFT collection with 404 response. Previously it logged [http-error] with response (body+headers), which produced a lot of logs every 15s. Now it's 2 lines only.

## Additional Notes
Now logs look like this (Talker's extra lines are omited):
```
[Talker] ┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────
         │ [http-request] [GET] https://staging.nft.identity.io/account/3ce59df2cddec7863e91ca6461cc7d3afc33cca1fd8d282c1f4996769803fdc1
         └──────────────────────────────────────────────────────────────────────────────────────────────────────────────
[Talker] ┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────
         │ [debug] | 20:50:43 957ms | NFT collection not available yet; will retry
         └──────────────────────────────────────────────────────────────────────────────────────────────────────────────
```

## Type of Change
- [x] Bug fix
