### PR TITLE
fix: remove quick swiper from stories page to enable down swipe dismiss

### DIFF
--- a/lib/app/features/feed/stories/views/components/story_viewer/components/core/cube_page_view.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/core/cube_page_view.dart
@@ -4,7 +4,6 @@ import 'dart:math';
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
-import 'package:ion/app/features/components/quick_page_swiper/quick_page_swiper.dart';
 
 /// This widget is adapted from https://github.com/aeyrium/cube_transition
 /// with modifications to the disposal behavior of the PageController to prevent an exception
@@ -121,28 +120,23 @@ class CubePageViewState extends State<CubePageView> {
     return Center(
       child: ValueListenableBuilder<double>(
         valueListenable: _pageNotifier,
-        builder: (_, value, child) => QuickPageSwiper(
-          pageController: _pageController,
-          direction: Axis.horizontal,
-          child: PageView.builder(
-            scrollDirection: widget.scrollDirection,
-            controller: _pageController,
-            onPageChanged: widget.onPageChanged,
-            physics: const NeverScrollableScrollPhysics(),
-            itemCount: widget.itemCount ?? widget.children?.length ?? 0,
-            itemBuilder: (_, index) {
-              if (widget.itemBuilder != null) {
-                return widget.itemBuilder!(context, index, value);
-              }
-              return CubeWidget(
-                index: index,
-                pageNotifier: value,
-                rotationDirection: widget.scrollDirection,
-                transformStyle: widget.transformStyle,
-                child: widget.children![index],
-              );
-            },
-          ),
+        builder: (_, value, child) => PageView.builder(
+          scrollDirection: widget.scrollDirection,
+          controller: _pageController,
+          onPageChanged: widget.onPageChanged,
+          itemCount: widget.itemCount ?? widget.children?.length ?? 0,
+          itemBuilder: (_, index) {
+            if (widget.itemBuilder != null) {
+              return widget.itemBuilder!(context, index, value);
+            }
+            return CubeWidget(
+              index: index,
+              pageNotifier: value,
+              rotationDirection: widget.scrollDirection,
+              transformStyle: widget.transformStyle,
+              child: widget.children![index],
+            );
+          },
         ),
       ),
     );


### PR DESCRIPTION
## Description
This PR removes the QuickSwiper wrapper over the stories viewer page because it disabled the swipe down to dismiss functionality.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
<!-- Add corresponding task ID here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
https://github.com/user-attachments/assets/058a7065-2965-4da1-9f8e-9a1ef60fbdb0


