### PR TITLE
fix: scroll width for _CupertinoBackGestureDetector

### DIFF
--- a/lib/app/router/custom_routes.dart
+++ b/lib/app/router/custom_routes.dart
@@ -15,6 +15,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
+import 'package:ion/app/extensions/extensions.dart';
 
 const double _kMinFlingVelocity = 1; // Screen widths per second.
 
@@ -804,7 +805,7 @@ class _CupertinoBackGestureDetectorState<T> extends State<_CupertinoBackGestureD
         widget.child,
         PositionedDirectional(
           start: 0,
-          width: max(dragAreaWidth, MediaQuery.sizeOf(context).width),
+          width: max(dragAreaWidth, 64.0.s),
           top: 0,
           bottom: 0,
           child: Listener(


### PR DESCRIPTION
## Description
- Change ios back swipe area width

## Task ID
- ION-3589

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)

https://github.com/user-attachments/assets/083594aa-68de-4aad-9f77-e0faa3ed809d


