### PR TITLE
fix: stop user blocking himself in article section

### DIFF
--- a/lib/app/features/feed/views/pages/article_details_page/components/articles_carousel_item.dart
+++ b/lib/app/features/feed/views/pages/article_details_page/components/articles_carousel_item.dart
@@ -43,9 +43,7 @@ class ArticlesCarouselItem extends ConsumerWidget {
         children: [
           UserInfo(
             pubkey: article.masterPubkey,
-            trailing: isOwnedByCurrentUser
-                ? null
-                : UserInfoMenu(eventReference: eventReference),
+            trailing: isOwnedByCurrentUser ? null : UserInfoMenu(eventReference: eventReference),
           ),
           Flexible(
             child: Row(

--- a/lib/app/features/feed/views/pages/article_details_page/components/articles_carousel_item.dart
+++ b/lib/app/features/feed/views/pages/article_details_page/components/articles_carousel_item.dart
@@ -3,11 +3,13 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/extensions/extensions.dart';
+import 'package:ion/app/features/auth/providers/auth_provider.m.dart';
 import 'package:ion/app/features/feed/data/models/entities/article_data.f.dart';
 import 'package:ion/app/features/feed/data/models/feed_type.dart';
 import 'package:ion/app/features/feed/providers/feed_user_interests_provider.r.dart';
 import 'package:ion/app/features/feed/providers/ion_connect_entity_with_counters_provider.r.dart';
 import 'package:ion/app/features/feed/views/components/feed_network_image/feed_network_image.dart';
+import 'package:ion/app/features/feed/views/components/overlay_menu/own_entity_menu.dart';
 import 'package:ion/app/features/feed/views/components/overlay_menu/user_info_menu.dart';
 import 'package:ion/app/features/feed/views/components/user_info/user_info.dart';
 import 'package:ion/app/features/ion_connect/model/event_reference.f.dart';
@@ -32,6 +34,8 @@ class ArticlesCarouselItem extends ConsumerWidget {
           .select((state) => state.valueOrNull?.subcategories ?? {}),
     );
     final topicsNames = topics.map((key) => availableSubcategories[key]?.display).nonNulls.toList();
+    final isOwnedByCurrentUser =
+        ref.watch(isCurrentUserSelectorProvider(eventReference.masterPubkey));
 
     return GestureDetector(
       onTap: () => ArticleDetailsRoute(eventReference: eventReference.encode()).push<void>(context),
@@ -39,7 +43,9 @@ class ArticlesCarouselItem extends ConsumerWidget {
         children: [
           UserInfo(
             pubkey: article.masterPubkey,
-            trailing: UserInfoMenu(eventReference: eventReference),
+            trailing: isOwnedByCurrentUser
+                ? null
+                : UserInfoMenu(eventReference: eventReference),
           ),
           Flexible(
             child: Row(

--- a/lib/app/features/feed/views/pages/article_details_page/components/articles_carousel_item.dart
+++ b/lib/app/features/feed/views/pages/article_details_page/components/articles_carousel_item.dart
@@ -9,7 +9,6 @@ import 'package:ion/app/features/feed/data/models/feed_type.dart';
 import 'package:ion/app/features/feed/providers/feed_user_interests_provider.r.dart';
 import 'package:ion/app/features/feed/providers/ion_connect_entity_with_counters_provider.r.dart';
 import 'package:ion/app/features/feed/views/components/feed_network_image/feed_network_image.dart';
-import 'package:ion/app/features/feed/views/components/overlay_menu/own_entity_menu.dart';
 import 'package:ion/app/features/feed/views/components/overlay_menu/user_info_menu.dart';
 import 'package:ion/app/features/feed/views/components/user_info/user_info.dart';
 import 'package:ion/app/features/ion_connect/model/event_reference.f.dart';


### PR DESCRIPTION
## Description
user was proposed to block/follow/report himself on article details screen when he has more than 1 article.
context menu is hidden if current user is the owner of the post.

## Additional Notes
WTR: 

1. Log in the app.
2. Go to the Feed.
3. Publish 1st article.
4. Publish 2nd article.
5. Open 2nd article.

## Task ID
ION-3528

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
Own post          .          .          .              Another user post
<img width="30%" alt="Screenshot 2025-08-12 at 17 39 40" src="https://github.com/user-attachments/assets/b0bd7796-d8f1-4a99-830b-72b2622bb0ec" /><img width="30%" alt="Simulator Screenshot - iPhone 16 Plus - 2025-08-12 at 17 39 06" src="https://github.com/user-attachments/assets/0e308d57-e976-46f3-a4b1-ff55f4d0799a" />

