### PR TITLE
fix(wallet): make `nftNetworksViewModelProvider` non-autoDispose

### DIFF
--- a/lib/app/features/wallets/views/pages/wallet_page/view_models/nft_networks_view_model.dart
+++ b/lib/app/features/wallets/views/pages/wallet_page/view_models/nft_networks_view_model.dart
@@ -9,7 +9,7 @@ import 'package:ion/app/features/wallets/model/network_data.f.dart';
 import 'package:ion/app/services/command/command.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-final nftNetworksViewModelProvider = Provider.autoDispose(
+final nftNetworksViewModelProvider = Provider(
   (ref) {
     final filterService = ref.watch(nftNetworkFilterManagerProvider);
     final networksRepository = ref.watch(networksRepositoryProvider);


### PR DESCRIPTION
## Description
Previously, when a user switched from the NFTs tab to Coins and back to NFTs, the “Networks” filter state would reset to its initial state. I made the ViewModel non-autoDispose so that it preserves the filter state.

## Task ID
ION-3554

## Type of Change
- [x] Bug fix

## Screenshots

https://github.com/user-attachments/assets/3f7168c5-1040-4141-a4c6-06157610673f


