### PR TITLE
fix: use correct config retry multipliers for for you and following feed pages

### DIFF
--- a/lib/app/features/feed/providers/feed_following_content_provider.m.dart
+++ b/lib/app/features/feed/providers/feed_following_content_provider.m.dart
@@ -590,7 +590,7 @@ class FeedFollowingContent extends _$FeedFollowingContent implements PagedNotifi
 
   Future<RetryCounter> _buildRetryCounter() async {
     final feedConfig = await ref.read(feedConfigProvider.future);
-    final maxRetries = (feedType.pageSize * feedConfig.forYouMaxRetriesMultiplier).ceil();
+    final maxRetries = (feedType.pageSize * feedConfig.followingMaxRetriesMultiplier).ceil();
     return RetryCounter(limit: maxRetries);
   }
 

--- a/lib/app/features/feed/providers/feed_for_you_content_provider.m.dart
+++ b/lib/app/features/feed/providers/feed_for_you_content_provider.m.dart
@@ -32,7 +32,6 @@ import 'package:ion/app/utils/pagination.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'feed_for_you_content_provider.m.freezed.dart';
-
 part 'feed_for_you_content_provider.m.g.dart';
 
 @riverpod
@@ -118,7 +117,7 @@ class FeedForYouContent extends _$FeedForYouContent implements PagedNotifier {
 
   Future<RetryCounter> _buildRetryCounter() async {
     final feedConfig = await ref.read(feedConfigProvider.future);
-    final maxRetries = (feedType.pageSize * feedConfig.followingMaxRetriesMultiplier).ceil();
+    final maxRetries = (feedType.pageSize * feedConfig.forYouMaxRetriesMultiplier).ceil();
     return RetryCounter(limit: maxRetries);
   }
 


### PR DESCRIPTION
## Description
This PR fixes an issue where forYou fed was using a max retry count config from following and vice versa.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
<!-- Add corresponding task ID here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
