### PR TITLE
fix: follow button not updating after unfollow in stories

### DIFF
--- a/lib/app/features/optimistic_ui/core/optimistic_service.dart
+++ b/lib/app/features/optimistic_ui/core/optimistic_service.dart
@@ -17,6 +17,8 @@ class OptimisticService<T extends OptimisticModel> {
         (l) => l.firstWhereOrNull((e) => e.optimisticId == id),
       );
 
+  T? get(String id) => _manager.snapshot.firstWhereOrNull((e) => e.optimisticId == id);
+
   /// Dispatches an optimistic intent.
   Future<void> dispatch(OptimisticIntent<T> intent, T current) async =>
       _manager.perform(previous: current, optimistic: intent.optimistic(current));

--- a/lib/app/features/optimistic_ui/features/follow/follow_provider.r.dart
+++ b/lib/app/features/optimistic_ui/features/follow/follow_provider.r.dart
@@ -15,6 +15,7 @@ part 'follow_provider.r.g.dart';
 
 @riverpod
 OptimisticService<UserFollow> followService(Ref ref) {
+  keepAliveWhenAuthenticated(ref);
   final manager = ref.watch(followManagerProvider);
   final initialFollows = ref.read(currentUserSyncFollowListProvider)?.masterPubkeys ?? [];
   final initialUserFollows = initialFollows.map((pubkey) {
@@ -56,7 +57,7 @@ class ToggleFollowNotifier extends _$ToggleFollowNotifier {
 
   Future<void> toggle(String pubkey) async {
     final service = ref.read(followServiceProvider);
-    var current = ref.read(followWatchProvider(pubkey)).valueOrNull;
+    var current = service.get(pubkey);
 
     current ??= UserFollow(
       pubkey: pubkey,


### PR DESCRIPTION
## Description
This PR fixes an issue where unfollow button in stories viewer didn't change to `follow` after unfollowing.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
3415

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)

https://github.com/user-attachments/assets/68d0ad62-4dc9-45f6-a5f2-6375c93d9cf6


