### PR TITLE
fix: use ActionType.read instead of nullable actionType

### DIFF
--- a/lib/app/features/ion_connect/providers/ion_connect_notifier.r.dart
+++ b/lib/app/features/ion_connect/providers/ion_connect_notifier.r.dart
@@ -212,7 +212,7 @@ class IonConnectNotifier extends _$IonConnectNotifier {
               )
             : await ref.read(relayPickerProvider.notifier).getActionSourceRelay(
                   actionSource,
-                  actionType: ActionType.read,
+                  actionType: actionType ?? ActionType.read,
                   dislikedUrls: DislikedRelayUrlsCollection(dislikedRelaysUrls),
                 );
         triedRelay = relay;


### PR DESCRIPTION
## Description
- quick fix for action type

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
