### PR TITLE
fix: image loading placeholder

### DIFF
--- a/lib/app/components/placeholder/ion_placeholder.dart
+++ b/lib/app/components/placeholder/ion_placeholder.dart
@@ -5,18 +5,22 @@ import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/generated/assets.gen.dart';
 
 class IonPlaceholder extends StatelessWidget {
-  const IonPlaceholder({super.key});
+  const IonPlaceholder({super.key, this.isPlaceholder = false});
+
+  final bool isPlaceholder;
 
   @override
   Widget build(BuildContext context) {
     return ColoredBox(
       color: context.theme.appColors.tertiaryBackground,
-      child: Center(
-        child: Assets.svg.iconFeedUnavailable.icon(
-          size: 40.0.s,
-          color: context.theme.appColors.sheetLine,
-        ),
-      ),
+      child: isPlaceholder
+          ? const SizedBox.shrink()
+          : Center(
+              child: Assets.svg.iconFeedUnavailable.icon(
+                size: 40.0.s,
+                color: context.theme.appColors.sheetLine,
+              ),
+            ),
     );
   }
 }

--- a/lib/app/features/components/ion_connect_network_image/ion_connect_network_image.dart
+++ b/lib/app/features/components/ion_connect_network_image/ion_connect_network_image.dart
@@ -69,7 +69,7 @@ class IonConnectNetworkImage extends ConsumerWidget {
       fadeInDuration: fadeInDuration ?? Duration.zero,
       fadeOutDuration: fadeOutDuration ?? Duration.zero,
       borderRadius: borderRadius,
-      errorListener: (error) {
+      errorListener: (_) {
         if (ref.context.mounted) {
           ref.read(iONConnectMediaUrlFallbackProvider.notifier).generateFallback(
                 imageUrl,


### PR DESCRIPTION
## Description
- Fixed image loading placeholder (error state was used for loading too);
- Using a proper loading placeholder revealed a flickering issue cause there are internal retries in case of image loading 5xx so were flickering from loading placeholder to error state widget. Had to apply custom solution for that;

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)


https://github.com/user-attachments/assets/c29acfbf-ee87-44e4-849a-b5be62a24020




