### PR TITLE
fix: filter following articles by selected category

### DIFF
--- a/lib/app/features/feed/data/database/following_feed_database/dao/seen_events_dao.m.dart
+++ b/lib/app/features/feed/data/database/following_feed_database/dao/seen_events_dao.m.dart
@@ -186,21 +186,8 @@ class SeenEventsDao extends DatabaseAccessor<FollowingFeedDatabase> with _$SeenE
 
   Future<void> deleteEvents({
     required FeedType feedType,
-    required List<String> retainPubkeys,
-    required int until,
-    FeedModifier? feedModifier,
   }) async {
-    final query = delete(db.seenEventsTable)
-      ..where((tbl) => tbl.feedType.equalsValue(feedType))
-      ..where(
-        (tbl) => tbl.feedModifier.equals(const FeedModifierConverter().toSql(feedModifier)),
-      )
-      ..where(
-        (tbl) => Expression.or([
-          tbl.createdAt.isSmallerThanValue(until.toMicroseconds),
-          tbl.pubkey.isNotIn(retainPubkeys),
-        ]),
-      );
+    final query = delete(db.seenEventsTable)..where((tbl) => tbl.feedType.equalsValue(feedType));
     await query.go();
   }
 

--- a/lib/app/features/feed/data/repository/following_feed_seen_events_repository.r.dart
+++ b/lib/app/features/feed/data/repository/following_feed_seen_events_repository.r.dart
@@ -137,15 +137,9 @@ class FollowingFeedSeenEventsRepository {
 
   Future<void> deleteEvents({
     required FeedType feedType,
-    required List<String> retainPubkeys,
-    required int until,
-    FeedModifier? feedModifier,
   }) async {
     await _seenEventsDao.deleteEvents(
       feedType: feedType,
-      feedModifier: feedModifier,
-      retainPubkeys: retainPubkeys,
-      until: until,
     );
   }
 

--- a/lib/app/features/feed/providers/feed_following_content_provider.m.dart
+++ b/lib/app/features/feed/providers/feed_following_content_provider.m.dart
@@ -19,12 +19,14 @@ import 'package:ion/app/features/feed/data/repository/following_users_fetch_stat
 import 'package:ion/app/features/feed/providers/feed_config_provider.r.dart';
 import 'package:ion/app/features/feed/providers/feed_data_source_builders.dart';
 import 'package:ion/app/features/feed/providers/feed_request_queue.r.dart';
+import 'package:ion/app/features/feed/providers/feed_selected_article_categories_provider.r.dart';
 import 'package:ion/app/features/feed/providers/relevant_users_to_fetch_service.r.dart';
 import 'package:ion/app/features/ion_connect/ion_connect.dart';
 import 'package:ion/app/features/ion_connect/model/action_source.f.dart';
 import 'package:ion/app/features/ion_connect/model/event_reference.f.dart';
 import 'package:ion/app/features/ion_connect/model/events_metadata.f.dart';
 import 'package:ion/app/features/ion_connect/model/ion_connect_entity.dart';
+import 'package:ion/app/features/ion_connect/model/related_hashtag.f.dart';
 import 'package:ion/app/features/ion_connect/model/search_extension.dart';
 import 'package:ion/app/features/ion_connect/providers/entities_paged_data_provider.m.dart';
 import 'package:ion/app/features/ion_connect/providers/ion_connect_entity_provider.r.dart';
@@ -327,6 +329,8 @@ class FeedFollowingContent extends _$FeedFollowingContent implements PagedNotifi
   }) async {
     final ionConnectNotifier = ref.read(ionConnectNotifierProvider.notifier);
 
+    final selectedArticleCategories = ref.read(feedSelectedArticleCategoriesProvider);
+
     final feedConfig = await ref.read(feedConfigProvider.future);
     final FeedEntitiesDataSource(:dataSource, :responseFilter) =
         _getDataSourceForPubkey(pubkey, feedConfig);
@@ -341,6 +345,11 @@ class FeedFollowingContent extends _$FeedFollowingContent implements PagedNotifi
         filter.copyWith(
           limit: () => 1,
           until: () => until,
+          tags: () => selectedArticleCategories.isEmpty
+              ? null
+              : {
+                  '#${RelatedHashtag.tagName}': selectedArticleCategories.toList(),
+                },
         ),
       );
     }

--- a/lib/app/features/feed/views/pages/feed_page/components/article_categories_menu/article_categories_menu.dart
+++ b/lib/app/features/feed/views/pages/feed_page/components/article_categories_menu/article_categories_menu.dart
@@ -5,6 +5,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/section_separator/section_separator.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/feed/data/models/feed_type.dart';
+import 'package:ion/app/features/feed/data/repository/following_feed_seen_events_repository.r.dart';
 import 'package:ion/app/features/feed/providers/feed_posts_provider.r.dart';
 import 'package:ion/app/features/feed/providers/feed_selected_article_categories_provider.r.dart';
 import 'package:ion/app/features/feed/providers/feed_selected_visible_article_categories_provider.r.dart';
@@ -67,7 +68,7 @@ class ArticleCategoriesMenu extends HookConsumerWidget {
     );
   }
 
-  void _toggleCategory(WidgetRef ref, String categoryKey) {
+  Future<void> _toggleCategory(WidgetRef ref, String categoryKey) async {
     final selectedSubcategoriesKeys = ref.read(feedSelectedArticleCategoriesProvider);
     final newCategories = selectedSubcategoriesKeys.toSet();
     if (newCategories.contains(categoryKey)) {
@@ -76,6 +77,9 @@ class ArticleCategoriesMenu extends HookConsumerWidget {
       newCategories.add(categoryKey);
     }
     ref.read(feedSelectedArticleCategoriesProvider.notifier).categories = newCategories;
+    await ref
+        .read(followingFeedSeenEventsRepositoryProvider)
+        .deleteEvents(feedType: FeedType.article);
     ref.read(feedPostsProvider.notifier).refresh();
   }
 }

--- a/test/feed/relevant_users_to_fetch_service_test.dart
+++ b/test/feed/relevant_users_to_fetch_service_test.dart
@@ -266,9 +266,6 @@ class FakeFollowingFeedSeenEventsRepository implements FollowingFeedSeenEventsRe
   @override
   Future<void> deleteEvents({
     required FeedType feedType,
-    required List<String> retainPubkeys,
-    required int until,
-    FeedModifier? feedModifier,
   }) {
     throw UnimplementedError();
   }


### PR DESCRIPTION
## Description
This update ensures that the "Following" articles list is filtered according to the currently selected category.  
Previously, all following articles were displayed regardless of category selection, causing irrelevant content to appear.  

## Additional Notes
N/A

## Task ID
3305

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)

https://github.com/user-attachments/assets/08ff0957-5055-4e44-947e-743ec312f038



