### PR TITLE
fix(feed): fixed jumping CreateContent dialog with different states

### DIFF
--- a/lib/app/features/feed/views/pages/feed_main_modal/feed_main_modal_page.dart
+++ b/lib/app/features/feed/views/pages/feed_main_modal/feed_main_modal_page.dart
@@ -15,6 +15,7 @@ import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/core/permissions/data/models/permissions_types.dart';
 import 'package:ion/app/features/core/permissions/views/components/permission_aware_widget.dart';
 import 'package:ion/app/features/core/permissions/views/components/permission_dialogs/permission_sheets.dart';
+import 'package:ion/app/features/core/views/pages/error_modal.dart';
 import 'package:ion/app/features/feed/constants/video_constants.dart';
 import 'package:ion/app/features/feed/data/models/feed_type.dart';
 import 'package:ion/app/features/feed/nft/sync/nft_collection_sync_controller.r.dart';
@@ -41,10 +42,17 @@ class FeedMainModalPage extends ConsumerWidget {
     return SheetContent(
       backgroundColor: context.theme.appColors.secondaryBackground,
       topPadding: 0.0.s,
-      body: hasNftCollectionState.maybeWhen(
-        data: (hasNftCollection) =>
-            hasNftCollection ? const _CreateContentModal() : const _ContentCreationBlockedModal(),
-        orElse: () => const _CreateContentLoadingModal(),
+      body: AnimatedSwitcher(
+        duration: const Duration(milliseconds: 200),
+        switchInCurve: Curves.easeIn,
+        switchOutCurve: Curves.easeOut,
+        child: hasNftCollectionState.when(
+          data: (hasContentNftCollection) => hasContentNftCollection
+              ? const _CreateContentModal()
+              : const _ContentCreationBlockedModal(),
+          loading: () => const _CreateContentLoadingModal(),
+          error: (error, __) => ErrorModal(error: error),
+        ),
       ),
     );
   }
@@ -88,7 +96,6 @@ class _CreateContentModal extends StatelessWidget {
   }
 }
 
-// ignore: unused_element
 class _ContentCreationBlockedModal extends HookConsumerWidget {
   const _ContentCreationBlockedModal();
 
@@ -148,18 +155,26 @@ class _ContentCreationBlockedModal extends HookConsumerWidget {
   }
 }
 
-// ignore: unused_element
 class _CreateContentLoadingModal extends StatelessWidget {
   const _CreateContentLoadingModal();
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(height: 375.s);
+    return ConstrainedBox(
+      constraints: BoxConstraints(maxHeight: 333.s),
+      child: const Center(
+        child: IONLoadingIndicatorThemed(),
+      ),
+    );
   }
 }
 
 class _SharePostButton extends HookConsumerWidget {
-  const _SharePostButton({required this.type, required this.index});
+  const _SharePostButton({
+    required this.type,
+    required this.index,
+  });
+
   final MainModalListItem type;
   final int index;
 


### PR DESCRIPTION
## Description

### What
- Updated UI for the `FeedMainModalPage`. Now Loading state is a proper loading and there's also an Error state.

### Why
- In case of error it showed the "loading" state, which was confusing
- The Loading state was written poorly, which lead to a transparent dialog

## Type of Change
- [x] Bug fix

## Screenshots
<img width="350" alt="Simulator Screenshot - iPhone 16 Plus - 2025-08-15 at 17 51 14" src="https://github.com/user-attachments/assets/e6e96015-9910-4adc-aeb0-5494ff1b78fb" />
<img width="350" alt="Simulator Screenshot - iPhone 16 Plus - 2025-08-15 at 17 51 29" src="https://github.com/user-attachments/assets/4ec8d4ab-b3f5-4649-8869-06535dbf464d" />
<img width="350" alt="Simulator Screenshot - iPhone 16 Plus - 2025-08-15 at 17 51 39" src="https://github.com/user-attachments/assets/52028f62-7bc1-462f-b96d-2ae8c747a1aa" />
<img width="350" alt="Simulator Screenshot - iPhone 16 Plus - 2025-08-15 at 17 51 49" src="https://github.com/user-attachments/assets/dd662478-fb3d-4ecc-9fa5-a17cae2e4564" />

