### PR TITLE
fix: reduce amount of requests for InternetConnectionChecker

### DIFF
--- a/lib/app/features/core/providers/internet_connection_checker_provider.r.dart
+++ b/lib/app/features/core/providers/internet_connection_checker_provider.r.dart
@@ -9,7 +9,7 @@ part 'internet_connection_checker_provider.r.g.dart';
 
 @Riverpod(keepAlive: true)
 InternetConnectionChecker internetConnectionChecker(Ref ref) {
-  const checkInterval = Duration(seconds: 10);
+  const checkInterval = Duration(hours: 1);
   const hosts = [
     InternetCheckOption(host: '1.1.1.1'), // Cloudflare
     InternetCheckOption(host: '8.8.8.8'), // Google

--- a/lib/app/features/core/services/internet_connection_checker.dart
+++ b/lib/app/features/core/services/internet_connection_checker.dart
@@ -66,11 +66,13 @@ class InternetConnectionChecker {
   }
 
   Future<bool> _hasInternetAccess() async {
-    final futures = _internetCheckOptions.map(_dialHost);
-    return Stream.fromFutures(futures).firstWhere(
-      (isSuccess) => isSuccess,
-      orElse: () => false,
-    );
+    for (final option in _internetCheckOptions) {
+      final isSuccess = await _dialHost(option);
+      if (isSuccess) {
+        return true;
+      }
+    }
+    return false;
   }
 
   Future<bool> _dialHost(InternetCheckOption option) async {


### PR DESCRIPTION
## Description

### What
- Change the timer interval from 10 seconds to 1 hour
- Don't call all IPs at once, do it 1 by 1

### Why
- Currently the `InternetConnectionChecker` makes too many requests. We want to reduce that. This is the first step.

## Type of Change
- [x] Bug fix