### PR TITLE
build(ios): add setup-xcode step

### DIFF
--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -211,6 +211,10 @@ jobs:
             ~/.pub-cache
             ./*
           key: ${{ github.sha }}_${{ github.run_number }}
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
       - name: Mask APP environment and keys in logs
         id: mask-secrets
         run: |


### PR DESCRIPTION
## Description
This PR fixes an issue related to the recent github action runner image changes.
Specify latest stable Xcode version instead of the one available on the runner by default as a workaround.

## Additional Info
[related thread](https://github.com/actions/runner-images/issues/12758)

## Task ID
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
