### PR TITLE
fix: full screen video controller initialization errors

### DIFF
--- a/lib/app/features/core/providers/video_player_provider.r.dart
+++ b/lib/app/features/core/providers/video_player_provider.r.dart
@@ -150,7 +150,9 @@ class VideoController extends _$VideoController {
             if (controller.value.isPlaying) {
               final prev = VideoController._currentlyPlayingController;
               if (prev != null && prev != controller) {
-                prev.pause();
+                if (prev.value.isPlaying) {
+                  prev.pause();
+                }
               }
               VideoController._currentlyPlayingController = controller;
             }

--- a/lib/app/features/video/views/pages/videos_vertical_scroll_page.dart
+++ b/lib/app/features/video/views/pages/videos_vertical_scroll_page.dart
@@ -120,7 +120,9 @@ class VideosVerticalScrollPage extends HookConsumerWidget {
         void listener() {
           if (userPageController.offset < -150 ||
               (userPageController.offset > userPageController.position.maxScrollExtent + 150)) {
-            context.pop();
+            if (context.canPop()) {
+              context.pop();
+            }
           }
         }
 

--- a/lib/app/hooks/use_auto_play.dart
+++ b/lib/app/hooks/use_auto_play.dart
@@ -1,14 +1,20 @@
 // SPDX-License-Identifier: ice License 1.0
 
+import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:video_player/video_player.dart';
 
 void useAutoPlay(VideoPlayerController? controller) {
   useEffect(
     () {
-      controller?.play();
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        controller?.play();
+      });
+
       return () {
-        controller?.pause();
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          controller?.pause();
+        });
       };
     },
     [controller],


### PR DESCRIPTION
## Description
This PR fixes video controller issues that occur when swiping between full‑screen videos and navigating between pages, ensuring smooth playback and correct pause/resume behavior.

## Additional Notes
N/A

## Task ID
3669

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
