### PR TITLE
chore(ios): add INSendMessageIntent to NSUserActivityTypes

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -86,5 +86,9 @@
 	<string>This app needs microphone access to record voice messages or videos for sharing in chats.</string>
 	<key>NSFaceIDUsageDescription</key>
 	<string>This app uses Face ID to securely authenticate your identity for account access.</string>
+	<key>NSUserActivityTypes</key>
+	<array>
+		<string>INSendMessageIntent</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Description
This PR adds `INSendMessageIntent` to `NSUserActivityTypes` in iOS `Info.plist` - that is required to use `com.apple.developer.usernotifications.communication`.
In our case, we need this to be able to add avatars to push notifications.

## Additional Notes
N/A

## Task ID
N/A

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [x] Chore
