### PR TITLE
fix: use BoxFit.cover for video with bigger aspect ratio than 9/16

### DIFF
--- a/lib/app/features/feed/stories/views/components/story_preview/media/story_video_preview.dart
+++ b/lib/app/features/feed/stories/views/components/story_preview/media/story_video_preview.dart
@@ -30,12 +30,25 @@ class StoryVideoPreview extends HookConsumerWidget {
 
     return LayoutBuilder(
       builder: (context, constraints) {
+        final isHorizontal = videoController.value.aspectRatio > 1.0;
+        final maxAspectRatioMultiplier = isHorizontal ? (9 / 16) : (16 / 9);
+        final visibleHeight = constraints.maxWidth * maxAspectRatioMultiplier;
+
         return ClipRRect(
           borderRadius: BorderRadius.circular(22.0.s),
           child: SizedBox(
             width: constraints.maxWidth,
-            height: constraints.maxWidth / videoController.value.aspectRatio,
-            child: VideoPlayer(videoController),
+            height: visibleHeight,
+            child: FittedBox(
+              fit: isHorizontal ? BoxFit.contain : BoxFit.cover,
+              child: SizedBox(
+                width: constraints.maxWidth,
+                child: AspectRatio(
+                  aspectRatio: videoController.value.aspectRatio,
+                  child: VideoPlayer(videoController),
+                ),
+              ),
+            ),
           ),
         );
       },


### PR DESCRIPTION
## Description
This PR fixes an issue where videos with bigger AR than 9/16 were losing their aspect ratio and were stretched horizontally.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
3403

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)

https://github.com/user-attachments/assets/a098961f-7819-44a9-820e-781892503c70

