### PR TITLE
fix(wallet): clear search query when NFTs networks dialog is opened

### DIFF
--- a/lib/app/features/wallets/views/pages/manage_nfts/manage_nfts_page.dart
+++ b/lib/app/features/wallets/views/pages/manage_nfts/manage_nfts_page.dart
@@ -11,6 +11,7 @@ import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/wallets/views/pages/manage_nfts/components/all_chains_item.dart';
 import 'package:ion/app/features/wallets/views/pages/manage_nfts/components/manage_nft_item.dart';
 import 'package:ion/app/features/wallets/views/pages/wallet_page/view_models/nft_networks_view_model.dart';
+import 'package:ion/app/hooks/use_on_init.dart';
 import 'package:ion/app/router/components/navigation_app_bar/collapsing_app_bar.dart';
 import 'package:ion/app/router/components/navigation_app_bar/navigation_app_bar.dart';
 import 'package:ion/app/router/components/sheet_content/sheet_content.dart';
@@ -22,6 +23,10 @@ class ManageNftsPage extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final viewModel = ref.watch(nftNetworksViewModelProvider);
+
+    useOnInit(() {
+      viewModel.searchQueryCommand.execute('');
+    });
 
     return SheetContent(
       body: Column(


### PR DESCRIPTION
## Description
The reason of the bug is that ViewModel stays in memory when a user leaves the dialog. Reset the search query onInit fixes the issue.

## Task ID
ION-3674

## Type of Change
- [x] Bug fix

## Screenshots
<img width="350" alt="image" src="https://github.com/user-attachments/assets/9a80f233-413f-4f07-9553-0eaad2106199" />

