### PR TITLE
fix(feed): remove loading state for _ContentCreationBlockedModal

### DIFF
--- a/lib/app/features/feed/views/pages/feed_main_modal/feed_main_modal_page.dart
+++ b/lib/app/features/feed/views/pages/feed_main_modal/feed_main_modal_page.dart
@@ -3,7 +3,6 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/button/button.dart';
@@ -105,8 +104,6 @@ class _ContentCreationBlockedModal extends HookConsumerWidget {
     final colors = context.theme.appColors;
     final locale = context.i18n;
 
-    final isLoading = useState(false);
-
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
@@ -130,20 +127,9 @@ class _ContentCreationBlockedModal extends HookConsumerWidget {
               SizedBox(height: 24.s),
               Button(
                 minimumSize: Size(double.infinity, 56.s),
-                leadingIcon: isLoading.value
-                    ? const IONLoadingIndicator()
-                    : Assets.svg.iconbuttonTryagain.icon(size: 24.s),
                 label: Text(locale.button_try_again),
-                disabled: isLoading.value,
-                type: isLoading.value ? ButtonType.disabled : ButtonType.primary,
-                onPressed: () async {
-                  try {
-                    isLoading.value = true;
-                    await invalidateCurrentUserMetadataProviders(ref);
-                    await Future<void>.delayed(const Duration(milliseconds: 500));
-                  } finally {
-                    isLoading.value = false;
-                  }
+                onPressed: () {
+                  invalidateCurrentUserMetadataProviders(ref);
                 },
               ),
             ],


### PR DESCRIPTION
## Description
This PR removes the loading state from `_ContentCreationBlockedModal`, since we already have `_CreateContentLoadingModal` to handle loading.
The loading state inside `_ContentCreationBlockedModal` was causing a setting state call after the widget was disposed (because the dialog is switched).

## Additional Notes
https://github.com/ice-blockchain/ion-framework/pull/1873

## Type of Change
- [x] Bug fix