### PR TITLE
fix: prevent firebase config provider rebuilds loop on non default writeRelay

### DIFF
--- a/lib/app/features/push_notifications/providers/relay_firebase_app_config_provider.m.dart
+++ b/lib/app/features/push_notifications/providers/relay_firebase_app_config_provider.m.dart
@@ -52,7 +52,7 @@ class RelayFirebaseAppConfig extends _$RelayFirebaseAppConfig {
 
     // Using [writeRelay] with priority because it holds the actual relay
     // that was used to sent the last event.
-    // Note: [writeRelay] could be even a read relay fallback if all write relays are unavailable.
+    // Note: [writeRelay] could even be a read relay fallback if all write relays are unavailable.
     if (writeRelay != null) {
       final relayFirebaseConfig = await _getRelayFirebaseConfig(writeRelay);
       if (relayFirebaseConfig != null) {


### PR DESCRIPTION
## Description
This PR fixes infinity rebuilds of `relayFirebaseAppConfigProvider` when `writeRelay` is not equal to the `actionSourceRelay.getActionSourceRelay(actionType: ActionType.write)` (default write relay). This might happen if sending fails to the primary write relay and another current user `writeRelay` is selected on retry.

## Additional Notes
N/A

## Task ID
ION-3706

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
