### PR TITLE
fix: relays not found after foreground

### DIFF
--- a/lib/app/features/user/providers/relays/ranked_user_relays_provider.r.dart
+++ b/lib/app/features/user/providers/relays/ranked_user_relays_provider.r.dart
@@ -34,14 +34,12 @@ class RankedCurrentUserRelays extends _$RankedCurrentUserRelays {
         ref.watch(envProvider.notifier).get<int>(EnvVariable.RELAY_PING_INTERVAL_SECONDS);
 
     final controller = StreamController<List<UserRelay>>();
-    final interval = Duration(seconds: pingIntervalSeconds);
-
     ref
         .watch(
-          pauseablePeriodicRunnerProvider.notifier,
+          pauseablePeriodicRunnerProvider,
         )
         .start(
-          interval: interval,
+          interval: Duration(seconds: pingIntervalSeconds),
           onTick: (cancelToken) =>
               controller.addStream(_rank(currentUserRelays, cancelToken: cancelToken)),
           runImmediately: true,


### PR DESCRIPTION
## Description
- Fixed an issue when user get `Relay not found` after foreground;
Main idea is to pause scheduled relays ranking when in the background and continue when is in foreground;


## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

