### PR TITLE
fix:move CounterItemsFooter out of PageView in ImageCarousel to avoid scrolling effect on it

### DIFF
--- a/lib/app/features/feed/views/pages/fullscreen_media/components/image_carousel.dart
+++ b/lib/app/features/feed/views/pages/fullscreen_media/components/image_carousel.dart
@@ -55,33 +55,35 @@ class ImageCarousel extends HookConsumerWidget {
 
     final isZoomed = ref.watch(imageZoomProvider);
 
-    return Column(
+    return Stack(
+      fit: StackFit.expand,
       children: [
-        Expanded(
-          child: PageView.builder(
-            controller: pageController,
-            physics: isZoomed ? const NeverScrollableScrollPhysics() : const PageScrollPhysics(),
-            itemCount: images.length,
-            itemBuilder: (context, index) {
-              return CarouselImageItem(
-                key: ValueKey(images[index].url),
-                imageUrl: images[index].url,
-                authorPubkey: eventReference.masterPubkey,
-                zoomController: zoomController,
-                bottomOverlayBuilder: index == currentPage.value
-                    ? (context) => SafeArea(
-                          top: false,
-                          child: ColoredBox(
-                            color: Colors.transparent,
-                            child: CounterItemsFooter(
-                              eventReference: eventReference,
-                              color: onPrimaryAccentColor,
-                            ),
-                          ),
-                        )
-                    : null,
-              );
-            },
+        PageView.builder(
+          controller: pageController,
+          physics: isZoomed ? const NeverScrollableScrollPhysics() : const PageScrollPhysics(),
+          itemCount: images.length,
+          itemBuilder: (context, index) {
+            return CarouselImageItem(
+              key: ValueKey(images[index].url),
+              imageUrl: images[index].url,
+              authorPubkey: eventReference.masterPubkey,
+              zoomController: zoomController,
+            );
+          },
+        ),
+        PositionedDirectional(
+          start: 0,
+          end: 0,
+          bottom: 0,
+          child: SafeArea(
+            top: false,
+            child: ColoredBox(
+              color: Colors.transparent,
+              child: CounterItemsFooter(
+                eventReference: eventReference,
+                color: onPrimaryAccentColor,
+              ),
+            ),
           ),
         ),
       ],


### PR DESCRIPTION

## Description
The bottom panel on image carousel shouldn't scroll with pageView swaps

## Additional Notes
Moved the panel out pf the pageView 

## Task ID
ION-3479

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)

https://github.com/user-attachments/assets/87a38eb6-db73-4514-a915-f35111d0c6b0


