### PR TITLE
fix: ios keychain locked device access

### DIFF
--- a/lib/app/services/storage/secure_storage.r.dart
+++ b/lib/app/services/storage/secure_storage.r.dart
@@ -10,7 +10,16 @@ import 'package:shared_preferences/shared_preferences.dart';
 part 'secure_storage.r.g.dart';
 
 class SecureStorage {
-  final FlutterSecureStorage _storage = const FlutterSecureStorage();
+  // Use accessibility settings that allow access when device is locked
+  // This is required for iOS notification service extensions
+  final FlutterSecureStorage _storage = const FlutterSecureStorage(
+    aOptions: AndroidOptions(
+      encryptedSharedPreferences: true,
+    ),
+    iOptions: IOSOptions(
+      accessibility: KeychainAccessibility.first_unlock_this_device,
+    ),
+  );
 
   Future<String?> getString({required String key}) {
     return _storage.read(key: key);


### PR DESCRIPTION
## Description
- add `accessibility` attribute for keychain to allow access while device locked

## Additional Notes
- add `encryptedSharedPreferences` for Android to provide double encryption layer (EncryptedSharedPreferences + Android Keystore) for enhanced security of private keys stored on Android devices

## Task ID
ION-3709

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
