### PR TITLE
fix: image asset path as a cache key

### DIFF
--- a/lib/app/components/image/ion_network_image.dart
+++ b/lib/app/components/image/ion_network_image.dart
@@ -54,8 +54,7 @@ class IonNetworkImage extends HookWidget {
   @override
   Widget build(BuildContext context) {
     final devicePixelRatio = MediaQuery.devicePixelRatioOf(context);
-    final fullWidth = MediaQuery.sizeOf(context).width;
-    final cacheWidth = (width ?? fullWidth) * devicePixelRatio;
+    final cacheWidth = (width ?? MediaQuery.sizeOf(context).width) * devicePixelRatio;
     final cacheHeight = height != null ? height! * devicePixelRatio : null;
     int? memCacheWidth;
     int? memCacheHeight;
@@ -73,6 +72,7 @@ class IonNetworkImage extends HookWidget {
     }
 
     final fetchError = useRef<Object?>(null);
+    final cacheKey = Uri.tryParse(imageUrl)?.path ?? imageUrl;
 
     if (borderRadius != null) {
       return DecoratedBox(
@@ -83,6 +83,7 @@ class IonNetworkImage extends HookWidget {
               imageUrl,
               maxWidth: memCacheWidth,
               maxHeight: memCacheHeight,
+              cacheKey: cacheKey,
             ),
             fit: fit,
           ),
@@ -96,6 +97,7 @@ class IonNetworkImage extends HookWidget {
 
     return CachedNetworkImage(
       key: Key("${imageUrl}_${cacheWidth.toInt()}x${cacheHeight?.toInt() ?? 'auto'}"),
+      cacheKey: cacheKey,
       imageUrl: imageUrl,
       height: height,
       width: width,


### PR DESCRIPTION
## Description
- Use explicit cache key which is an asset path. cause by default whole url is used but we can have the same asset on multiple hosts.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
