### PR TITLE
fix: avoid removing current video post during duplications filtering in VideosVerticalScrollPage

### DIFF
--- a/lib/app/features/video/views/pages/videos_vertical_scroll_page.dart
+++ b/lib/app/features/video/views/pages/videos_vertical_scroll_page.dart
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: ice License 1.0
 
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -80,10 +81,21 @@ class VideosVerticalScrollPage extends HookConsumerWidget {
       return videoPost || videoRepost;
     });
 
-    final videos = filteredVideos.isEmpty ? [ionConnectEntity] : filteredVideos;
+    final videos = filteredVideos.isEmpty ? [ionConnectEntity] : filteredVideos.toList();
 
     final List<_FlattenedVideo> flattenedVideos = useMemoized(
       () {
+        final currentEntityFlattenedVideo = videos.firstWhereOrNull(
+          (v) => v.id == ionConnectEntity.id,
+        );
+
+        //ensuring current entity is always the first before flattening them and filtering them by distinct
+        if (currentEntityFlattenedVideo != null) {
+          videos
+            ..remove(currentEntityFlattenedVideo)
+            ..insert(0, currentEntityFlattenedVideo);
+        }
+
         final result = <_FlattenedVideo>[];
         for (final entity in videos) {
           if (entity is ModifiablePostEntity || entity is PostEntity) {


### PR DESCRIPTION

## Description
Fix the filtering by distinct logic on VideosVerticalScrollPage

## Additional Notes
In some cases different post have same video URL and .distinctBy((video) => video.media.url) could remove the actual entity that user clicked on

## Task ID
ION-3707

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
