### PR TITLE
fix: optimize text message rendering by using text scaler from context

### DIFF
--- a/lib/app/features/chat/views/components/message_items/message_types/text_message/text_message.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/text_message/text_message.dart
@@ -146,6 +146,8 @@ class _TextMessageContent extends HookWidget {
 
     final metadataWidth = useState<double>(0);
 
+    final textScaler = MediaQuery.textScalerOf(context);
+
     useEffect(
       () {
         WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -156,14 +158,14 @@ class _TextMessageContent extends HookWidget {
         });
         return null;
       },
-      [eventMessage],
+      [eventMessage, textScaler],
     );
 
     final oneLineTextPainter = TextPainter(
       text: TextSpan(text: content, style: textStyle),
       textDirection: TextDirection.ltr,
       textWidthBasis: TextWidthBasis.longestLine,
-      textScaler: MediaQuery.textScalerOf(context),
+      textScaler: textScaler,
     )..layout(maxWidth: maxAvailableWidth - metadataWidth.value.s);
 
     final oneLineMetrics = oneLineTextPainter.computeLineMetrics();
@@ -197,7 +199,7 @@ class _TextMessageContent extends HookWidget {
         text: TextSpan(text: content, style: textStyle),
         textDirection: TextDirection.ltr,
         textWidthBasis: TextWidthBasis.longestLine,
-        textScaler: MediaQuery.textScalerOf(context),
+        textScaler: textScaler,
       )..layout(maxWidth: maxAvailableWidth);
 
       final lineMetrics = multiLineTextPainter.computeLineMetrics();


### PR DESCRIPTION
## Description
This PR optimize text message rendering by using text scaler from context to prevent overlap issue for different screen zooms.

## Additional Notes
N/A

## Task ID
3705

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)

[untitled.webm](https://github.com/user-attachments/assets/d384b404-968e-4aa1-ac04-f94e16663ef5)

