### PR TITLE
fix:prevent opening overlay menu when scroll is active

### DIFF
--- a/lib/app/components/overlay_menu/overlay_menu.dart
+++ b/lib/app/components/overlay_menu/overlay_menu.dart
@@ -46,9 +46,13 @@ class OverlayMenu extends HookWidget {
 
     final showMenu = useCallback(
       () {
-        overlayPortalController.show();
-        animationController.forward();
-        onOpen?.call();
+        final isScrolling = scrollController?.position.isScrollingNotifier.value ?? false;
+        //prevent opening filters menu if scroll is active
+        if (!isScrolling) {
+          overlayPortalController.show();
+          animationController.forward();
+          onOpen?.call();
+        }
       },
       [overlayPortalController],
     );


### PR DESCRIPTION
## Description
Remove blinking effect on filters menu during the scroll

## Additional Notes
Effect was causes by auto close logic implemented earlier. To compliment it I added restriction on opening menu during the active scroll

## Task ID
ION-3717

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

