### PR TITLE
fix: make background for posts shared to stories take whole height

### DIFF
--- a/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/image_story_viewer.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/image_story_viewer.dart
@@ -64,21 +64,18 @@ class ImageStoryViewer extends HookConsumerWidget {
         color: context.theme.appColors.attentionBlock,
         child: Padding(
           padding: EdgeInsets.symmetric(horizontal: 20.0.s),
-          child: FractionallySizedBox(
-            heightFactor: 0.7,
-            child: TapToSeeHint(
-              onTap: () {
-                final eventReference =
-                    quotedEvent?.eventReference ?? sourcePostReference!.eventReference;
-                PostDetailsRoute(
-                  eventReference: eventReference.encode(),
-                ).push<void>(context);
-              },
-              onVisibilityChanged: (isVisible) {
-                ref.read(storyPauseControllerProvider.notifier).paused = isVisible;
-              },
-              child: imageWidget,
-            ),
+          child: TapToSeeHint(
+            onTap: () {
+              final eventReference =
+                  quotedEvent?.eventReference ?? sourcePostReference!.eventReference;
+              PostDetailsRoute(
+                eventReference: eventReference.encode(),
+              ).push<void>(context);
+            },
+            onVisibilityChanged: (isVisible) {
+              ref.read(storyPauseControllerProvider.notifier).paused = isVisible;
+            },
+            child: imageWidget,
           ),
         ),
       );


### PR DESCRIPTION
## Description
This PR makes the background for posts shared to stories full screen.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
3741

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<img width="1118" height="2124" alt="ScreenShot 2025-08-27 at 11 40 43@2x" src="https://github.com/user-attachments/assets/a0e356bb-9ebf-467c-9e23-f00970d41cd8" />

