### PR TITLE
fix: payment request messages status not shown after restart

### DIFF
--- a/lib/app/features/wallets/data/repository/request_assets_repository.r.dart
+++ b/lib/app/features/wallets/data/repository/request_assets_repository.r.dart
@@ -43,8 +43,7 @@ class RequestAssetsRepository {
         .asyncMap(
           (transactionId) => _transactionsDao
               .getTransactions(txHashes: [transactionId]).then((list) => list.firstOrNull),
-        )
-        .startWith(null);
+        );
 
     yield* requestStream.combineLatest(
       transactionStream,


### PR DESCRIPTION
## Description
- updated request_assets_repository not to return null initially

## Task ID
ION-3632

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)


https://github.com/user-attachments/assets/6ecb3eec-a242-482d-928b-6257408756e5

