### PR TITLE
fix: android secure storage options in ion_identity_client

### DIFF
--- a/packages/ion_identity_client/lib/src/core/service_locator/network_service_locator.dart
+++ b/packages/ion_identity_client/lib/src/core/service_locator/network_service_locator.dart
@@ -126,6 +126,10 @@ mixin _Interceptors {
   }
 }
 
+const _defaultSecureStorage = FlutterSecureStorage(
+  aOptions: AndroidOptions(encryptedSharedPreferences: true),
+);
+
 mixin _TokenStorage {
   TokenStorage? _tokenStorageInstance;
   FlutterSecureStorage? _flutterSecureStorage;
@@ -146,9 +150,7 @@ mixin _TokenStorage {
       return _flutterSecureStorage!;
     }
 
-    _flutterSecureStorage = const FlutterSecureStorage(
-      aOptions: AndroidOptions(encryptedSharedPreferences: true),
-    );
+    _flutterSecureStorage = _defaultSecureStorage;
     return _flutterSecureStorage!;
   }
 }
@@ -173,9 +175,7 @@ mixin _PrivateKeyStorage {
       return _flutterSecureStorage!;
     }
 
-    _flutterSecureStorage = const FlutterSecureStorage(
-      aOptions: AndroidOptions(encryptedSharedPreferences: true),
-    );
+    _flutterSecureStorage = _defaultSecureStorage;
     return _flutterSecureStorage!;
   }
 }
@@ -200,9 +200,7 @@ mixin _BiometricsStateStorage {
       return _flutterSecureStorage!;
     }
 
-    _flutterSecureStorage = const FlutterSecureStorage(
-      aOptions: AndroidOptions(encryptedSharedPreferences: true),
-    );
+    _flutterSecureStorage = _defaultSecureStorage;
     return _flutterSecureStorage!;
   }
 }
@@ -227,9 +225,7 @@ mixin _LocalPasskeyCredsStateStorage {
       return _flutterSecureStorage!;
     }
 
-    _flutterSecureStorage = const FlutterSecureStorage(
-      aOptions: AndroidOptions(encryptedSharedPreferences: true),
-    );
+    _flutterSecureStorage = _defaultSecureStorage;
     return _flutterSecureStorage!;
   }
 }


### PR DESCRIPTION
## Description
This PR fixes incomparability between android secure storage options in the lib and main package that leads to logout on every app restart.
So we need to use the same android secure storage options across the packages.

## Additional Notes
N/A

## Task ID
ION-3738

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
