### PR TITLE
fix: counters not loading when opened a post using a deep link

### DIFF
--- a/lib/app/features/chat/providers/share_feed_item_to_chat_provider.r.dart
+++ b/lib/app/features/chat/providers/share_feed_item_to_chat_provider.r.dart
@@ -55,7 +55,7 @@ class ShareFeedItemToChat extends _$ShareFeedItemToChat {
         final sendChatMessageService = ref.read(sendE2eeChatMessageServiceProvider);
 
         final feedItemEntity =
-            ref.watch(ionConnectEntityWithCountersProvider(eventReference: eventReference));
+            ref.watch(ionConnectSyncEntityWithCountersProvider(eventReference: eventReference));
 
         final feedItemEventMessage = await switch (feedItemEntity) {
           final ModifiablePostEntity entity => entity.toEntityEventMessage(),

--- a/lib/app/features/chat/views/pages/share_via_message_modal/components/share_send_button.dart
+++ b/lib/app/features/chat/views/pages/share_via_message_modal/components/share_send_button.dart
@@ -68,7 +68,7 @@ class ShareSendButton extends HookConsumerWidget {
             loading.value = true;
             try {
               final entity =
-                  ref.read(ionConnectEntityWithCountersProvider(eventReference: eventReference));
+                  ref.read(ionConnectSyncEntityWithCountersProvider(eventReference: eventReference));
 
               if (entity is UserMetadataEntity) {
                 unawaited(shareProfileToChat());

--- a/lib/app/features/components/entities_list/components/repost_list_item.dart
+++ b/lib/app/features/components/entities_list/components/repost_list_item.dart
@@ -30,7 +30,7 @@ class RepostListItem extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final repostEntity =
-        ref.watch(ionConnectEntityWithCountersProvider(eventReference: eventReference));
+        ref.watch(ionConnectSyncEntityWithCountersProvider(eventReference: eventReference));
 
     if (repostEntity == null) {
       return const Skeleton(child: PostSkeleton());

--- a/lib/app/features/components/entities_list/entities_list.dart
+++ b/lib/app/features/components/entities_list/entities_list.dart
@@ -117,7 +117,7 @@ class _EntityListItem extends ConsumerWidget {
   bool _isRepostedEntityDeleted(WidgetRef ref, IonConnectEntity entity) {
     if (entity is GenericRepostEntity) {
       final repostedEntity = ref
-          .watch(ionConnectEntityWithCountersProvider(eventReference: entity.data.eventReference));
+          .watch(ionConnectSyncEntityWithCountersProvider(eventReference: entity.data.eventReference));
       return repostedEntity == null ||
           (repostedEntity is SoftDeletableEntity && repostedEntity.isDeleted);
     }

--- a/lib/app/features/feed/create_post/views/pages/post_form_modal/components/parent_entity.dart
+++ b/lib/app/features/feed/create_post/views/pages/post_form_modal/components/parent_entity.dart
@@ -30,7 +30,7 @@ class ParentEntity extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final parentEntity =
-        ref.watch(ionConnectEntityWithCountersProvider(eventReference: eventReference));
+        ref.watch(ionConnectSyncEntityWithCountersProvider(eventReference: eventReference));
     final userMetadata = ref.watch(userMetadataProvider(eventReference.masterPubkey)).valueOrNull;
 
     if (parentEntity == null || userMetadata == null) {

--- a/lib/app/features/feed/create_post/views/pages/post_form_modal/components/quoted_entity.dart
+++ b/lib/app/features/feed/create_post/views/pages/post_form_modal/components/quoted_entity.dart
@@ -27,7 +27,7 @@ class QuotedEntity extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final ionConnectEntity =
-        ref.watch(ionConnectEntityWithCountersProvider(eventReference: eventReference));
+        ref.watch(ionConnectSyncEntityWithCountersProvider(eventReference: eventReference));
 
     if (ionConnectEntity == null) {
       return const Skeleton(child: PostSkeleton());

--- a/lib/app/features/feed/notifications/views/notifications_history_page/components/notification_item/notification_info.dart
+++ b/lib/app/features/feed/notifications/views/notifications_history_page/components/notification_item/notification_info.dart
@@ -147,7 +147,7 @@ class NotificationInfo extends HookConsumerWidget {
       return null;
     }
 
-    final entity = ref.watch(ionConnectEntityWithCountersProvider(eventReference: eventReference));
+    final entity = ref.watch(ionConnectSyncEntityWithCountersProvider(eventReference: eventReference));
 
     if (entity == null) {
       return null;
@@ -167,7 +167,7 @@ class NotificationInfo extends HookConsumerWidget {
 
       if (relatedEventReference != null) {
         return ref
-            .watch(ionConnectEntityWithCountersProvider(eventReference: relatedEventReference));
+            .watch(ionConnectSyncEntityWithCountersProvider(eventReference: relatedEventReference));
       }
     }
 

--- a/lib/app/features/feed/notifications/views/notifications_history_page/components/notification_item/notification_item.dart
+++ b/lib/app/features/feed/notifications/views/notifications_history_page/components/notification_item/notification_item.dart
@@ -37,7 +37,7 @@ class NotificationItem extends ConsumerWidget {
     IonConnectEntity? entity;
 
     if (eventReference != null) {
-      entity = ref.watch(ionConnectEntityWithCountersProvider(eventReference: eventReference));
+      entity = ref.watch(ionConnectSyncEntityWithCountersProvider(eventReference: eventReference));
       if (entity == null || _isDeleted(ref, entity) || _isRepostedEntityDeleted(ref, entity)) {
         return const SizedBox.shrink();
       }
@@ -101,7 +101,7 @@ class NotificationItem extends ConsumerWidget {
   bool _isRepostedEntityDeleted(WidgetRef ref, IonConnectEntity entity) {
     if (entity is GenericRepostEntity) {
       final repostedEntity = ref
-          .watch(ionConnectEntityWithCountersProvider(eventReference: entity.data.eventReference));
+          .watch(ionConnectSyncEntityWithCountersProvider(eventReference: entity.data.eventReference));
       return repostedEntity == null ||
           (repostedEntity is SoftDeletableEntity && repostedEntity.isDeleted);
     }

--- a/lib/app/features/feed/providers/feed_posts_provider.r.dart
+++ b/lib/app/features/feed/providers/feed_posts_provider.r.dart
@@ -138,5 +138,5 @@ IonConnectEntity? getRepostedEntity(Ref ref, IonConnectEntity entity) {
     repostedEventReference = entity.data.eventReference;
   }
   if (repostedEventReference == null) return null;
-  return ref.read(ionConnectEntityWithCountersProvider(eventReference: repostedEventReference));
+  return ref.read(ionConnectSyncEntityWithCountersProvider(eventReference: repostedEventReference));
 }

--- a/lib/app/features/feed/providers/ion_connect_entity_with_counters_provider.r.dart
+++ b/lib/app/features/feed/providers/ion_connect_entity_with_counters_provider.r.dart
@@ -4,19 +4,17 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/exceptions/exceptions.dart';
 import 'package:ion/app/features/auth/providers/auth_provider.m.dart';
 import 'package:ion/app/features/feed/data/models/entities/article_data.f.dart';
-import 'package:ion/app/features/feed/data/models/entities/event_count_result_data.f.dart';
 import 'package:ion/app/features/feed/data/models/entities/modifiable_post_data.f.dart';
 import 'package:ion/app/features/ion_connect/model/event_reference.f.dart';
 import 'package:ion/app/features/ion_connect/model/ion_connect_entity.dart';
 import 'package:ion/app/features/ion_connect/model/search_extension.dart';
-import 'package:ion/app/features/ion_connect/providers/ion_connect_cache.r.dart';
 import 'package:ion/app/features/ion_connect/providers/ion_connect_entity_provider.r.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'ion_connect_entity_with_counters_provider.r.g.dart';
 
 @riverpod
-IonConnectEntity? ionConnectEntityWithCounters(
+IonConnectEntity? ionConnectSyncEntityWithCounters(
   Ref ref, {
   required EventReference eventReference,
   bool network = true,
@@ -46,23 +44,6 @@ IonConnectEntity? ionConnectEntityWithCounters(
     ).extensions,
   ]).toString();
 
-  final hasCounterData = ref.read(ionConnectCacheProvider).containsKey(
-    EventCountResultEntity.cacheKeyBuilder(
-      key: eventReference.toString(),
-      type: EventCountResultType.reactions,
-    ),
-  );
-
-  if (!hasCounterData && network) {
-    return ref.watch(
-      ionConnectSyncEntityProvider(
-        eventReference: eventReference,
-        search: search,
-        cache: false, 
-      ),
-    );
-  }
-
   return ref.watch(
     ionConnectSyncEntityProvider(
       eventReference: eventReference,
@@ -70,5 +51,46 @@ IonConnectEntity? ionConnectEntityWithCounters(
       network: network,
       cache: cache,
     ),
+  );
+}
+
+@riverpod
+Future<IonConnectEntity?> ionConnectEntityWithCounters(
+  Ref ref, {
+  required EventReference eventReference,
+  bool network = true,
+  bool cache = true,
+}) async {
+  final currentUser = ref.watch(currentIdentityKeyNameSelectorProvider);
+  if (currentUser == null) {
+    throw const CurrentUserNotFoundException();
+  }
+
+  // Do not query counters and deps if the entity if not a post or article (e.g. a repost)
+  if (eventReference is! ReplaceableEventReference ||
+      (eventReference.kind != ModifiablePostEntity.kind &&
+          eventReference.kind != ArticleEntity.kind)) {
+    return ref.watch(ionConnectEntityProvider(eventReference: eventReference).future);
+  }
+
+  final currentUserPubkey = ref.watch(currentPubkeySelectorProvider);
+  if (currentUserPubkey == null) {
+    throw const CurrentUserNotFoundException();
+  }
+
+  final search = SearchExtensions([
+    ...SearchExtensions.withCounters(
+      currentPubkey: currentUserPubkey,
+      forKind: eventReference.kind,
+    ).extensions,
+  ]).toString();
+
+  return ref.watch(
+    ionConnectEntityProvider(
+      eventReference: eventReference,
+      search: search,
+      network: network,
+      cache: cache,
+    ).future,
   );
 }

--- a/lib/app/features/feed/views/components/article/article.dart
+++ b/lib/app/features/feed/views/components/article/article.dart
@@ -77,7 +77,7 @@ class Article extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final entity = ref.watch(ionConnectEntityWithCountersProvider(eventReference: eventReference));
+    final entity = ref.watch(ionConnectSyncEntityWithCountersProvider(eventReference: eventReference));
 
     if (entity is! ArticleEntity) {
       return Padding(

--- a/lib/app/features/feed/views/components/article/article_title.dart
+++ b/lib/app/features/feed/views/components/article/article_title.dart
@@ -16,7 +16,7 @@ class ArticleTitle extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final entity = ref.watch(ionConnectEntityWithCountersProvider(eventReference: eventReference));
+    final entity = ref.watch(ionConnectSyncEntityWithCountersProvider(eventReference: eventReference));
 
     if (entity is! ArticleEntity) {
       return const SizedBox.shrink();

--- a/lib/app/features/feed/views/components/post/post.dart
+++ b/lib/app/features/feed/views/components/post/post.dart
@@ -69,7 +69,7 @@ class Post extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final entity = ref.watch(ionConnectEntityWithCountersProvider(eventReference: eventReference));
+    final entity = ref.watch(ionConnectSyncEntityWithCountersProvider(eventReference: eventReference));
 
     if (entity == null) {
       return ScreenSideOffset.small(
@@ -261,7 +261,7 @@ final class _FramedEvent extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final entity = ref.watch(ionConnectEntityWithCountersProvider(eventReference: eventReference));
+    final entity = ref.watch(ionConnectSyncEntityWithCountersProvider(eventReference: eventReference));
     Widget? deletedEntity;
 
     if (entity is ModifiablePostEntity && entity.isDeleted) {
@@ -332,7 +332,7 @@ final class _QuotedPost extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final postEntity =
-        ref.watch(ionConnectEntityWithCountersProvider(eventReference: eventReference));
+        ref.watch(ionConnectSyncEntityWithCountersProvider(eventReference: eventReference));
 
     return QuotedEntityFrame.post(
       child: GestureDetector(

--- a/lib/app/features/feed/views/pages/article_details_page/article_details_page.dart
+++ b/lib/app/features/feed/views/pages/article_details_page/article_details_page.dart
@@ -42,7 +42,7 @@ class ArticleDetailsPage extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final articleEntity =
-        ref.watch(ionConnectEntityWithCountersProvider(eventReference: eventReference));
+        ref.watch(ionConnectSyncEntityWithCountersProvider(eventReference: eventReference));
     final isOwnedByCurrentUser =
         ref.watch(isCurrentUserSelectorProvider(eventReference.masterPubkey));
 

--- a/lib/app/features/feed/views/pages/article_details_page/components/articles_carousel_item.dart
+++ b/lib/app/features/feed/views/pages/article_details_page/components/articles_carousel_item.dart
@@ -21,7 +21,7 @@ class ArticlesCarouselItem extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final article = ref.watch(ionConnectEntityWithCountersProvider(eventReference: eventReference));
+    final article = ref.watch(ionConnectSyncEntityWithCountersProvider(eventReference: eventReference));
 
     if (article is! ArticleEntity || article.isDeleted) {
       return const SizedBox.shrink();

--- a/lib/app/features/video/views/pages/feed_videos_page.dart
+++ b/lib/app/features/video/views/pages/feed_videos_page.dart
@@ -22,7 +22,7 @@ class FeedVideosPage extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final video = ref.watch(ionConnectEntityWithCountersProvider(eventReference: eventReference));
+    final video = ref.watch(ionConnectSyncEntityWithCountersProvider(eventReference: eventReference));
     final entities = <IonConnectEntity>[
       if (video != null) video,
       ...ref.watch(feedVideosProvider.select((state) => state.items ?? {})),

--- a/lib/app/features/video/views/pages/videos_vertical_scroll_page.dart
+++ b/lib/app/features/video/views/pages/videos_vertical_scroll_page.dart
@@ -70,7 +70,7 @@ class VideosVerticalScrollPage extends HookConsumerWidget {
     final animationDuration = 100.ms;
 
     final ionConnectEntity =
-        ref.watch(ionConnectEntityWithCountersProvider(eventReference: eventReference));
+        ref.watch(ionConnectSyncEntityWithCountersProvider(eventReference: eventReference));
 
     if (ionConnectEntity == null ||
         (ionConnectEntity is! ModifiablePostEntity && ionConnectEntity is! PostEntity)) {

--- a/lib/app/services/deep_link/deep_link_service.r.dart
+++ b/lib/app/services/deep_link/deep_link_service.r.dart
@@ -15,9 +15,9 @@ import 'package:ion/app/features/core/providers/env_provider.r.dart';
 import 'package:ion/app/features/core/providers/splash_provider.r.dart';
 import 'package:ion/app/features/feed/data/models/entities/article_data.f.dart';
 import 'package:ion/app/features/feed/data/models/entities/modifiable_post_data.f.dart';
+import 'package:ion/app/features/feed/providers/ion_connect_entity_with_counters_provider.r.dart';
 import 'package:ion/app/features/ion_connect/model/event_reference.f.dart';
 import 'package:ion/app/features/ion_connect/providers/ion_connect_db_cache_notifier.r.dart';
-import 'package:ion/app/features/ion_connect/providers/ion_connect_entity_provider.r.dart';
 import 'package:ion/app/features/user/model/user_metadata.f.dart';
 import 'package:ion/app/features/user/model/user_relays.f.dart';
 import 'package:ion/app/router/app_routes.gr.dart';
@@ -101,7 +101,7 @@ Future<void> deeplinkInitializer(Ref ref) async {
     EventReference eventReference,
     String encodedEventReference,
   ) async {
-    final entity = await ref.read(ionConnectEntityProvider(eventReference: eventReference).future);
+    final entity = await ref.read(ionConnectEntityWithCountersProvider(eventReference: eventReference).future);
 
     if (entity is ModifiablePostEntity) {
       if (entity.isStory) {


### PR DESCRIPTION
## Description
- made 2 versions of ion_connect_entity_with_counters_provider: one is sync, another one is async.
- change affects only deeplink service

## Task ID
ION-3677

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)


https://github.com/user-attachments/assets/cf02cdb5-6224-4368-a973-f1c062df3866

