### PR TITLE
fix: avoid unnecessary rebuilds in reposts provider

### DIFF
--- a/lib/app/features/feed/reposts/models/post_repost.f.dart
+++ b/lib/app/features/feed/reposts/models/post_repost.f.dart
@@ -2,6 +2,7 @@
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:ion/app/features/ion_connect/model/event_reference.f.dart';
+import 'package:ion/app/features/ion_connect/providers/ion_connect_cache.r.dart';
 import 'package:ion/app/features/optimistic_ui/core/optimistic_model.dart';
 
 part 'post_repost.f.freezed.dart';
@@ -28,4 +29,11 @@ class PostRepost with _$PostRepost implements OptimisticModel {
     // If user has reposted but total is 0, return 1 to maintain UI consistency
     return (repostedByMe && total == 0) ? 1 : total;
   }
+}
+
+@freezed
+class RepostEntities with _$RepostEntities {
+  const factory RepostEntities({
+    required List<CacheableEntity> items,
+  }) = _RepostEntities;
 }

--- a/lib/app/features/feed/reposts/providers/optimistic/post_repost_provider.r.dart
+++ b/lib/app/features/feed/reposts/providers/optimistic/post_repost_provider.r.dart
@@ -75,16 +75,23 @@ List<PostRepost> loadRepostsFromCache(Ref ref) {
     manager.snapshot.map((pr) => MapEntry(pr.eventReference, pr)),
   );
 
-  final allEntities = ref.watch(ionConnectCacheProvider).values.map((e) => e.entity).toList();
+  final repostEntities = ref.watch(
+    ionConnectCacheProvider.select(
+      (result) {
+        final allEntities = result.values.map((e) => e.entity).toList();
+        final reposts = allEntities
+            .where((entity) => entity.masterPubkey == currentPubkey)
+            .where((entity) => entity is RepostEntity || entity is GenericRepostEntity)
+            .toList();
 
-  final repostEntities = allEntities
-      .where((entity) => entity.masterPubkey == currentPubkey)
-      .where((entity) => entity is RepostEntity || entity is GenericRepostEntity)
-      .toList();
+        return RepostEntities(items: reposts);
+      },
+    ),
+  );
 
   final postReposts = <PostRepost>[];
 
-  for (final entity in repostEntities) {
+  for (final entity in repostEntities.items) {
     final eventReference = entity is RepostEntity
         ? entity.data.eventReference
         : (entity as GenericRepostEntity).data.eventReference;


### PR DESCRIPTION
## Description
The issue with post repost provider was that it was watching ionConnectCacheProvider and rebuilding on any change in it

## Additional Notes
Rebuild rate dropped from 1000+ to 2. Solution is not really beautiful though.

## Task ID
ION-3502

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

