### PR TITLE
fix: remove unnecesary duplicate context menu button on profile page, set correct height of the button to not overflow the app bar

### DIFF
--- a/lib/app/features/user/pages/profile_page/profile_page.dart
+++ b/lib/app/features/user/pages/profile_page/profile_page.dart
@@ -12,7 +12,6 @@ import 'package:ion/app/features/feed/data/models/entities/event_count_result_da
 import 'package:ion/app/features/ion_connect/providers/ion_connect_cache.r.dart';
 import 'package:ion/app/features/user/model/tab_entity_type.dart';
 import 'package:ion/app/features/user/model/user_content_type.dart';
-import 'package:ion/app/features/user/pages/components/header_action/header_action.dart';
 import 'package:ion/app/features/user/pages/components/profile_avatar/profile_avatar.dart';
 import 'package:ion/app/features/user/pages/profile_page/cant_find_profile_page.dart';
 import 'package:ion/app/features/user/pages/profile_page/components/header/header.dart';
@@ -167,16 +166,6 @@ class ProfilePage extends HookConsumerWidget {
                   pubkey: pubkey,
                   showBackButton: !isCurrentUserProfile,
                 ),
-                actions: [
-                  SizedBox(width: 12.0.s),
-                  Padding(
-                    padding: EdgeInsetsDirectional.only(end: 16.s),
-                    child: SizedBox(
-                      height: HeaderAction.buttonSize,
-                      child: ProfileContextMenu(pubkey: pubkey),
-                    ),
-                  ),
-                ],
               ),
             ),
             Align(
@@ -184,7 +173,7 @@ class ProfilePage extends HookConsumerWidget {
               child: Padding(
                 padding: EdgeInsetsDirectional.only(end: 16.s),
                 child: SizedBox(
-                  height: HeaderAction.buttonSize,
+                  height: NavigationAppBar.screenHeaderHeight,
                   child: ProfileContextMenu(pubkey: pubkey),
                 ),
               ),


### PR DESCRIPTION


## Description
<!-- Briefly explain the purpose of this PR and what it accomplishes. -->

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
3749

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<img width="1118" height="2124" alt="ScreenShot 2025-08-28 at 13 25 10@2x" src="https://github.com/user-attachments/assets/80c3acc0-3bbb-423c-8af5-2a67189adb7b" />

