### PR TITLE
chore: no exception on user validation cancel

### DIFF
--- a/lib/app/features/auth/providers/login_action_notifier.r.dart
+++ b/lib/app/features/auth/providers/login_action_notifier.r.dart
@@ -43,8 +43,6 @@ class LoginActionNotifier extends _$LoginActionNotifier {
               twoFATypes: twoFATypes,
               localCredsOnly: localCredsOnly,
             );
-      } on PasskeyCancelledException {
-        return;
       } on NoLocalPasskeyCredsFoundIONIdentityException {
         // Are we trying to suggest a passkey for empty identity key name?
         // If yes, and there're no local creds, do nothing

--- a/lib/app/features/auth/views/pages/get_started/components/login_form.dart
+++ b/lib/app/features/auth/views/pages/get_started/components/login_form.dart
@@ -34,8 +34,9 @@ class LoginForm extends HookConsumerWidget {
         children: [
           IdentityKeyNameInput(
             errorText: switch (loginActionState.error) {
+              final PasskeyCancelledException _ => null,
               final IONIdentityException identityException => identityException.title(context),
-              _ => loginActionState.error?.toString()
+              _ => loginActionState.error?.toString(),
             },
             controller: identityKeyNameController,
             scrollPadding: EdgeInsetsDirectional.only(bottom: 88.0.s),

--- a/lib/app/features/auth/views/pages/get_started/components/sign_in_step.dart
+++ b/lib/app/features/auth/views/pages/get_started/components/sign_in_step.dart
@@ -229,7 +229,9 @@ class SignInStep extends HookConsumerWidget {
               localCredsOnly: false,
               twoFaTypes: twoFAOptions.value,
             );
-            await onSuggestToCreatePasskeyCreds(username);
+            if (ref.context.mounted && !ref.read(loginActionNotifierProvider).hasError) {
+              await onSuggestToCreatePasskeyCreds(username);
+            }
           }
         }
       } else if (loginPassword != null) {

--- a/lib/app/features/auth/views/pages/sign_up_passkey/sign_up_passkey_form.dart
+++ b/lib/app/features/auth/views/pages/sign_up_passkey/sign_up_passkey_form.dart
@@ -47,6 +47,7 @@ class SignUpPasskeyForm extends HookConsumerWidget {
         children: [
           IdentityKeyNameInput(
             errorText: switch (registerActionState.error) {
+              final PasskeyCancelledException _ => null,
               final IONIdentityException identityException => identityException.title(context),
               _ => registerActionState.error?.toString()
             },

--- a/packages/ion_identity_client/lib/src/signer/passkey_signer.dart
+++ b/packages/ion_identity_client/lib/src/signer/passkey_signer.dart
@@ -134,7 +134,6 @@ class PasskeysSigner {
         localCredsOnly: localCredsOnly,
       );
     } on NoCredentialsAvailableException {
-      // final assertionRequestData = await sign(challenge);
       if (localCredsOnly) {
         await localPasskeyCredsStateStorage.updateLocalPasskeyCredsState(
           username: username,
@@ -142,7 +141,6 @@ class PasskeysSigner {
         );
       }
       throw const NoLocalPasskeyCredsFoundIONIdentityException();
-      // return assertionRequestData;
     } on PasskeyAuthCancelledException {
       throw const PasskeyCancelledException();
     }
@@ -191,6 +189,12 @@ class PasskeysSigner {
       rethrow;
     } on PasskeyAuthCancelledException {
       throw const PasskeyCancelledException();
+    } on UnhandledAuthenticatorException catch (e) {
+      final msg = (e.message ?? '').toLowerCase();
+      if (msg.contains('cancel') && msg.contains('user')) {
+        throw const PasskeyCancelledException();
+      }
+      throw const PasskeyValidationException();
     } catch (e) {
       throw const PasskeyValidationException();
     }


### PR DESCRIPTION
## Description
- No popup with exception when user cancels passkey verification during sign in with another device flow;

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [x] Chore

## Screenshots (if applicable)


https://github.com/user-attachments/assets/b159973e-89ba-4f08-a9dc-1e5d7d606e7e

