### PR TITLE
feat(account): skip phone number countries from remote config for 2fa

### DIFF
--- a/lib/app/features/protect_account/phone/provider/country_provider.r.dart
+++ b/lib/app/features/protect_account/phone/provider/country_provider.r.dart
@@ -5,12 +5,23 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/constants/countries.f.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/core/providers/app_locale_provider.r.dart';
+import 'package:ion/app/features/protect_account/phone/provider/skip_countries_provider.r.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'country_provider.r.g.dart';
 
 @riverpod
-List<Country> countries(Ref ref) => countriesData;
+List<Country> countries(Ref ref) {
+  final skipIsoSet = ref.watch(skipCountriesIsoSetProvider).valueOrNull;
+  if (skipIsoSet == null || skipIsoSet.isEmpty) {
+    return countriesData;
+  }
+  return countriesData
+      .whereNot(
+        (c) => skipIsoSet.contains(c.isoCode.toUpperCase()),
+      )
+      .toList();
+}
 
 @riverpod
 class SelectedCountry extends _$SelectedCountry {

--- a/lib/app/features/protect_account/phone/provider/skip_countries_provider.r.dart
+++ b/lib/app/features/protect_account/phone/provider/skip_countries_provider.r.dart
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'dart:convert';
+
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:ion/app/features/config/data/models/app_config_cache_strategy.dart';
+import 'package:ion/app/features/config/providers/config_repository.r.dart';
+import 'package:ion/app/services/logger/logger.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'skip_countries_provider.r.g.dart';
+
+const _skipCountriesKey = 'blacklisted_countries_phone2fa';
+
+/// Remote config that returns a list of ISO country codes to skip/hide.
+/// Expected payload example: ["IR", "KP"]
+@riverpod
+Future<Set<String>> skipCountriesIsoSet(Ref ref) async {
+  try {
+    final repo = await ref.watch(configRepositoryProvider.future);
+    final result = await repo.getConfig<List<String>>(
+      _skipCountriesKey,
+      cacheStrategy: AppConfigCacheStrategy.localStorage,
+      parser: (data) => (jsonDecode(data) as List<dynamic>).cast<String>(),
+      checkVersion: true,
+    );
+
+    return result.map((e) => e.toUpperCase()).toSet();
+  } catch (error, stackTrace) {
+    Logger.error(
+      error,
+      stackTrace: stackTrace,
+      message: 'Failed to load phone skip countries config',
+    );
+    return <String>{};
+  }
+}


### PR DESCRIPTION
## Description
We want to be able to exclude some countries from the 2FA phone setup list. To do this, we want to get a remote config values.

- Added `skipCountriesIsoSet` provider
- Updated `countries` provider

## Task ID
ION-3458

## Type of Change
- [x] New feature

## Screenshots
<img width="350" alt="image" src="https://github.com/user-attachments/assets/3ebd4c86-033f-4e9a-8fb9-768a2cf3e826" />
