### PR TITLE
fix: backup success checkmark shown on cancelled operation

### DIFF
--- a/lib/app/features/protect_account/backup/providers/create_recovery_key_action_notifier.r.dart
+++ b/lib/app/features/protect_account/backup/providers/create_recovery_key_action_notifier.r.dart
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:ion/app/features/auth/providers/auth_provider.m.dart';
-import 'package:ion/app/features/protect_account/secure_account/providers/recovery_credentials_enabled_notifier.r.dart';
 import 'package:ion/app/services/ion_identity/ion_identity_provider.r.dart';
 import 'package:ion_identity_client/ion_identity.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -31,7 +30,6 @@ class CreateRecoveryKeyActionNotifier extends _$CreateRecoveryKeyActionNotifier 
         final response = await ionIdentity(username: selectedUser)
             .auth
             .createRecoveryCredentials(onVerifyIdentity);
-        ref.read(recoveryCredentialsEnabledProvider.notifier).setEnabled();
         return response;
       } on PasskeyCancelledException {
         return null;

--- a/lib/app/features/protect_account/backup/views/pages/backup_with_cloud_page/components/backup_with_cloud_password_input_body.dart
+++ b/lib/app/features/protect_account/backup/views/pages/backup_with_cloud_page/components/backup_with_cloud_password_input_body.dart
@@ -14,6 +14,7 @@ import 'package:ion/app/features/components/verify_identity/components/password_
 import 'package:ion/app/features/protect_account/backup/providers/cloud_stored_recovery_keys_names_provider.r.dart';
 import 'package:ion/app/features/protect_account/backup/providers/create_recovery_key_action_notifier.r.dart';
 import 'package:ion/app/features/protect_account/backup/providers/recovery_key_cloud_backup_notifier.r.dart';
+import 'package:ion/app/features/protect_account/secure_account/providers/recovery_credentials_enabled_notifier.r.dart';
 import 'package:ion/app/router/app_routes.gr.dart';
 
 final class BackupWithCloudPasswordInputBody extends HookConsumerWidget {
@@ -123,6 +124,7 @@ final class BackupWithCloudPasswordInputBody extends HookConsumerWidget {
                         );
                     final state = ref.read(recoveryKeyCloudBackupNotifierProvider);
                     if (!state.hasError && context.mounted) {
+                      ref.read(recoveryCredentialsEnabledProvider.notifier).setEnabled();
                       ref.invalidate(cloudStoredRecoveryKeysNamesProvider);
                       await BackupWithCloudSuccessRoute().push<void>(context);
                     }

--- a/lib/app/features/protect_account/backup/views/pages/validate_recovery_key_page.dart
+++ b/lib/app/features/protect_account/backup/views/pages/validate_recovery_key_page.dart
@@ -5,6 +5,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/features/auth/views/components/recovery_keys_input_container/recovery_keys_input_container.dart';
 import 'package:ion/app/features/protect_account/backup/data/models/recovery_key_property.dart';
 import 'package:ion/app/features/protect_account/backup/providers/create_recovery_key_action_notifier.r.dart';
+import 'package:ion/app/features/protect_account/secure_account/providers/recovery_credentials_enabled_notifier.r.dart';
 import 'package:ion/app/router/app_routes.gr.dart';
 import 'package:ion_identity_client/ion_identity.dart';
 
@@ -17,7 +18,10 @@ class ValidateRecoveryKeyPage extends ConsumerWidget {
 
     return RecoveryKeysInputContainer(
       validator: (value, property) => _validateProperty(value, property, recoveryResult!),
-      onContinuePressed: (_, __, ___) => RecoveryKeysSuccessRoute().push<void>(context),
+      onContinuePressed: (_, __, ___) {
+        ref.read(recoveryCredentialsEnabledProvider.notifier).setEnabled();
+        RecoveryKeysSuccessRoute().push<void>(context);
+      },
     );
   }
 


### PR DESCRIPTION
## Description
  - Previously, the recovery credentials were marked as enabled as soon as they were created
  - Now, they are only marked as enabled after the user completes the entire backup flow
  - If the user cancels at any point (like pressing back on the password setup page), the
  indicator won't be incorrectly shown as enabled

## Task ID
ION-3745

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
