### PR TITLE
feat: navigate to post details on reply tap on media full screen page

### DIFF
--- a/lib/app/components/counter_items_footer/counter_items_footer.dart
+++ b/lib/app/components/counter_items_footer/counter_items_footer.dart
@@ -17,6 +17,7 @@ class CounterItemsFooter extends HookConsumerWidget {
     this.itemPadding,
     this.sidePadding,
     this.color,
+    this.onReplyTap,
     super.key,
   });
 
@@ -24,6 +25,7 @@ class CounterItemsFooter extends HookConsumerWidget {
   final EdgeInsetsDirectional? itemPadding;
   final double? sidePadding;
   final Color? color;
+  final VoidCallback? onReplyTap;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -40,6 +42,7 @@ class CounterItemsFooter extends HookConsumerWidget {
             eventReference: eventReference,
             padding: itemPadding + EdgeInsetsDirectional.symmetric(horizontal: sidePadding),
             color: color,
+            onTap: onReplyTap,
           ),
         ),
         Center(

--- a/lib/app/components/counter_items_footer/replies_counter_button.dart
+++ b/lib/app/components/counter_items_footer/replies_counter_button.dart
@@ -23,12 +23,14 @@ class RepliesCounterButton extends HookConsumerWidget {
     required this.eventReference,
     this.color,
     this.padding,
+    this.onTap,
     super.key,
   });
 
   final EventReference eventReference;
   final Color? color;
   final EdgeInsetsGeometry? padding;
+  final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -40,6 +42,10 @@ class RepliesCounterButton extends HookConsumerWidget {
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
       onTap: () async {
+        if (onTap case final onTap?) {
+          onTap();
+          return;
+        }
         if (isLoading.value) {
           return;
         }

--- a/lib/app/features/feed/views/pages/fullscreen_media/components/media_carousel.dart
+++ b/lib/app/features/feed/views/pages/fullscreen_media/components/media_carousel.dart
@@ -7,6 +7,9 @@ import 'package:ion/app/components/counter_items_footer/counter_items_footer.dar
 import 'package:ion/app/components/progress_bar/centered_loading_indicator.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/core/model/media_type.dart';
+import 'package:ion/app/features/feed/data/models/entities/article_data.f.dart';
+import 'package:ion/app/features/feed/data/models/entities/modifiable_post_data.f.dart';
+import 'package:ion/app/features/feed/data/models/entities/post_data.f.dart';
 import 'package:ion/app/features/feed/views/components/feed_network_image/feed_network_image.dart';
 import 'package:ion/app/features/feed/views/pages/fullscreen_media/hooks/use_image_zoom.dart';
 import 'package:ion/app/features/feed/views/pages/fullscreen_media/providers/image_zoom_provider.r.dart';
@@ -16,6 +19,7 @@ import 'package:ion/app/features/ion_connect/model/media_attachment.dart';
 import 'package:ion/app/features/video/views/components/video_actions.dart';
 import 'package:ion/app/features/video/views/components/video_post_info.dart';
 import 'package:ion/app/features/video/views/pages/video_page.dart';
+import 'package:ion/app/router/app_routes.gr.dart';
 
 class MediaCarousel extends HookConsumerWidget {
   const MediaCarousel({
@@ -77,7 +81,10 @@ class MediaCarousel extends HookConsumerWidget {
               return VideoPage(
                 key: ValueKey('video_${mediaItem.url}'),
                 videoInfo: VideoPostInfo(videoPost: entity),
-                bottomOverlay: VideoActions(eventReference: eventReference),
+                bottomOverlay: VideoActions(
+                  eventReference: eventReference,
+                  onReplyTap: () => _onReplyTap(context),
+                ),
                 videoUrl: mediaItem.url,
                 authorPubkey: eventReference.masterPubkey,
                 thumbnailUrl: mediaItem.thumb,
@@ -106,12 +113,21 @@ class MediaCarousel extends HookConsumerWidget {
               child: CounterItemsFooter(
                 eventReference: eventReference,
                 color: onPrimaryAccentColor,
+                onReplyTap: () => _onReplyTap(context),
               ),
             ),
           ),
         ),
       ],
     );
+  }
+
+  void _onReplyTap(BuildContext context) {
+    if (entity is ModifiablePostEntity || entity is PostEntity) {
+      PostDetailsRoute(eventReference: eventReference.encode()).push<void>(context);
+    } else if (entity is ArticleEntity) {
+      ArticleDetailsRoute(eventReference: eventReference.encode()).push<void>(context);
+    }
   }
 }
 

--- a/lib/app/features/feed/views/pages/fullscreen_media/components/single_media_view.dart
+++ b/lib/app/features/feed/views/pages/fullscreen_media/components/single_media_view.dart
@@ -15,6 +15,7 @@ import 'package:ion/app/features/video/views/components/video_actions.dart';
 import 'package:ion/app/features/video/views/components/video_post_info.dart';
 import 'package:ion/app/features/video/views/hooks/use_wake_lock.dart';
 import 'package:ion/app/features/video/views/pages/video_page.dart';
+import 'package:ion/app/router/app_routes.gr.dart';
 
 class SingleMediaView extends HookWidget {
   const SingleMediaView({
@@ -43,7 +44,10 @@ class SingleMediaView extends HookWidget {
       final entity = (post ?? article!) as IonConnectEntity;
       return VideoPage(
         videoInfo: VideoPostInfo(videoPost: entity),
-        bottomOverlay: VideoActions(eventReference: eventReference),
+        bottomOverlay: VideoActions(
+          eventReference: eventReference,
+          onReplyTap: () => _onReplyTap(context),
+        ),
         videoUrl: media.url,
         authorPubkey: eventReference.masterPubkey,
         thumbnailUrl: media.thumb,
@@ -66,10 +70,19 @@ class SingleMediaView extends HookWidget {
               eventReference: eventReference,
               color: onPrimaryAccentColor,
               itemPadding: EdgeInsetsDirectional.symmetric(vertical: 12.0.s),
+              onReplyTap: () => _onReplyTap(context),
             ),
           ),
         ),
       ),
     );
+  }
+
+  void _onReplyTap(BuildContext context) {
+    if (post != null) {
+      PostDetailsRoute(eventReference: eventReference.encode()).push<void>(context);
+    } else if (article != null) {
+      ArticleDetailsRoute(eventReference: eventReference.encode()).push<void>(context);
+    }
   }
 }

--- a/lib/app/features/video/views/components/video_actions.dart
+++ b/lib/app/features/video/views/components/video_actions.dart
@@ -8,10 +8,12 @@ import 'package:ion/app/features/ion_connect/model/event_reference.f.dart';
 class VideoActions extends StatelessWidget {
   const VideoActions({
     required this.eventReference,
+    this.onReplyTap,
     super.key,
   });
 
   final EventReference eventReference;
+  final VoidCallback? onReplyTap;
 
   @override
   Widget build(BuildContext context) {
@@ -24,6 +26,7 @@ class VideoActions extends StatelessWidget {
         ),
         eventReference: eventReference,
         color: context.theme.appColors.secondaryBackground,
+        onReplyTap: onReplyTap,
       ),
     );
   }

--- a/lib/app/features/video/views/pages/videos_vertical_scroll_page.dart
+++ b/lib/app/features/video/views/pages/videos_vertical_scroll_page.dart
@@ -26,6 +26,7 @@ import 'package:ion/app/features/video/views/hooks/use_status_bar_color.dart';
 import 'package:ion/app/features/video/views/hooks/use_wake_lock.dart';
 import 'package:ion/app/features/video/views/pages/video_page.dart';
 import 'package:ion/app/hooks/use_on_init.dart';
+import 'package:ion/app/router/app_routes.gr.dart';
 import 'package:ion/app/router/components/navigation_app_bar/navigation_app_bar.dart';
 import 'package:ion/app/router/components/navigation_app_bar/navigation_back_button.dart';
 import 'package:ion/generated/assets.gen.dart';
@@ -208,8 +209,10 @@ class VideosVerticalScrollPage extends HookConsumerWidget {
             },
             itemBuilder: (_, index) => VideoPage(
               videoInfo: VideoPostInfo(videoPost: flattenedVideos[index].entity),
-              bottomOverlay:
-                  VideoActions(eventReference: flattenedVideos[index].entity.toEventReference()),
+              bottomOverlay: VideoActions(
+                eventReference: flattenedVideos[index].entity.toEventReference(),
+                onReplyTap: () => PostDetailsRoute(eventReference: eventReference.encode()).push<void>(context),
+              ),
               videoUrl: flattenedVideos[index].media.url,
               authorPubkey: eventReference.masterPubkey,
               thumbnailUrl: flattenedVideos[index].media.thumb,

--- a/lib/app/router/media_picker_routes.dart
+++ b/lib/app/router/media_picker_routes.dart
@@ -51,26 +51,3 @@ class GalleryCameraRoute extends BaseRouteData with _$GalleryCameraRoute {
 
   final MediaPickerType mediaPickerType;
 }
-
-@TypedGoRoute<FullscreenMediaRoute>(path: '${MediaPickerRoutes.routesPrefix}/fullscreen-media')
-class FullscreenMediaRoute extends BaseRouteData with _$FullscreenMediaRoute {
-  FullscreenMediaRoute({
-    required this.initialMediaIndex,
-    required this.eventReference,
-    this.framedEventReference,
-  }) : super(
-          child: FullscreenMediaPage(
-            initialMediaIndex: initialMediaIndex,
-            eventReference: EventReference.fromEncoded(eventReference),
-            framedEventReference: framedEventReference != null
-                ? EventReference.fromEncoded(framedEventReference)
-                : null,
-          ),
-          type: IceRouteType.swipeDismissible,
-          isFullscreenMedia: true,
-        );
-
-  final int initialMediaIndex;
-  final String eventReference;
-  final String? framedEventReference;
-}

--- a/lib/app/router/profile_routes.dart
+++ b/lib/app/router/profile_routes.dart
@@ -6,6 +6,7 @@ class ProfileRoutes {
   static const routes = <TypedRoute<RouteData>>[
     TypedGoRoute<ProfileRoute>(path: 'user/:pubkey'),
     TypedGoRoute<ProfileVideosRoute>(path: 'user-videos-fullstack/:pubkey'),
+    TypedGoRoute<FullscreenMediaRoute>(path: 'fullscreen-media-fullstack'),
     TypedGoRoute<ProfileEditRoute>(path: 'profile_edit'),
     TypedGoRoute<BookmarksRoute>(path: 'bookmarks'),
     TypedGoRoute<EditBookmarksRoute>(path: 'bookmarks_edit'),
@@ -292,4 +293,26 @@ class CreateQuoteProfileRoute extends BaseRouteData with _$CreateQuoteProfileRou
   final String quotedEvent;
   final String? content;
   final String? attachedMedia;
+}
+
+class FullscreenMediaRoute extends BaseRouteData with _$FullscreenMediaRoute {
+  FullscreenMediaRoute({
+    required this.initialMediaIndex,
+    required this.eventReference,
+    this.framedEventReference,
+  }) : super(
+          child: FullscreenMediaPage(
+            initialMediaIndex: initialMediaIndex,
+            eventReference: EventReference.fromEncoded(eventReference),
+            framedEventReference: framedEventReference != null
+                ? EventReference.fromEncoded(framedEventReference)
+                : null,
+          ),
+          type: IceRouteType.swipeDismissible,
+          isFullscreenMedia: true,
+        );
+
+  final int initialMediaIndex;
+  final String eventReference;
+  final String? framedEventReference;
 }


### PR DESCRIPTION
## Description
This PR changes the behaviour of reply button in full screen media pages so that it navigates to post/article detail pages.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
<!-- Add corresponding task ID here. -->

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)

https://github.com/user-attachments/assets/d5d854ec-b5ec-4b37-886a-c46fd04e7a24


