### PR TITLE
fix(chat): funds request message not displayed

### DIFF
--- a/lib/app/features/chat/views/pages/share_via_message_modal/components/share_send_button.dart
+++ b/lib/app/features/chat/views/pages/share_via_message_modal/components/share_send_button.dart
@@ -67,8 +67,8 @@ class ShareSendButton extends HookConsumerWidget {
           onPressed: () {
             loading.value = true;
             try {
-              final entity =
-                  ref.read(ionConnectSyncEntityWithCountersProvider(eventReference: eventReference));
+              final entity = ref
+                  .read(ionConnectSyncEntityWithCountersProvider(eventReference: eventReference));
 
               if (entity is UserMetadataEntity) {
                 unawaited(shareProfileToChat());

--- a/lib/app/features/components/entities_list/entities_list.dart
+++ b/lib/app/features/components/entities_list/entities_list.dart
@@ -116,8 +116,9 @@ class _EntityListItem extends ConsumerWidget {
 
   bool _isRepostedEntityDeleted(WidgetRef ref, IonConnectEntity entity) {
     if (entity is GenericRepostEntity) {
-      final repostedEntity = ref
-          .watch(ionConnectSyncEntityWithCountersProvider(eventReference: entity.data.eventReference));
+      final repostedEntity = ref.watch(
+        ionConnectSyncEntityWithCountersProvider(eventReference: entity.data.eventReference),
+      );
       return repostedEntity == null ||
           (repostedEntity is SoftDeletableEntity && repostedEntity.isDeleted);
     }

--- a/lib/app/features/feed/notifications/views/notifications_history_page/components/notification_item/notification_info.dart
+++ b/lib/app/features/feed/notifications/views/notifications_history_page/components/notification_item/notification_info.dart
@@ -147,7 +147,8 @@ class NotificationInfo extends HookConsumerWidget {
       return null;
     }
 
-    final entity = ref.watch(ionConnectSyncEntityWithCountersProvider(eventReference: eventReference));
+    final entity =
+        ref.watch(ionConnectSyncEntityWithCountersProvider(eventReference: eventReference));
 
     if (entity == null) {
       return null;

--- a/lib/app/features/feed/notifications/views/notifications_history_page/components/notification_item/notification_item.dart
+++ b/lib/app/features/feed/notifications/views/notifications_history_page/components/notification_item/notification_item.dart
@@ -100,8 +100,9 @@ class NotificationItem extends ConsumerWidget {
 
   bool _isRepostedEntityDeleted(WidgetRef ref, IonConnectEntity entity) {
     if (entity is GenericRepostEntity) {
-      final repostedEntity = ref
-          .watch(ionConnectSyncEntityWithCountersProvider(eventReference: entity.data.eventReference));
+      final repostedEntity = ref.watch(
+        ionConnectSyncEntityWithCountersProvider(eventReference: entity.data.eventReference),
+      );
       return repostedEntity == null ||
           (repostedEntity is SoftDeletableEntity && repostedEntity.isDeleted);
     }

--- a/lib/app/features/feed/views/components/article/article.dart
+++ b/lib/app/features/feed/views/components/article/article.dart
@@ -77,7 +77,8 @@ class Article extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final entity = ref.watch(ionConnectSyncEntityWithCountersProvider(eventReference: eventReference));
+    final entity =
+        ref.watch(ionConnectSyncEntityWithCountersProvider(eventReference: eventReference));
 
     if (entity is! ArticleEntity) {
       return Padding(

--- a/lib/app/features/feed/views/components/article/article_title.dart
+++ b/lib/app/features/feed/views/components/article/article_title.dart
@@ -16,7 +16,8 @@ class ArticleTitle extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final entity = ref.watch(ionConnectSyncEntityWithCountersProvider(eventReference: eventReference));
+    final entity =
+        ref.watch(ionConnectSyncEntityWithCountersProvider(eventReference: eventReference));
 
     if (entity is! ArticleEntity) {
       return const SizedBox.shrink();

--- a/lib/app/features/feed/views/components/post/post.dart
+++ b/lib/app/features/feed/views/components/post/post.dart
@@ -69,7 +69,8 @@ class Post extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final entity = ref.watch(ionConnectSyncEntityWithCountersProvider(eventReference: eventReference));
+    final entity =
+        ref.watch(ionConnectSyncEntityWithCountersProvider(eventReference: eventReference));
 
     if (entity == null) {
       return ScreenSideOffset.small(
@@ -261,7 +262,8 @@ final class _FramedEvent extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final entity = ref.watch(ionConnectSyncEntityWithCountersProvider(eventReference: eventReference));
+    final entity =
+        ref.watch(ionConnectSyncEntityWithCountersProvider(eventReference: eventReference));
     Widget? deletedEntity;
 
     if (entity is ModifiablePostEntity && entity.isDeleted) {

--- a/lib/app/features/feed/views/pages/article_details_page/components/articles_carousel_item.dart
+++ b/lib/app/features/feed/views/pages/article_details_page/components/articles_carousel_item.dart
@@ -21,7 +21,8 @@ class ArticlesCarouselItem extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final article = ref.watch(ionConnectSyncEntityWithCountersProvider(eventReference: eventReference));
+    final article =
+        ref.watch(ionConnectSyncEntityWithCountersProvider(eventReference: eventReference));
 
     if (article is! ArticleEntity || article.isDeleted) {
       return const SizedBox.shrink();

--- a/lib/app/features/video/views/pages/feed_videos_page.dart
+++ b/lib/app/features/video/views/pages/feed_videos_page.dart
@@ -22,7 +22,8 @@ class FeedVideosPage extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final video = ref.watch(ionConnectSyncEntityWithCountersProvider(eventReference: eventReference));
+    final video =
+        ref.watch(ionConnectSyncEntityWithCountersProvider(eventReference: eventReference));
     final entities = <IonConnectEntity>[
       if (video != null) video,
       ...ref.watch(feedVideosProvider.select((state) => state.items ?? {})),

--- a/lib/app/services/deep_link/deep_link_service.r.dart
+++ b/lib/app/services/deep_link/deep_link_service.r.dart
@@ -101,7 +101,8 @@ Future<void> deeplinkInitializer(Ref ref) async {
     EventReference eventReference,
     String encodedEventReference,
   ) async {
-    final entity = await ref.read(ionConnectEntityWithCountersProvider(eventReference: eventReference).future);
+    final entity =
+        await ref.read(ionConnectEntityWithCountersProvider(eventReference: eventReference).future);
 
     if (entity is ModifiablePostEntity) {
       if (entity.isStory) {


### PR DESCRIPTION
## Description
This PR fixes the issue with the existing funds request message now being shown. This issue appeared after the [recent fix](https://github.com/ice-blockchain/ion-framework/pull/1950) where the "send" button changed its state incorrectly and (`startWith(null)` was removed from the TransactionId stream). If there was no TransactionId in the database at all, the message stream failed to load because it was using `combineLatest`.

## Task ID
ION-3758

## Type of Change
- [x] Bug fix

## Screenshots
<img width="350" alt="image" src="https://github.com/user-attachments/assets/5f28170e-036f-460a-9f47-f4a97a10906c" />

<img width="350" alt="image" src="https://github.com/user-attachments/assets/b252c1c4-1474-43d0-899a-9bd91a2a38a5" />

