### PR TITLE
fix: ensure encrypted media is fetched directly from the original url

### DIFF
--- a/lib/app/features/push_notifications/data/models/ion_connect_push_data_payload.f.dart
+++ b/lib/app/features/push_notifications/data/models/ion_connect_push_data_payload.f.dart
@@ -296,10 +296,12 @@ class IonConnectPushDataPayload {
         );
 
         if (imageMedia != null) {
+          final thumbMedia = message.data.media.values.firstWhereOrNull(
+            (media) => media.url == imageMedia.thumb,
+          );
           final decryptedMedia = await mediaEncryptionService.retrieveEncryptedMedia(
-            imageMedia,
+            thumbMedia ?? imageMedia,
             authorPubkey: message.pubkey,
-            tryLoadThumbnail: true,
           );
           attachmentUrl = decryptedMedia.path;
         }

--- a/lib/app/services/media_service/media_encryption_service.m.dart
+++ b/lib/app/services/media_service/media_encryption_service.m.dart
@@ -40,13 +40,12 @@ class MediaEncryptionService {
   Future<File> retrieveEncryptedMedia(
     MediaAttachment attachment, {
     required String authorPubkey,
-    bool tryLoadThumbnail = false,
   }) async {
     try {
       if (attachment.encryptionKey != null &&
           attachment.encryptionNonce != null &&
           attachment.encryptionMac != null) {
-        final url = tryLoadThumbnail ? attachment.thumb ?? attachment.url : attachment.url;
+        final url = attachment.url;
         final mac = base64Decode(attachment.encryptionMac!);
         final nonce = base64Decode(attachment.encryptionNonce!);
         final secretKey = base64Decode(attachment.encryptionKey!);


### PR DESCRIPTION
## Description
currently, encrypted media could try alternative urls when being retrieved. this change ensures that all encrypted media is always fetched directly from the original url.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
3757

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
