### PR TITLE
fix: add a provider for overlay content visiblity on stories as hiding it on story pause was causing issues

### DIFF
--- a/lib/app/features/feed/stories/providers/story_pause_provider.r.dart
+++ b/lib/app/features/feed/stories/providers/story_pause_provider.r.dart
@@ -13,6 +13,14 @@ class StoryPauseController extends _$StoryPauseController {
 }
 
 @riverpod
+class StoryOverlayContentVisibilityController extends _$StoryOverlayContentVisibilityController {
+  @override
+  bool build() => true;
+
+  set visible(bool value) => state = value;
+}
+
+@riverpod
 class StoryMenuController extends _$StoryMenuController {
   @override
   bool build() => false;

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/core/story_content.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/core/story_content.dart
@@ -16,7 +16,7 @@ import 'package:ion/app/features/feed/stories/providers/story_pause_provider.r.d
 import 'package:ion/app/features/feed/stories/providers/story_reply_notification_provider.m.dart';
 import 'package:ion/app/features/feed/stories/providers/story_reply_provider.r.dart';
 import 'package:ion/app/features/feed/stories/views/components/story_viewer/components/components.dart';
-import 'package:ion/app/features/feed/stories/views/components/story_viewer/components/core/story_pause_visibility_wrapper.dart';
+import 'package:ion/app/features/feed/stories/views/components/story_viewer/components/core/story_overlay_content_visibility_wrapper.dart';
 import 'package:ion/app/features/feed/stories/views/components/story_viewer/components/header/story_viewer_header.dart';
 import 'package:ion/app/utils/future.dart';
 
@@ -132,7 +132,7 @@ class _StoryControlsPanel extends HookConsumerWidget {
       (_, next) => ref.read(storyPauseControllerProvider.notifier).paused = next.isLoading,
     );
 
-    return StoryPauseVisibilityWrapper(
+    return StoryOverlayContentVisibilityWrapper(
       child: Stack(
         children: [
           if (canSendMessage && !isOwnerStory)

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/core/story_gesture_handler.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/core/story_gesture_handler.dart
@@ -47,8 +47,14 @@ class StoryGestureHandler extends HookConsumerWidget {
           onTapRight();
         }
       },
-      onLongPressStart: (_) => ref.read(storyPauseControllerProvider.notifier).paused = true,
-      onLongPressEnd: (_) => ref.read(storyPauseControllerProvider.notifier).paused = false,
+      onLongPressStart: (_) {
+        ref.read(storyPauseControllerProvider.notifier).paused = true;
+        ref.read(storyOverlayContentVisibilityControllerProvider.notifier).visible = false;
+      },
+      onLongPressEnd: (_) {
+        ref.read(storyPauseControllerProvider.notifier).paused = false;
+        ref.read(storyOverlayContentVisibilityControllerProvider.notifier).visible = true;
+      },
       child: child,
     );
   }

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/core/story_overlay_content_visibility_wrapper.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/core/story_overlay_content_visibility_wrapper.dart
@@ -4,8 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/features/feed/stories/providers/story_pause_provider.r.dart';
 
-class StoryPauseVisibilityWrapper extends ConsumerWidget {
-  const StoryPauseVisibilityWrapper({
+class StoryOverlayContentVisibilityWrapper extends ConsumerWidget {
+  const StoryOverlayContentVisibilityWrapper({
     required this.child,
     super.key,
   });
@@ -14,10 +14,10 @@ class StoryPauseVisibilityWrapper extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final isPaused = ref.watch(storyPauseControllerProvider);
+    final isVisible = ref.watch(storyOverlayContentVisibilityControllerProvider);
 
     return AnimatedOpacity(
-      opacity: isPaused ? 0 : 1,
+      opacity: isVisible ? 1 : 0,
       duration: const Duration(milliseconds: 150),
       child: child,
     );

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/header/story_viewer_header.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/header/story_viewer_header.dart
@@ -7,7 +7,7 @@ import 'package:ion/app/components/list_item/list_item.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/components/ion_connect_avatar/ion_connect_avatar.dart';
 import 'package:ion/app/features/feed/data/models/entities/modifiable_post_data.f.dart';
-import 'package:ion/app/features/feed/stories/views/components/story_viewer/components/core/story_pause_visibility_wrapper.dart';
+import 'package:ion/app/features/feed/stories/views/components/story_viewer/components/core/story_overlay_content_visibility_wrapper.dart';
 import 'package:ion/app/features/feed/stories/views/components/story_viewer/components/header/header.dart';
 import 'package:ion/app/features/feed/views/components/time_ago/time_ago.dart';
 import 'package:ion/app/features/user/providers/user_metadata_provider.r.dart';
@@ -50,7 +50,7 @@ class StoryViewerHeader extends ConsumerWidget {
           top: 14.0.s,
           start: 16.0.s,
           end: 22.0.s,
-          child: StoryPauseVisibilityWrapper(
+          child: StoryOverlayContentVisibilityWrapper(
             child: GestureDetector(
               onTap: () => ProfileRoute(pubkey: currentPost.masterPubkey).push<void>(context),
               child: BadgesUserListItem(

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/reactions/story_reaction_notification.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/reactions/story_reaction_notification.dart
@@ -8,7 +8,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/chat/views/components/message_items/components.dart';
 import 'package:ion/app/features/feed/stories/providers/story_reply_notification_provider.m.dart';
-import 'package:ion/app/features/feed/stories/views/components/story_viewer/components/core/story_pause_visibility_wrapper.dart';
+import 'package:ion/app/features/feed/stories/views/components/story_viewer/components/core/story_overlay_content_visibility_wrapper.dart';
 
 class StoryReplyNotification extends ConsumerWidget {
   const StoryReplyNotification({super.key});
@@ -26,7 +26,7 @@ class StoryReplyNotification extends ConsumerWidget {
       top: 70.0.s,
       start: 0.0.s,
       end: 0.0.s,
-      child: StoryPauseVisibilityWrapper(
+      child: StoryOverlayContentVisibilityWrapper(
         child: Animate(
           key: ValueKey(storyReplyNotification.selectedEmoji),
           onComplete: (_) {


### PR DESCRIPTION


## Description
This PR fixes an issue where clicking on input field or context menu hid all the overlay content on a story.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
3766

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)

https://github.com/user-attachments/assets/e356de0b-a8b8-48dc-82a8-ab34eb814ad5


