### PR TITLE
chore: add createDestinationAccount:true for the Spl and Spl2022 transfers

### DIFF
--- a/lib/app/features/wallets/domain/coins/transfer_factory.dart
+++ b/lib/app/features/wallets/domain/coins/transfer_factory.dart
@@ -40,11 +40,13 @@ class _TransferFactory {
         mint: asset.mint,
         to: receiverAddress,
         amount: amount,
+        createDestinationAccount: true,
       ),
       spl2022: (asset) => Spl2022Transfer(
         mint: asset.mint,
         to: receiverAddress,
         amount: amount,
+        createDestinationAccount: true,
       ),
       sep41: (asset) => Sep41Transfer(
         amount: amount,


### PR DESCRIPTION
## Description
This change fixes the issue, when the recipient doesn't have an associated token account for `PYUSD`.

## Task ID
ION-3723

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
