### PR TITLE
fix(wallet): nfts reloaded each time user opens nfts tag

### DIFF
--- a/lib/app/features/wallets/providers/current_nfts_provider.r.dart
+++ b/lib/app/features/wallets/providers/current_nfts_provider.r.dart
@@ -8,7 +8,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'current_nfts_provider.r.g.dart';
 
-@riverpod
+@Riverpod(keepAlive: true)
 Future<List<NftData>> currentNfts(Ref ref) async {
   final nftsRepository = ref.watch(nftsRepositoryProvider);
 

--- a/lib/app/features/wallets/views/pages/wallet_page.dart
+++ b/lib/app/features/wallets/views/pages/wallet_page.dart
@@ -82,13 +82,18 @@ class WalletPage extends HookConsumerWidget {
               ],
             ),
           ),
-          if (activeTab.value == WalletTabType.nfts)
-            const SliverToBoxAdapter(
-              child: NftsTabHeader(),
-            )
-          else
-            const CoinsTabHeader(),
-          _ActiveTabContent(activeTab: activeTab.value),
+          ...switch (activeTab.value) {
+            WalletTabType.coins => const [
+                CoinsTabHeader(),
+                CoinsTab(),
+              ],
+            WalletTabType.nfts => const [
+                SliverToBoxAdapter(
+                  child: NftsTabHeader(),
+                ),
+                NftsTab(),
+              ],
+          },
         ],
         onRefresh: () async {
           final currentUserFollowList = ref.read(currentUserFollowListProvider).valueOrNull;
@@ -113,21 +118,5 @@ class WalletPage extends HookConsumerWidget {
         ),
       ),
     );
-  }
-}
-
-class _ActiveTabContent extends StatelessWidget {
-  const _ActiveTabContent({
-    required this.activeTab,
-  });
-
-  final WalletTabType activeTab;
-
-  @override
-  Widget build(BuildContext context) {
-    return switch (activeTab) {
-      WalletTabType.coins => const CoinsTab(),
-      WalletTabType.nfts => const NftsTab(),
-    };
   }
 }

--- a/lib/app/features/wallets/views/pages/wallet_page/view_models/wallet_nfts_view_model.dart
+++ b/lib/app/features/wallets/views/pages/wallet_page/view_models/wallet_nfts_view_model.dart
@@ -10,7 +10,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 typedef NftsState = ({List<NftData> allNfts, List<NftData> filteredNfts});
 
-final walletNftsViewModelProvider = Provider.autoDispose(
+final walletNftsViewModelProvider = Provider(
   (ref) {
     final nftFilterService = ref.watch(nftNetworkFilterManagerProvider);
 


### PR DESCRIPTION
## Description
Previously, the “NFTs” tab was reloaded every time the user opened it. This happened because the `currentNftsProvider` and `walletNftsViewModelProvider` were disposed of when the widget was disposed.

## Type of Change
- [x] Bug fix

## Screenshots 
https://github.com/user-attachments/assets/ad668913-b974-4572-8a66-864608bbad4a


