### PR TITLE
fix: replace ffmpeg with pure dart implementation for webp to jpeg conversion on background push notification handler isolate

### DIFF
--- a/lib/app/services/converters/dart_webp_to_jpeg_converter.dart
+++ b/lib/app/services/converters/dart_webp_to_jpeg_converter.dart
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'dart:io';
+
+import 'package:image/image.dart' as img;
+import 'package:ion/app/features/core/model/mime_type.dart';
+import 'package:ion/app/services/media_service/media_service.m.dart';
+
+/// Pure-Dart WebP -> JPEG converter for use in background isolates (e.g., FCM).
+Future<MediaFile> webpToJpeg(String inputPath) async {
+  final inputFile = File(inputPath);
+  final bytes = await inputFile.readAsBytes();
+
+  // Early return if already JPEG (by extension)
+  final lower = inputPath.toLowerCase();
+  final isJpegByExt = lower.endsWith('.jpg') || lower.endsWith('.jpeg');
+  if (isJpegByExt) {
+    return MediaFile(
+      path: inputPath,
+      mimeType: LocalMimeType.jpeg.value,
+      originalMimeType: LocalMimeType.jpeg.value,
+    );
+  }
+
+  final decoded = img.decodeWebP(bytes);
+  if (decoded == null) {
+    throw StateError('Failed to decode WebP: $inputPath');
+  }
+
+  final jpgBytes = img.encodeJpg(decoded);
+  final outPath = inputPath.replaceAll(RegExp(r'\.[^.]+$'), '.jpg');
+  final outFile = File(outPath);
+  await outFile.writeAsBytes(jpgBytes, flush: true);
+
+  return MediaFile(
+    path: outPath,
+    mimeType: LocalMimeType.jpeg.value,
+    originalMimeType: MimeType.image.value,
+    width: decoded.width,
+    height: decoded.height,
+  );
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1573,7 +1573,7 @@ packages:
     source: hosted
     version: "2.2.0"
   image:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: image
       sha256: "4e973fcf4caae1a4be2fa0a13157aa38a8f9cb049db6529aa00b4d71abc4d928"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -99,6 +99,7 @@ dependencies:
   googleapis: ^13.2.0
   hooks_riverpod: ^2.6.1
   icloud_storage: ^2.2.0
+  image: ^4.5.4
   image_cropper: ^8.1.0
   intl: any
   ion_connect_cache:


### PR DESCRIPTION

## Description
This PR fixes an issue where android push notifications didn't contain any images an icons when push was received when app was in background

## Additional Notes
The main issue here is that we use ffmpegKit for converting push notification images from webp to jpeg. However this library [doesn't work on other isolates than main one](https://github.com/arthenica/ffmpeg-kit/issues/367). However firebase background notification handler runs on a background isolate. 
The solution uses a pure dart solution for image conversion that works on all isolates.

## Task ID
3570

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<img width="814" height="544" alt="ScreenShot 2025-09-03 at 13 02 12@2x" src="https://github.com/user-attachments/assets/fbc4a99f-43d4-4be3-9399-ba6e03a8439c" />

