### PR TITLE
fix: show stories when first page is loaded

### DIFF
--- a/lib/app/features/feed/providers/feed_for_you_content_provider.m.dart
+++ b/lib/app/features/feed/providers/feed_for_you_content_provider.m.dart
@@ -273,33 +273,44 @@ class FeedForYouContent extends _$FeedForYouContent implements PagedNotifier {
   }
 
   Stream<IonConnectEntity> _fetchFollowing({required int limit, bool global = false}) async* {
-    final providerNotifier = ref.read(
-      feedFollowingContentProvider(
-        feedType,
-        feedModifier: feedModifier,
-        fetchSeen: false,
-        autoFetch: false,
-        global: global,
-      ).notifier,
-    );
-    final providerData = ref.read(
-      feedFollowingContentProvider(
-        feedType,
-        feedModifier: feedModifier,
-        fetchSeen: false,
-        autoFetch: false,
-        global: global,
-      ),
-    );
-
-    if (!providerData.hasMore) {
+    if (!ref
+        .read(
+          feedFollowingContentProvider(
+            feedType,
+            feedModifier: feedModifier,
+            fetchSeen: false,
+            autoFetch: false,
+            global: global,
+          ),
+        )
+        .hasMore) {
       state = state.copyWith(hasMoreFollowing: false);
       return;
     }
 
-    yield* providerNotifier.requestEntities(limit: limit);
+    yield* ref
+        .read(
+          feedFollowingContentProvider(
+            feedType,
+            feedModifier: feedModifier,
+            fetchSeen: false,
+            autoFetch: false,
+            global: global,
+          ).notifier,
+        )
+        .requestEntities(limit: limit);
 
-    if (!providerData.hasMore) {
+    if (!ref
+        .read(
+          feedFollowingContentProvider(
+            feedType,
+            feedModifier: feedModifier,
+            fetchSeen: false,
+            autoFetch: false,
+            global: global,
+          ),
+        )
+        .hasMore) {
       state = state.copyWith(hasMoreFollowing: false);
     }
   }
@@ -675,7 +686,9 @@ class FeedForYouContentState with _$FeedForYouContentState implements PagedState
 
   const FeedForYouContentState._();
 
-  bool get hasMoreForYou => modifiersPagination.values.any(
+  bool get hasMoreForYou =>
+      modifiersPagination.isEmpty ||
+      modifiersPagination.values.any(
         (modifierPagination) => modifierPagination.values.any((pagination) => pagination.hasMore),
       );
 

--- a/lib/app/features/feed/stories/providers/feed_stories_provider.r.dart
+++ b/lib/app/features/feed/stories/providers/feed_stories_provider.r.dart
@@ -23,12 +23,14 @@ class FeedStories extends _$FeedStories with DelegatedPagedNotifier {
     final currentUserStory = ref.watch(currentUserFeedStoryProvider);
     final data = switch (filter.filter) {
       FeedFilter.following => ref.watch(
-          feedFollowingContentProvider(FeedType.story)
-              .select((data) => (items: data.items, hasMore: data.hasMore)),
+          feedFollowingContentProvider(FeedType.story).select(
+            (data) => (items: data.items, hasMore: data.hasMore, isLoading: data.isLoading),
+          ),
         ),
       FeedFilter.forYou => ref.watch(
-          feedForYouContentProvider(FeedType.story)
-              .select((data) => (items: data.items, hasMore: data.hasMore)),
+          feedForYouContentProvider(FeedType.story).select(
+            (data) => (items: data.items, hasMore: data.hasMore, isLoading: data.isLoading),
+          ),
         ),
     };
 
@@ -42,7 +44,7 @@ class FeedStories extends _$FeedStories with DelegatedPagedNotifier {
       items: stories,
       hasMore: data.hasMore,
       // Approx number of items needed to fill the viewport
-      ready: stories.length >= (currentUserStory != null ? 5 : 4) || !data.hasMore
+      ready: stories.length >= (currentUserStory != null ? 5 : 4) || !data.isLoading
     );
   }
 


### PR DESCRIPTION
## Description
This PR fixes an issue when the total number of stories on for_you feed is less than we need to fiill the viewport.
THe issues was that we didn't update properly the `hasMoreFollowing` flag - it was always `true`. Also changes the trigger from `hasMore` to `isLoading`.

## Task ID
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore