### PR TITLE
fix: transaction id from database ignored in payment messages

### DIFF
--- a/lib/app/features/chat/views/components/message_items/message_types/money_message/money_message.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/money_message/money_message.dart
@@ -96,6 +96,7 @@ class _RequestedMoneyMessage extends ConsumerWidget {
 
     final amount = fundsRequest.data.content.amount?.let(double.parse) ?? 0.0;
     final equivalentUsd = fundsRequest.data.content.amountUsd?.let(double.parse) ?? 0.0;
+    final isPaid = fundsRequest.data.transaction != null || fundsRequest.data.transactionId != null;
 
     return _MoneyMessageContent(
       isMe: isMe,
@@ -110,7 +111,7 @@ class _RequestedMoneyMessage extends ConsumerWidget {
       button: RequestedMoneyMessageButton(
         isMe: isMe,
         eventId: eventReference.eventId,
-        isPaid: fundsRequest.data.transaction != null,
+        isPaid: isPaid,
         isDeleted: fundsRequest.data.deleted,
         request: fundsRequest,
         eventMessage: eventMessage,

--- a/lib/app/features/wallets/data/mappers/funds_request_mapper.dart
+++ b/lib/app/features/wallets/data/mappers/funds_request_mapper.dart
@@ -51,6 +51,7 @@ class FundsRequestMapper {
         pubkey: db.userPubkey,
         request: db.request,
         transaction: transaction,
+        transactionId: db.transactionId,
         deleted: db.deleted,
       ),
     );

--- a/lib/app/features/wallets/model/entities/funds_request_entity.f.dart
+++ b/lib/app/features/wallets/model/entities/funds_request_entity.f.dart
@@ -64,6 +64,7 @@ class FundsRequestData with _$FundsRequestData {
     String? pubkey,
     String? request,
     TransactionData? transaction,
+    String? transactionId,
     @Default(false) bool deleted,
   }) = _FundsRequestData;
 


### PR DESCRIPTION
## Description
"Send" button in payment messages was checking if request contains a transaction, but that object might not be available after app restart. There already is existing `transactionId` field in the database, so here i'm using it to resolve the status of the "Send" button

## Task ID
ION-3632

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<img width="343" height="300" alt="image" src="https://github.com/user-attachments/assets/63ef89e3-4793-4245-ad74-1f7522ee9dc1" />

