### PR TITLE
fix: bottom menu height

### DIFF
--- a/lib/app/router/main_tabs/components/tab_icon.dart
+++ b/lib/app/router/main_tabs/components/tab_icon.dart
@@ -19,7 +19,7 @@ class TabIcon extends StatelessWidget {
       height: 50.0.s,
       child: icon.icon(
         size: 24.0.s,
-        fit: BoxFit.none,
+        fit: BoxFit.contain,
         color: isSelected
             ? context.theme.appColors.primaryAccent
             : context.theme.appColors.tertiaryText,

--- a/lib/app/router/main_tabs/main_tab_navigation.dart
+++ b/lib/app/router/main_tabs/main_tab_navigation.dart
@@ -153,33 +153,31 @@ class _BottomNavBarContent extends ConsumerWidget {
                     ),
                   ],
           ),
-          child: Padding(
-            padding: EdgeInsetsDirectional.only(bottom: bottomPadding),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: TabItem.values.map((tabItem) {
-                final isSelected = currentTab == tabItem;
+          padding: EdgeInsetsDirectional.only(bottom: bottomPadding),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: TabItem.values.map((tabItem) {
+              final isSelected = currentTab == tabItem;
 
-                return Expanded(
-                  child: GestureDetector(
-                    behavior: HitTestBehavior.opaque,
-                    onTap: () => onTabPressed(tabItem),
-                    child: Container(
-                      padding: EdgeInsets.symmetric(vertical: _navBarVerticalPadding.s),
-                      color: context.theme.appColors.secondaryBackground,
-                      child: Stack(
-                        alignment: Alignment.center,
-                        children: [
-                          tabItem.getIcon(isSelected: isSelected),
-                          if (tabItem == TabItem.chat) const UnreadMessagesCounter(),
-                          if (tabItem == TabItem.wallet) const UnseenTransactionsCounter(),
-                        ],
-                      ),
+              return Expanded(
+                child: GestureDetector(
+                  behavior: HitTestBehavior.opaque,
+                  onTap: () => onTabPressed(tabItem),
+                  child: Container(
+                    padding: EdgeInsets.symmetric(vertical: _navBarVerticalPadding.s),
+                    color: context.theme.appColors.secondaryBackground,
+                    child: Stack(
+                      alignment: Alignment.center,
+                      children: [
+                        tabItem.getIcon(isSelected: isSelected),
+                        if (tabItem == TabItem.chat) const UnreadMessagesCounter(),
+                        if (tabItem == TabItem.wallet) const UnseenTransactionsCounter(),
+                      ],
                     ),
                   ),
-                );
-              }).toList(),
-            ),
+                ),
+              );
+            }).toList(),
           ),
         ),
         if (conversationsEditMode && currentTab == TabItem.chat) const ConversationEditBottomBar(),

--- a/lib/app/router/main_tabs/main_tab_navigation.dart
+++ b/lib/app/router/main_tabs/main_tab_navigation.dart
@@ -154,7 +154,7 @@ class _BottomNavBarContent extends ConsumerWidget {
                   ],
           ),
           child: Padding(
-            padding: EdgeInsets.only(bottom: bottomPadding),
+            padding: EdgeInsetsDirectional.only(bottom: bottomPadding),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: TabItem.values.map((tabItem) {

--- a/lib/app/router/main_tabs/main_tab_navigation.dart
+++ b/lib/app/router/main_tabs/main_tab_navigation.dart
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: ice License 1.0
 
+import 'dart:io';
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -11,6 +14,8 @@ import 'package:ion/app/features/chat/recent_chats/views/components/conversation
 import 'package:ion/app/features/chat/views/components/unread_messages_counter.dart';
 import 'package:ion/app/features/wallets/views/components/unseen_transactions_counter.dart';
 import 'package:ion/app/router/main_tabs/components/components.dart';
+
+const _navBarVerticalPadding = 9.0;
 
 class MainTabNavigation extends HookWidget {
   const MainTabNavigation({
@@ -111,9 +116,20 @@ class _BottomNavBarContent extends ConsumerWidget {
   final TabItem currentTab;
   final ValueChanged<TabItem> onTabPressed;
 
+  double _getBottomPadding(BuildContext context) {
+    final mqPaddings = MediaQuery.paddingOf(context);
+    return Platform.isIOS
+        // On iOS we need to get under safe area a bit(8px), because the safe area is bigger than the home indicator itself
+        ? max(0, mqPaddings.bottom - _navBarVerticalPadding.s - 8.s)
+        // On Android the size of the system gesture inset is about the same as the home indicator, so we can just use it
+        // in case of 2/3 button navigation using the size of System navigation bar
+        : mqPaddings.bottom;
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final conversationsEditMode = ref.watch(conversationsEditModeProvider);
+    final bottomPadding = _getBottomPadding(context);
 
     return Stack(
       children: [
@@ -129,17 +145,19 @@ class _BottomNavBarContent extends ConsumerWidget {
                     ),
                   ],
           ),
-          child: SafeArea(
+          child: Padding(
+            padding: EdgeInsets.only(bottom: bottomPadding),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: TabItem.values.map((tabItem) {
                 final isSelected = currentTab == tabItem;
+
                 return Expanded(
                   child: GestureDetector(
                     behavior: HitTestBehavior.opaque,
                     onTap: () => onTabPressed(tabItem),
                     child: Container(
-                      padding: EdgeInsets.symmetric(vertical: 9.0.s),
+                      padding: EdgeInsets.symmetric(vertical: _navBarVerticalPadding.s),
                       color: context.theme.appColors.secondaryBackground,
                       child: Stack(
                         alignment: Alignment.center,

--- a/lib/app/router/main_tabs/main_tab_navigation.dart
+++ b/lib/app/router/main_tabs/main_tab_navigation.dart
@@ -118,12 +118,20 @@ class _BottomNavBarContent extends ConsumerWidget {
 
   double _getBottomPadding(BuildContext context) {
     final mqPaddings = MediaQuery.paddingOf(context);
-    return Platform.isIOS
-        // On iOS we need to get under safe area a bit(8px), because the safe area is bigger than the home indicator itself
-        ? max(0, mqPaddings.bottom - _navBarVerticalPadding.s - 8.s)
-        // On Android the size of the system gesture inset is about the same as the home indicator, so we can just use it
-        // in case of 2/3 button navigation using the size of System navigation bar
-        : mqPaddings.bottom;
+    if (Platform.isIOS) {
+      // On iOS we need to get under safe area a bit(8px), because the safe area is bigger than the home indicator itself
+      // assuming the is no devices older than iPhone X in use
+      return max(0, mqPaddings.bottom - _navBarVerticalPadding.s - 8.s);
+    } else if (Platform.isAndroid && MediaQuery.systemGestureInsetsOf(context).left > 0) {
+      // On Android we need to check for system gesture insets to determine is there is a 2/3 button navigation or home indicator
+      // The system nav bar inset may vary so we can just use some average formula
+
+      return mqPaddings.bottom > 12.s ? max(0, (mqPaddings.bottom / 2) + 6.s) : mqPaddings.bottom;
+    } else {
+      // Default case, just return the bottom padding
+      // for all cases when there is no gesture inset (old devices with buttons, etc)
+      return mqPaddings.bottom;
+    }
   }
 
   @override


### PR DESCRIPTION
## Description
Fix bottom navigation height

## Additional Notes
Removed SafeArea and calculate bottom padding manually
Allow bottom navigation bar to go under bottom safe area for some devices. depending on platform and system navigation mode.

## Task ID
ION-3789 Fix bottom menu height

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
iPhones : 
1. 16 Plus (bottom safe area is 34 px, 8px of our bottom navigation bar is underneath the safe area),
2. SE 3gen(showing as is - 9px padding between navbar buttons and system navigation panel) 

<img width="240" height="912" alt="iPhone 16" src="https://github.com/user-attachments/assets/44d3fe9a-f95d-4785-a52d-5a80938dd0fb" />
<img width="240" height="810" alt="iPhone SE" src="https://github.com/user-attachments/assets/5c8b1167-97a7-48d6-8432-1a0385bf655a" />

Android:
Sanmung S23: 
1. 3 buttons(showing as is - 9px padding between navbar buttons and system navigation panel),
2. gestures (bottom safe area is 16 px, padding between navbar buttons and system navigation panel reduced to 7px)

<img width="240" height="1280" alt="samsung S23 3 buttons" src="https://github.com/user-attachments/assets/e61ef9c9-cb0a-4d49-98b3-d4c6a64106f0" />
<img width="240" height="1280" alt="samsung S23 gestures" src="https://github.com/user-attachments/assets/c31f4086-12da-433c-9285-2d398bfe1ce4" />

emulator: 
1. 2 buttons, (showing as is - 9px padding between navbar buttons and system navigation panel)
2. 3 buttons, (showing as is - 9px padding between navbar buttons and system navigation panel)
3. gestures (bottom safe area is 24 px, padding between navbar buttons and system navigation panel reduced to 5px)

<img width="240" height="2400" alt="emulator 2buttons" src="https://github.com/user-attachments/assets/1eca09d5-d502-421f-967e-92498910bcf4" />
<img width="240" height="2400" alt="emulator 3buttons" src="https://github.com/user-attachments/assets/a4be3fa5-a4e8-499d-b674-58f03e6e5584" />
<img width="240" height="2400" alt="emulator gestures" src="https://github.com/user-attachments/assets/b5ab0c7d-4d63-4314-9fa8-60ddd59c4f0f" />
