### PR TITLE
chore: show trending videos only when viewport is filled

### DIFF
--- a/lib/app/features/feed/providers/feed_trending_videos_provider.r.dart
+++ b/lib/app/features/feed/providers/feed_trending_videos_provider.r.dart
@@ -15,19 +15,26 @@ part 'feed_trending_videos_provider.r.g.dart';
 @riverpod
 class FeedTrendingVideos extends _$FeedTrendingVideos with DelegatedPagedNotifier {
   @override
-  ({Iterable<IonConnectEntity>? items, bool hasMore}) build() {
+  ({Iterable<IonConnectEntity>? items, bool hasMore, bool ready}) build() {
     final filter = ref.watch(feedCurrentFilterProvider);
     final data = switch (filter.filter) {
       FeedFilter.following => ref.watch(
           feedFollowingContentProvider(FeedType.video, feedModifier: FeedModifier.trending())
-              .select((data) => (items: data.items, hasMore: data.hasMore)),
+              .select(
+            (data) => (items: data.items, hasMore: data.hasMore, isLoading: data.isLoading),
+          ),
         ),
       FeedFilter.forYou => ref.watch(
-          feedForYouContentProvider(FeedType.video, feedModifier: FeedModifier.trending())
-              .select((data) => (items: data.items, hasMore: data.hasMore)),
+          feedForYouContentProvider(FeedType.video, feedModifier: FeedModifier.trending()).select(
+            (data) => (items: data.items, hasMore: data.hasMore, isLoading: data.isLoading),
+          ),
         ),
     };
-    return (items: data.items, hasMore: data.hasMore);
+    return (
+      items: data.items,
+      hasMore: data.hasMore,
+      ready: (data.items?.length ?? 0) >= 3 || !data.isLoading
+    );
   }
 
   @override

--- a/lib/app/features/feed/views/pages/feed_page/components/trending_videos/trending_videos.dart
+++ b/lib/app/features/feed/views/pages/feed_page/components/trending_videos/trending_videos.dart
@@ -27,7 +27,7 @@ class TrendingVideos extends HookConsumerWidget {
     // final listOverlay = ref.watch(trendingVideosOverlayNotifierProvider);
     const listOverlay = TrendingVideosOverlay.vertical;
 
-    final (:items, :hasMore) = ref.watch(feedTrendingVideosProvider);
+    final (:items, :hasMore, :ready) = ref.watch(feedTrendingVideosProvider);
 
     final postItems = useMemoized(
       () {
@@ -36,7 +36,7 @@ class TrendingVideos extends HookConsumerWidget {
       [items],
     );
 
-    if (postItems == null) {
+    if (postItems == null || !ready) {
       return Column(
         children: [
           SizedBox(height: 10.0.s),


### PR DESCRIPTION
## Description
This PR changes the logic of initial displaying of trending videos on feed. We wait until enough events are arrived to hide the loading placeholder.

## Task ID
ION-3801

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [x] Chore

## Videos
before:

https://github.com/user-attachments/assets/dfd3576a-af46-4f4a-9c9e-9eff803a3119

after:

https://github.com/user-attachments/assets/2de49154-4357-430c-bd67-e76494ff2a6e



