### PR TITLE
fix: improve the boxfit and padding for video preview blurhash in video page

### DIFF
--- a/lib/app/features/video/views/components/video_thumbnail_preview.dart
+++ b/lib/app/features/video/views/components/video_thumbnail_preview.dart
@@ -11,7 +11,7 @@ class VideoThumbnailPreview extends ConsumerWidget {
     required this.thumbnailUrl,
     this.blurhash,
     this.authorPubkey,
-    this.fit = BoxFit.cover,
+    this.fit = BoxFit.contain,
     super.key,
   });
 

--- a/lib/app/features/video/views/pages/video_page.dart
+++ b/lib/app/features/video/views/pages/video_page.dart
@@ -74,10 +74,15 @@ class VideoPage extends HookConsumerWidget {
     if (playerController == null || !playerController.value.isInitialized) {
       final thumbnailAspectRatio = aspectRatio ?? MediaAspectRatio.landscape;
 
-      Widget thumbnailWidget = VideoThumbnailPreview(
-        thumbnailUrl: thumbnailUrl,
-        blurhash: blurhash,
-        authorPubkey: authorPubkey,
+      Widget thumbnailWidget = Padding(
+        padding: EdgeInsetsDirectional.only(
+          bottom: !hideBottomOverlay ? videoBottomPadding.s : 0,
+        ),
+        child: VideoThumbnailPreview(
+          thumbnailUrl: thumbnailUrl,
+          blurhash: blurhash,
+          authorPubkey: authorPubkey,
+        ),
       );
 
       if (thumbnailAspectRatio < 1) {


### PR DESCRIPTION


## Description
<!-- Briefly explain the purpose of this PR and what it accomplishes. -->

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
3813

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<img width="1124" height="2134" alt="ScreenShot 2025-09-08 at 14 42 44@2x" src="https://github.com/user-attachments/assets/f1130fdb-0de5-409f-aaa9-aabbb6dc79db" />
<img width="1124" height="2134" alt="ScreenShot 2025-09-08 at 14 43 16@2x" src="https://github.com/user-attachments/assets/83438c50-9b57-4920-a516-62d4518d9857" />

