### PR TITLE
feat: add abbreviations for big crypto balances

### DIFF
--- a/lib/app/features/wallets/views/utils/crypto_formatter.dart
+++ b/lib/app/features/wallets/views/utils/crypto_formatter.dart
@@ -36,16 +36,6 @@ String formatCrypto(double value, [String? currency]) {
   return formatted;
 }
 
-String _processDecimalPart(String decimalPart) {
-  // Truncate to maximum 3 decimal places
-  final truncated = decimalPart.length > 3 ? decimalPart.substring(0, 3) : decimalPart;
-
-  // Remove trailing zeros
-  final trimmed = truncated.replaceAll(RegExp(r'0+$'), '');
-
-  return trimmed;
-}
-
 String _formatWithAbbreviation(double value) {
   // Find the appropriate scale
   final scale = _scaleInfo.firstWhere((scale) => value >= scale.value);
@@ -60,7 +50,14 @@ String _formatWithAbbreviation(double value) {
     return '$integerPart${scale.suffix}';
   }
 
-  final processedDecimal = _processDecimalPart(parts[1]);
+  String processDecimalPart(String decimalPart) {
+    // Truncate to maximum 3 decimal places
+    final truncated = decimalPart.length > 3 ? decimalPart.substring(0, 3) : decimalPart;
+    // Remove trailing zeros
+    return truncated.replaceAll(RegExp(r'0+$'), '');
+  }
+
+  final processedDecimal = processDecimalPart(parts[1]);
   return processedDecimal.isEmpty
       ? '$integerPart${scale.suffix}'
       : '$integerPart.$processedDecimal${scale.suffix}';

--- a/lib/app/features/wallets/views/utils/crypto_formatter.dart
+++ b/lib/app/features/wallets/views/utils/crypto_formatter.dart
@@ -5,6 +5,7 @@ import 'package:ion/app/utils/num.dart';
 String formatCrypto(double value, [String? currency]) {
   final formatted = switch (value) {
     0.0 => formatDouble(value),
+    _ when value >= 1000000 => _formatWithAbbreviation(value),
     _ when value >= 10 => _formatWithSmartTruncation(value, maxDecimals: 2, minDecimals: 2),
     // For values 1-9.99: max 6 decimals, min 2 decimals
     // Handle truncation for cases like 1.1234567 -> 1.123456 and 2.0000001 -> 2.00
@@ -20,6 +21,55 @@ String formatCrypto(double value, [String? currency]) {
   if (currency != null) return '$formatted $currency';
 
   return formatted;
+}
+
+String _formatWithAbbreviation(double value) {
+  String suffix;
+  double divisor;
+
+  if (value >= 1000000000000) {
+    // Trillion
+    suffix = 'T';
+    divisor = 1000000000000;
+  } else if (value >= 1000000000) {
+    // Billion
+    suffix = 'B';
+    divisor = 1000000000;
+  } else {
+    // Million
+    suffix = 'M';
+    divisor = 1000000;
+  }
+
+  final scaledValue = value / divisor;
+
+  // Convert to string and extract parts
+  final stringValue = scaledValue.toString();
+  final parts = stringValue.split('.');
+  final integerPart = parts[0];
+
+  if (parts.length == 1) {
+    // No decimal part
+    return '$integerPart$suffix';
+  }
+
+  var decimalPart = parts[1];
+
+  // Truncate to maximum 3 decimal places
+  if (decimalPart.length > 3) {
+    decimalPart = decimalPart.substring(0, 3);
+  }
+
+  // Remove trailing zeros
+  while (decimalPart.isNotEmpty && decimalPart.endsWith('0')) {
+    decimalPart = decimalPart.substring(0, decimalPart.length - 1);
+  }
+
+  if (decimalPart.isEmpty) {
+    return '$integerPart$suffix';
+  }
+
+  return '$integerPart.$decimalPart$suffix';
 }
 
 String _formatWithSmartTruncation(

--- a/lib/app/features/wallets/views/utils/crypto_formatter.dart
+++ b/lib/app/features/wallets/views/utils/crypto_formatter.dart
@@ -2,10 +2,23 @@
 
 import 'package:ion/app/utils/num.dart';
 
+// Constants for scale values
+
+const _million = 1000000.0;
+const _billion = 1000000000.0;
+const _trillion = 1000000000000.0;
+
+// Scale information for abbreviation formatting
+const List<({double value, String suffix})> _scaleInfo = [
+  (value: _trillion, suffix: 'T'),
+  (value: _billion, suffix: 'B'),
+  (value: _million, suffix: 'M'),
+];
+
 String formatCrypto(double value, [String? currency]) {
   final formatted = switch (value) {
     0.0 => formatDouble(value),
-    _ when value >= 1000000 => _formatWithAbbreviation(value),
+    _ when value >= _million => _formatWithAbbreviation(value),
     _ when value >= 10 => _formatWithSmartTruncation(value, maxDecimals: 2, minDecimals: 2),
     // For values 1-9.99: max 6 decimals, min 2 decimals
     // Handle truncation for cases like 1.1234567 -> 1.123456 and 2.0000001 -> 2.00
@@ -23,53 +36,39 @@ String formatCrypto(double value, [String? currency]) {
   return formatted;
 }
 
+String _processDecimalPart(String decimalPart) {
+  // Truncate to maximum 3 decimal places
+  final truncated = decimalPart.length > 3 ? decimalPart.substring(0, 3) : decimalPart;
+
+  // Remove trailing zeros
+  final trimmed = truncated.replaceAll(RegExp(r'0+$'), '');
+
+  return trimmed;
+}
+
 String _formatWithAbbreviation(double value) {
-  String suffix;
-  double divisor;
+  // Find the appropriate scale
+  final scale = _scaleInfo.firstWhere((scale) => value >= scale.value);
 
-  if (value >= 1000000000000) {
-    // Trillion
-    suffix = 'T';
-    divisor = 1000000000000;
-  } else if (value >= 1000000000) {
-    // Billion
-    suffix = 'B';
-    divisor = 1000000000;
-  } else {
-    // Million
-    suffix = 'M';
-    divisor = 1000000;
-  }
-
-  final scaledValue = value / divisor;
+  final scaledValue = value / scale.value;
 
   // Convert to string and extract parts
   final stringValue = scaledValue.toString();
   final parts = stringValue.split('.');
   final integerPart = parts[0];
 
+  // Handle cases with no decimal part
   if (parts.length == 1) {
-    // No decimal part
-    return '$integerPart$suffix';
+    return '$integerPart${scale.suffix}';
   }
 
-  var decimalPart = parts[1];
+  // Process decimal part
+  final processedDecimal = _processDecimalPart(parts[1]);
 
-  // Truncate to maximum 3 decimal places
-  if (decimalPart.length > 3) {
-    decimalPart = decimalPart.substring(0, 3);
-  }
-
-  // Remove trailing zeros
-  while (decimalPart.isNotEmpty && decimalPart.endsWith('0')) {
-    decimalPart = decimalPart.substring(0, decimalPart.length - 1);
-  }
-
-  if (decimalPart.isEmpty) {
-    return '$integerPart$suffix';
-  }
-
-  return '$integerPart.$decimalPart$suffix';
+  // Return with or without decimal part
+  return processedDecimal.isEmpty
+      ? '$integerPart${scale.suffix}'
+      : '$integerPart.$processedDecimal${scale.suffix}';
 }
 
 String _formatWithSmartTruncation(

--- a/lib/app/features/wallets/views/utils/crypto_formatter.dart
+++ b/lib/app/features/wallets/views/utils/crypto_formatter.dart
@@ -49,7 +49,6 @@ String _processDecimalPart(String decimalPart) {
 String _formatWithAbbreviation(double value) {
   // Find the appropriate scale
   final scale = _scaleInfo.firstWhere((scale) => value >= scale.value);
-
   final scaledValue = value / scale.value;
 
   // Convert to string and extract parts
@@ -57,15 +56,11 @@ String _formatWithAbbreviation(double value) {
   final parts = stringValue.split('.');
   final integerPart = parts[0];
 
-  // Handle cases with no decimal part
   if (parts.length == 1) {
     return '$integerPart${scale.suffix}';
   }
 
-  // Process decimal part
   final processedDecimal = _processDecimalPart(parts[1]);
-
-  // Return with or without decimal part
   return processedDecimal.isEmpty
       ? '$integerPart${scale.suffix}'
       : '$integerPart.$processedDecimal${scale.suffix}';

--- a/test/app/features/wallets/utils/crypto_formatter_test.dart
+++ b/test/app/features/wallets/utils/crypto_formatter_test.dart
@@ -13,7 +13,61 @@ void main() {
       });
     });
 
-    group('values >= 10 (maximum 2 decimal places, minimum 2)', () {
+    group('values >= 1M (abbreviated format)', () {
+      parameterizedGroup('million values formatting', [
+        (value: 1000000.0, expected: '1M'),
+        (value: 1500000.0, expected: '1.5M'),
+        (value: 1500900.0, expected: '1.5M'), // truncated, not rounded
+        (value: 1999999.0, expected: '1.999M'),
+        (value: 1999900.0, expected: '1.999M'),
+        (value: 12345678.0, expected: '12.345M'),
+        (value: 12345678.999, expected: '12.345M'),
+        (value: 999999999.0, expected: '999.999M'),
+        (value: 1000000.123456, expected: '1M'), // trailing zeros removed
+        (value: 2500000.0, expected: '2.5M'),
+        (value: 2560000.0, expected: '2.56M'),
+        (value: 2567000.0, expected: '2.567M'),
+        (value: 2567890.0, expected: '2.567M'), // truncated to 3 decimals
+      ], (t) {
+        test('formatCrypto(${t.value}) returns ${t.expected}', () {
+          expect(formatCrypto(t.value), t.expected);
+        });
+      });
+
+      parameterizedGroup('billion values formatting', [
+        (value: 1000000000.0, expected: '1B'),
+        (value: 1500000000.0, expected: '1.5B'),
+        (value: 1234567890.0, expected: '1.234B'),
+        (value: 1234567890.999, expected: '1.234B'),
+        (value: 999999999999.0, expected: '999.999B'),
+        (value: 18308397101.0, expected: '18.308B'),
+        (value: 18308397101.537, expected: '18.308B'),
+      ], (t) {
+        test('formatCrypto(${t.value}) returns ${t.expected}', () {
+          expect(formatCrypto(t.value), t.expected);
+        });
+      });
+
+      parameterizedGroup('trillion values formatting', [
+        (value: 1000000000000.0, expected: '1T'),
+        (value: 1500000000000.0, expected: '1.5T'),
+        (value: 18308397101537.0, expected: '18.308T'),
+        (value: 18308397101537.31, expected: '18.308T'),
+        (value: 1234567890123456.0, expected: '1234.567T'),
+        (value: 9999999999999999.0, expected: '10000T'),
+      ], (t) {
+        test('formatCrypto(${t.value}) returns ${t.expected}', () {
+          expect(formatCrypto(t.value), t.expected);
+        });
+      });
+
+      test('boundary values near 1M', () {
+        expect(formatCrypto(999999), '999,999.00'); // stays unabbreviated
+        expect(formatCrypto(1000000), '1M'); // becomes abbreviated
+      });
+    });
+
+    group('values >= 10 and < 1M (maximum 2 decimal places, minimum 2)', () {
       parameterizedGroup('large values formatting', [
         (value: 11.0, expected: '11.00'),
         (value: 100.0, expected: '100.00'),
@@ -22,8 +76,8 @@ void main() {
         (value: 1000.0, expected: '1,000.00'),
         (value: 1000.12, expected: '1,000.12'),
         (value: 1000.123, expected: '1,000.12'),
-        (value: 1234567.89, expected: '1,234,567.89'),
-        (value: 1234567.999, expected: '1,234,567.99'),
+        (value: 999999.89, expected: '999,999.89'),
+        (value: 999999.999, expected: '999,999.99'),
         (value: 50.0, expected: '50.00'),
         (value: 99.99, expected: '99.99'),
         (value: 10.1, expected: '10.10'),
@@ -89,6 +143,12 @@ void main() {
         (value: 11.0, currency: 'DOGE', expected: '11.00 DOGE'),
         (value: 11.099999999, currency: 'DOGE', expected: '11.09 DOGE'),
         (value: 0.123456, currency: 'ADA', expected: '0.123456 ADA'),
+        // Abbreviated format with currency
+        (value: 1000000.0, currency: 'USD', expected: '1M USD'),
+        (value: 1500000.0, currency: 'BTC', expected: '1.5M BTC'),
+        (value: 1000000000.0, currency: 'ETH', expected: '1B ETH'),
+        (value: 18308397101537.31, currency: 'USD', expected: '18.308T USD'),
+        (value: 2567890.0, currency: 'SATS', expected: '2.567M SATS'),
       ], (t) {
         test('formatCrypto(${t.value}, ${t.currency}) returns ${t.expected}', () {
           expect(formatCrypto(t.value, t.currency), t.expected);


### PR DESCRIPTION
## Description
Starting from millions, add the abbreviation for the big crypto values:
1,200,000	              -  1.2M
18,308,397	              -  18.3M
508,920,000	              -  508.9M
7,320,000,000	      -  7.32B
18,308,397,101,537.31  -  18.308T

## Task ID
ION-3692

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
