### PR TITLE
fix: improve NFT image rendering with SVG support and dynamic sizing

### DIFF
--- a/lib/app/features/wallets/views/components/nft_item.dart
+++ b/lib/app/features/wallets/views/components/nft_item.dart
@@ -3,12 +3,12 @@
 import 'package:flutter/material.dart';
 import 'package:ion/app/components/icons/network_icon_widget.dart';
 import 'package:ion/app/components/icons/wallet_item_icon_type.dart';
-import 'package:ion/app/components/image/ion_network_image.dart';
 import 'package:ion/app/components/list_item/list_item.dart';
 import 'package:ion/app/extensions/build_context.dart';
 import 'package:ion/app/extensions/num.dart';
 import 'package:ion/app/extensions/theme_data.dart';
 import 'package:ion/app/features/wallets/model/nft_data.f.dart';
+import 'package:ion/app/features/wallets/views/components/nft_picture.dart';
 
 class NftItem extends StatelessWidget {
   const NftItem({
@@ -56,12 +56,10 @@ class NftItem extends StatelessWidget {
         ],
       ),
       backgroundColor: backgroundColor ?? context.theme.appColors.tertiaryBackground,
-      leading: IonNetworkImage(
+      leading: NftPicture(
         imageUrl: nftData.imageUrl,
-        width: imageWidth,
-        height: imageHeight,
+        size: Size(imageWidth, imageHeight),
         fit: BoxFit.fitWidth,
-        borderRadius: BorderRadius.circular(16.0.s),
       ),
     );
   }

--- a/lib/app/features/wallets/views/components/nft_picture.dart
+++ b/lib/app/features/wallets/views/components/nft_picture.dart
@@ -1,28 +1,47 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
 import 'package:ion/app/components/image/ion_network_image.dart';
 import 'package:ion/app/extensions/num.dart';
+import 'package:ion/app/utils/image_path.dart';
 
 class NftPicture extends StatelessWidget {
   const NftPicture({
     required this.imageUrl,
+    required this.size,
+    this.fit = BoxFit.cover,
+    this.borderRadius = 16.0,
     super.key,
   });
 
-  static double get imageWidth => 170.0.s;
-  static double get imageHeight => 170.0.s;
-
   final String imageUrl;
-
+  final Size size;
+  final BoxFit fit;
+  final double borderRadius;
   @override
   Widget build(BuildContext context) {
+    if (imageUrl.isSvg) {
+      return ClipRRect(
+        borderRadius: BorderRadius.circular(borderRadius.s),
+        child: SizedBox(
+          width: size.width,
+          height: size.height,
+          child: SvgPicture.network(
+            imageUrl,
+            width: size.width,
+            height: size.height,
+            fit: fit,
+          ),
+        ),
+      );
+    }
     return IonNetworkImage(
       imageUrl: imageUrl,
-      width: imageWidth,
-      height: imageHeight,
-      fit: BoxFit.fitWidth,
-      borderRadius: BorderRadius.circular(16.0.s),
+      width: size.width,
+      height: size.height,
+      fit: fit,
+      borderRadius: BorderRadius.circular(borderRadius.s),
     );
   }
 }

--- a/lib/app/features/wallets/views/pages/nft_details/components/nft_details.dart
+++ b/lib/app/features/wallets/views/pages/nft_details/components/nft_details.dart
@@ -40,6 +40,7 @@ class NftDetails extends ConsumerWidget {
       children: [
         NftPicture(
           imageUrl: nftData.imageUrl,
+          size: Size(180.0.s, 170.0.s),
         ),
         SizedBox(height: 15.0.s),
         NftName(

--- a/lib/app/features/wallets/views/pages/send_nft_form.dart
+++ b/lib/app/features/wallets/views/pages/send_nft_form.dart
@@ -68,6 +68,7 @@ class SendNftForm extends HookConsumerWidget {
                   children: [
                     NftPicture(
                       imageUrl: selectedNft.imageUrl,
+                      size: Size(180.0.s, 170.0.s),
                     ),
                     SizedBox(height: 16.s),
                     NftName(

--- a/lib/app/features/wallets/views/pages/wallet_page/components/nfts/nft_grid_item.dart
+++ b/lib/app/features/wallets/views/pages/wallet_page/components/nfts/nft_grid_item.dart
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:flutter/material.dart';
-import 'package:ion/app/components/image/ion_network_image.dart';
 import 'package:ion/app/components/screen_offset/screen_side_offset.dart';
 import 'package:ion/app/extensions/build_context.dart';
 import 'package:ion/app/extensions/num.dart';
 import 'package:ion/app/extensions/theme_data.dart';
 import 'package:ion/app/features/wallets/model/nft_data.f.dart';
+import 'package:ion/app/features/wallets/views/components/nft_picture.dart';
 import 'package:ion/app/features/wallets/views/pages/wallet_page/components/nfts/constants.dart';
 import 'package:ion/app/features/wallets/views/pages/wallet_page/components/nfts/nfts_network.dart';
 import 'package:ion/app/router/app_routes.gr.dart';
@@ -45,12 +45,10 @@ class NftGridItem extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
-            IonNetworkImage(
+            NftPicture(
               imageUrl: nftData.imageUrl,
-              width: imageWidth,
-              height: imageWidth * 1.13,
-              fit: BoxFit.fitHeight,
-              borderRadius: borderRadius,
+              size: Size(imageWidth, imageWidth * 1.13),
+              borderRadius: 6,
             ),
             Text(
               nftData.name,

--- a/lib/app/features/wallets/views/pages/wallet_page/components/nfts/nft_list_item.dart
+++ b/lib/app/features/wallets/views/pages/wallet_page/components/nfts/nft_list_item.dart
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:flutter/material.dart';
-import 'package:ion/app/components/avatar/avatar.dart';
 import 'package:ion/app/components/list_item/list_item.dart';
 import 'package:ion/app/extensions/build_context.dart';
 import 'package:ion/app/extensions/num.dart';
 import 'package:ion/app/extensions/theme_data.dart';
 import 'package:ion/app/features/wallets/model/nft_data.f.dart';
+import 'package:ion/app/features/wallets/views/components/nft_picture.dart';
 import 'package:ion/app/features/wallets/views/pages/wallet_page/components/nfts/nfts_network.dart';
 
 class NftListItem extends StatelessWidget {
@@ -26,9 +26,10 @@ class NftListItem extends StatelessWidget {
       onTap: onTap,
       subtitle: Text('#${nftData.tokenId}'),
       backgroundColor: context.theme.appColors.tertiaryBackground,
-      leading: Avatar(
-        size: 36.0.s,
+      leading: NftPicture(
         imageUrl: nftData.imageUrl,
+        size: Size(36.0.s, 36.0.s),
+        borderRadius: 10,
       ),
       trailing: Column(
         crossAxisAlignment: CrossAxisAlignment.end,


### PR DESCRIPTION
## Description
This PR fixes NFT image rendering issues by adding SVG support and implementing dynamic sizing.

## Additional Notes
N/A

## Task ID
3825

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)

<img width="240" height="2340" alt="Simulator Screenshot - iPhone 13 mini - 2025-09-09 at 16 28 13" src="https://github.com/user-attachments/assets/08228da2-b745-47f7-9f4e-a8dbfd717463" />
<img width="240" height="2340" alt="Simulator Screenshot - iPhone 13 mini - 2025-09-09 at 16 43 53" src="https://github.com/user-attachments/assets/0bef7729-e6a0-4419-b59b-26c93883dbb6" />
<img width="240" height="2340" alt="Simulator Screenshot - iPhone 13 mini - 2025-09-09 at 16 44 38" src="https://github.com/user-attachments/assets/5387b14f-3c1c-4d2d-b3a0-31e67e56829c" />



