### PR TITLE
fix: use AnimationBehavior.preserved for stories and videos

### DIFF
--- a/lib/app/features/feed/stories/hooks/use_recording_progress.dart
+++ b/lib/app/features/feed/stories/hooks/use_recording_progress.dart
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: ice License 1.0
 
+import 'package:flutter/animation.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -17,7 +18,10 @@ RecordingProgressResult useRecordingProgress(
   WidgetRef ref, {
   required bool isRecording,
 }) {
-  final animationController = useAnimationController(duration: maxRecordingDuration);
+  final animationController = useAnimationController(
+    duration: maxRecordingDuration,
+    animationBehavior: AnimationBehavior.preserve,
+  );
   final currentRecordingDuration = useState<Duration>(Duration.zero);
 
   useEffect(

--- a/lib/app/features/feed/stories/hooks/use_story_image_progress.dart
+++ b/lib/app/features/feed/stories/hooks/use_story_image_progress.dart
@@ -20,6 +20,7 @@ UseImageStoryResult useImageStoryProgress({
 }) {
   final animationController = useAnimationController(
     duration: const Duration(seconds: 5),
+    animationBehavior: AnimationBehavior.preserve,
     keys: [storyId],
   );
 

--- a/lib/app/features/video/views/components/video_progress.dart
+++ b/lib/app/features/video/views/components/video_progress.dart
@@ -23,6 +23,7 @@ class VideoProgress extends HookWidget {
     final value = useValueListenable(controller);
     final animationController = useAnimationController(
       duration: value.duration,
+      animationBehavior: AnimationBehavior.preserve,
       keys: [value.duration],
     );
 


### PR DESCRIPTION
## Description
This PR changes the animation behavior for stories and videos to work correctly on android devices with animation settings modified.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
3818

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
