### PR TITLE
feat: make work payments request push for foreground and android back…

### DIFF
--- a/lib/app/features/chat/e2ee/providers/send_chat_message/send_e2ee_chat_message_service.r.dart
+++ b/lib/app/features/chat/e2ee/providers/send_chat_message/send_e2ee_chat_message_service.r.dart
@@ -106,8 +106,18 @@ class SendE2eeChatMessageService {
         throw UserMasterPubkeyNotFoundException();
       }
 
+      // Extract optional paymentRequested payload from tags:
+      // Expecting a tag formed as: [ReplaceablePrivateDirectMessageData.paymentRequestedTagName, jsonEncode(event.jsonPayload)]
+      final paymentRequestedTag = tags?.firstWhereOrNull(
+        (t) =>
+            t.isNotEmpty && t.first == ReplaceablePrivateDirectMessageData.paymentRequestedTagName,
+      );
+      final paymentRequested = (paymentRequestedTag != null && paymentRequestedTag.length > 1)
+          ? paymentRequestedTag[1]
+          : null;
       final localEventMessageData = ReplaceablePrivateDirectMessageData(
         content: content,
+        paymentRequested: paymentRequested,
         messageId: sharedId,
         publishedAt: publishedAt,
         editingEndedAt: editingEndedAt,
@@ -175,6 +185,7 @@ class SendE2eeChatMessageService {
             try {
               final remoteEventMessage = await ReplaceablePrivateDirectMessageData(
                 content: content,
+                paymentRequested: paymentRequested,
                 messageId: sharedId,
                 publishedAt: publishedAt,
                 editingEndedAt: editingEndedAt,

--- a/lib/app/features/core/providers/app_locale_provider.r.dart
+++ b/lib/app/features/core/providers/app_locale_provider.r.dart
@@ -46,7 +46,7 @@ class AppLocale extends _$AppLocale {
     // Saving app locate using sharedPreferencesFoundation
     // to be able to read this value in the iOS Notification Service Extension
     final sharedPreferencesFoundation = await ref.read(sharedPreferencesFoundationProvider.future);
-    await sharedPreferencesFoundation.setString(_localePersistenceKey, state.languageCode);
+    await sharedPreferencesFoundation.setString(localePersistenceKey, state.languageCode);
 
     final identityKeyName = ref.read(currentIdentityKeyNameSelectorProvider);
     if (identityKeyName == null) {
@@ -54,7 +54,7 @@ class AppLocale extends _$AppLocale {
     }
     await ref
         .read(userPreferencesServiceProvider(identityKeyName: identityKeyName))
-        .setValue(_localePersistenceKey, json.encode(state.languageCode));
+        .setValue(localePersistenceKey, json.encode(state.languageCode));
   }
 
   Locale _loadSavedState() {
@@ -66,11 +66,11 @@ class AppLocale extends _$AppLocale {
 
     final userPreferencesService =
         ref.watch(userPreferencesServiceProvider(identityKeyName: identityKeyName));
-    final savedAppLocale = userPreferencesService.getValue<String>(_localePersistenceKey);
+    final savedAppLocale = userPreferencesService.getValue<String>(localePersistenceKey);
     return savedAppLocale != null ? Locale(json.decode(savedAppLocale) as String) : systemLocale;
   }
 
-  static const _localePersistenceKey = 'app_locale';
+  static const localePersistenceKey = 'app_locale';
 }
 
 @riverpod

--- a/lib/app/features/push_notifications/providers/foreground_messages_handler_provider.r.dart
+++ b/lib/app/features/push_notifications/providers/foreground_messages_handler_provider.r.dart
@@ -11,6 +11,7 @@ import 'package:ion/app/features/chat/recent_chats/providers/money_message_provi
 import 'package:ion/app/features/ion_connect/model/ion_connect_gift_wrap.f.dart';
 import 'package:ion/app/features/push_notifications/data/models/ion_connect_push_data_payload.f.dart';
 import 'package:ion/app/features/push_notifications/providers/configure_firebase_app_provider.r.dart';
+import 'package:ion/app/features/push_notifications/providers/fund_request_tag_handler.r.dart';
 import 'package:ion/app/features/push_notifications/providers/notification_data_parser_provider.r.dart';
 import 'package:ion/app/features/user_profile/database/dao/user_metadata_dao.m.dart';
 import 'package:ion/app/router/app_routes.gr.dart';
@@ -47,6 +48,9 @@ class ForegroundMessagesHandler extends _$ForegroundMessagesHandler {
         return (event, userMetadata);
       },
     );
+
+    final fundsRequestTagHandler = await ref.read(fundsRequestTagHandlerProvider.future);
+    await fundsRequestTagHandler.handle(data.decryptedEvent);
 
     if (await _shouldSkipOwnGiftWrap(data: data)) {
       return;

--- a/lib/app/features/push_notifications/providers/fund_request_tag_handler.r.dart
+++ b/lib/app/features/push_notifications/providers/fund_request_tag_handler.r.dart
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'dart:convert';
+
+import 'package:collection/collection.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:ion/app/features/chat/e2ee/model/entities/private_direct_message_data.f.dart';
+import 'package:ion/app/features/ion_connect/ion_connect.dart';
+import 'package:ion/app/features/wallets/data/repository/request_assets_repository.r.dart';
+import 'package:ion/app/features/wallets/model/entities/funds_request_entity.f.dart';
+import 'package:ion/app/services/logger/logger.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'fund_request_tag_handler.r.g.dart';
+
+/// Handles a funds request (1755) embedded as a tag on an 30014
+class FundsRequestTagHandler {
+  FundsRequestTagHandler(this._repo);
+
+  final RequestAssetsRepository _repo;
+
+  /// Looks for the `paymentRequested` tag, rebuilds the 1755 EventMessage from JSON,
+  /// and persists it to the wallets DB
+  Future<void> handle(EventMessage? event) async {
+    if (event == null) {
+      return;
+    }
+    try {
+      final tag = event.tags.firstWhereOrNull(
+        (t) =>
+            t.isNotEmpty && t.first == ReplaceablePrivateDirectMessageData.paymentRequestedTagName,
+      );
+      if (tag == null || tag.length < 2) {
+        return;
+      }
+
+      final rawJson = tag[1];
+      final decoded = jsonDecode(rawJson) as Map<String, dynamic>;
+      final requestEvent = EventMessage.fromPayloadJson(decoded);
+      final request = FundsRequestEntity.fromEventMessage(requestEvent);
+
+      final updated = request.copyWith(
+        data: request.data.copyWith(request: rawJson),
+      );
+
+      await _repo.saveRequestAsset(updated);
+      Logger.log('[FundsRequestTagHandler] persisted 1755 from tag: ${request.id}');
+    } catch (e, _) {
+      Logger.log('[FundsRequestTagHandler] failed to persist 1755 from tag: $e');
+    }
+  }
+}
+
+@riverpod
+Future<FundsRequestTagHandler> fundsRequestTagHandler(Ref ref) async {
+  final requestAssetsRepository = ref.watch(requestAssetsRepositoryProvider);
+  return FundsRequestTagHandler(requestAssetsRepository);
+}

--- a/lib/app/features/user/providers/request_coins_submit_notifier.r.dart
+++ b/lib/app/features/user/providers/request_coins_submit_notifier.r.dart
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:ion/app/exceptions/exceptions.dart';
 import 'package:ion/app/features/auth/providers/auth_provider.m.dart';
+import 'package:ion/app/features/chat/e2ee/model/entities/private_direct_message_data.f.dart';
 import 'package:ion/app/features/chat/e2ee/providers/send_chat_message_service.r.dart';
 import 'package:ion/app/features/ion_connect/model/event_reference.f.dart';
 import 'package:ion/app/features/user/model/request_coins_form_data.f.dart';
@@ -66,12 +68,17 @@ class RequestCoinsSubmitNotifier extends _$RequestCoinsSubmitNotifier {
       final content = eventReference.encode();
       final tag = eventReference.toTag();
 
+      final paymentRequestedTag = [
+        ReplaceablePrivateDirectMessageData.paymentRequestedTagName,
+        jsonEncode(event.jsonPayload),
+      ];
+
       final chatService = await ref.read(sendChatMessageServiceProvider.future);
       await chatService.send(
         kind: event.kind,
         receiverPubkey: pubkeys.receiver.masterPubkey,
         content: content,
-        tags: [tag],
+        tags: [tag, paymentRequestedTag],
       );
     });
   }

--- a/lib/app/features/user_profile/database/user_profile_database.d.dart
+++ b/lib/app/features/user_profile/database/user_profile_database.d.dart
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: ice License 1.0
 
-import 'dart:io';
-
 import 'package:drift/drift.dart';
 import 'package:drift_flutter/drift_flutter.dart';
 import 'package:ion/app/features/ion_connect/database/converters/event_reference_converter.d.dart';
@@ -10,6 +8,7 @@ import 'package:ion/app/features/ion_connect/model/event_reference.f.dart';
 import 'package:ion/app/features/user_profile/database/tables/user_badge_info_table.d.dart';
 import 'package:ion/app/features/user_profile/database/tables/user_delegation_table.d.dart';
 import 'package:ion/app/features/user_profile/database/tables/user_metadata_table.d.dart';
+import 'package:ion/app/utils/directory.dart';
 import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:path_provider_foundation/path_provider_foundation.dart';
@@ -58,13 +57,13 @@ class UserProfileDatabase extends _$UserProfileDatabase {
 
             final dbFile = join(basePath, '$databaseName.sqlite');
 
-            _ensureDirectoryExists(dbFile);
+            ensureDirectoryExists(dbFile);
 
             return dbFile;
           } catch (e) {
             final dbFile =
                 join((await getApplicationDocumentsDirectory()).path, '$databaseName.sqlite');
-            _ensureDirectoryExists(dbFile);
+            ensureDirectoryExists(dbFile);
 
             return dbFile;
           }
@@ -72,12 +71,5 @@ class UserProfileDatabase extends _$UserProfileDatabase {
         shareAcrossIsolates: true,
       ),
     );
-  }
-
-  static void _ensureDirectoryExists(String filePath) {
-    final dir = Directory(dirname(filePath));
-    if (!dir.existsSync()) {
-      dir.createSync(recursive: true);
-    }
   }
 }

--- a/lib/app/utils/directory.dart
+++ b/lib/app/utils/directory.dart
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'dart:io';
+
+import 'package:path/path.dart';
+
+void ensureDirectoryExists(String filePath) {
+  final dir = Directory(dirname(filePath));
+  if (!dir.existsSync()) {
+    dir.createSync(recursive: true);
+  }
+}


### PR DESCRIPTION
## Description
- 30014 can now include 'payment-requested' and 'payment-sent' tags;
- on push source side: populate 'payment-requested' tag with corresponding 1755 event for gift wrapped 30014 on payment request from a user;
- on push receiver side: extract 1755 from  'payment-requested' tag and save to local DB;
- updated android background pushes implementation to support request funds push (see attached video with such a push);
- made wallet database available on native ios side;


## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)

https://github.com/user-attachments/assets/c64f4dd7-ff20-43d4-9232-93a007001ca3


