### PR TITLE
fix: revoke additional unused permissions from AndroidManifest.xml

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -21,6 +21,9 @@
     <!-- Revoke AD_ID permission because AppsFlyer adds it by default, but we do not use it -->
     <uses-permission android:name="com.google.android.gms.permission.AD_ID"
         tools:node="remove" />
+    <uses-permission android:name="android.permission.ACCESS_ADSERVICES_ATTRIBUTION" tools:node="remove" />
+    <uses-permission android:name="android.permission.ACCESS_ADSERVICES_AD_ID" tools:node="remove" />
+
 
     <uses-sdk
         android:minSdkVersion="23"


### PR DESCRIPTION
## Description
- Removed ACCESS_ADSERVICES_ATTRIBUTION and ACCESS_ADSERVICES_AD_ID permissions that are not utilized in the application.

## Additional Notes
N/A

## Task ID
3854

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
