### PR TITLE
fix: icolud exception issue when try restore transaction history

### DIFF
--- a/lib/app/features/wallets/providers/transactions_visibility_cloud_backup.r.dart
+++ b/lib/app/features/wallets/providers/transactions_visibility_cloud_backup.r.dart
@@ -136,7 +136,8 @@ class TransactionsVisibilityCloudBackupIos implements TransactionsVisibilityClou
     required String restoredKey,
   }) async {
     await visibilityDao.transaction(() async {
-      await visibilityDao.customStatement('UPDATE transaction_visibility_status_table SET status = 1;');
+      await visibilityDao
+          .customStatement('UPDATE transaction_visibility_status_table SET status = 1;');
     });
 
     await localStorage.setBool(key: restoredKey, value: true);


### PR DESCRIPTION
## Description
- Fix issue if Icloud don't give us access to file and throw error

## Task ID
- No task  here

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
