### PR TITLE
fix(text_message): correct line width comparison for message overlap detection

### DIFF
--- a/lib/app/features/chat/views/components/message_items/message_types/text_message/text_message.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/text_message/text_message.dart
@@ -204,7 +204,7 @@ class _TextMessageContent extends HookWidget {
 
       final lineMetrics = multiLineTextPainter.computeLineMetrics();
 
-      final wouldOverlap = lineMetrics.last.width.s > (maxAvailableWidth - metadataWidth.value.s);
+      final wouldOverlap = lineMetrics.last.width > (maxAvailableWidth - metadataWidth.value.s);
 
       return Stack(
         alignment: AlignmentDirectional.bottomEnd,


### PR DESCRIPTION
## Description
Correct the line-width comparison used to detect message content overlap.

## Additional Notes
N/A

## Task ID
3858

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)


https://github.com/user-attachments/assets/8c3fde70-c64f-4974-9dd4-df40a9e7cb5e

