### PR TITLE
feat: add story owner user info to shared story message component

### DIFF
--- a/lib/app/features/chat/views/components/message_items/message_types/post_message/shared_story_message.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/post_message/shared_story_message.dart
@@ -215,8 +215,9 @@ class _StoryOwnerUserInfo extends ConsumerWidget {
       start: 12.0.s,
       end: 14.0.s,
       child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          IonConnectAvatar(size: 20, masterPubkey: masterPubkey),
+          IonConnectAvatar(size: 20.s, masterPubkey: masterPubkey),
           SizedBox(width: 4.0.s),
           Expanded(
             child: Text(


### PR DESCRIPTION
## Description
- Introduced a new widget to display the owner's information for shared stories, including their avatar and display name.
- Updated the shared story message layout to include this new information.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<img width="280" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-15 at 13 04 25" src="https://github.com/user-attachments/assets/66769ee3-f666-4e2d-83ff-4be7eb165c5d" />

