### PR TITLE
fix: content language initial state

### DIFF
--- a/lib/app/features/optimistic_ui/features/language/language_sync_strategy_provider.r.dart
+++ b/lib/app/features/optimistic_ui/features/language/language_sync_strategy_provider.r.dart
@@ -45,19 +45,18 @@ OptimisticService<ContentLangSet> contentLanguageService(Ref ref) {
   final manager = ref.watch(contentLanguageManagerProvider);
   final service = OptimisticService<ContentLangSet>(manager: manager);
 
-  if (manager.snapshot.isEmpty) {
-    service.initialize([_initialLangSet(ref)]);
-  }
-
-  ref.watch(currentUserInterestsSetProvider(InterestSetType.languages)).whenData((entity) {
+  ref.watch(currentUserInterestsSetProvider(InterestSetType.languages).future).then((entity) {
     final pubkey = ref.read(currentPubkeySelectorProvider);
-    if (entity == null || pubkey == null) return;
+    if (pubkey == null) return;
 
     service.initialize([
-      ContentLangSet(
-        pubkey: pubkey,
-        hashtags: entity.data.hashtags,
-      ).sorted,
+      if (entity != null)
+        ContentLangSet(
+          pubkey: pubkey,
+          hashtags: entity.data.hashtags,
+        ).sorted
+      else
+        _initialLangSet(ref),
     ]);
   });
 


### PR DESCRIPTION
## Description
This PR fixes content language optimistic UI initial state. So it first fetches the remote event and only after that initiates the provider with the initial value.

## Task ID
ION-3880

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

