### PR TITLE
build(ios): remove xcode select ios step

### DIFF
--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -211,10 +211,6 @@ jobs:
             ~/.pub-cache
             ./*
           key: ${{ github.sha }}_${{ github.run_number }}
-      - name: Setup Xcode
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: latest-stable
       - name: Mask APP environment and keys in logs
         id: mask-secrets
         run: |


### PR DESCRIPTION
## Description
This PR removes the "Setup Xcode" step from iOS CI/CD workflow.
It is no longer needed, since the [corresponding issue](https://github.com/actions/runner-images/issues/12758) is resolved and the "Setup Xcode" step starts to select "Code 26.0.0" as "latest-stable", instead of 16.4.0 - [related issue](https://github.com/maxim-lobanov/setup-xcode/issues/96).

## Task ID
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

