### PR TITLE
feat: ListCachedObjects cache replacement of sync providers

### DIFF
--- a/lib/app/features/components/entities_list/components/repost_list_item.dart
+++ b/lib/app/features/components/entities_list/components/repost_list_item.dart
@@ -35,12 +35,12 @@ class RepostListItem extends ConsumerWidget {
           ionConnectEntityWithCountersProvider(eventReference: eventReference).select((value) {
             final entity = value.valueOrNull;
             if (entity != null) {
-              ListCachedObjects.updateObject<IonConnectEntity, EventReference>(context, entity);
+              ListCachedObjects.updateObject<IonConnectEntity>(context, entity);
             }
             return entity;
           }),
         ) ??
-        ListCachedObjects.maybeObjectOf<IonConnectEntity, EventReference>(context, eventReference);
+        ListCachedObjects.maybeObjectOf<IonConnectEntity>(context, eventReference);
 
     if (repostEntity == null) {
       return const Skeleton(child: PostSkeleton());

--- a/lib/app/features/components/entities_list/components/repost_list_item.dart
+++ b/lib/app/features/components/entities_list/components/repost_list_item.dart
@@ -30,7 +30,7 @@ class RepostListItem extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final repostEntity =
-        ref.watch(ionConnectSyncEntityWithCountersProvider(eventReference: eventReference));
+        ref.watch(ionConnectEntityWithCountersProvider(eventReference: eventReference)).valueOrNull;
 
     if (repostEntity == null) {
       return const Skeleton(child: PostSkeleton());

--- a/lib/app/features/components/entities_list/components/repost_list_item.dart
+++ b/lib/app/features/components/entities_list/components/repost_list_item.dart
@@ -15,6 +15,7 @@ import 'package:ion/app/features/feed/views/components/article/article.dart';
 import 'package:ion/app/features/feed/views/components/post/post.dart';
 import 'package:ion/app/features/feed/views/components/post/post_skeleton.dart';
 import 'package:ion/app/features/ion_connect/model/event_reference.f.dart';
+import 'package:ion/app/features/ion_connect/model/ion_connect_entity.dart';
 import 'package:ion/app/router/app_routes.gr.dart';
 import 'package:ion/app/typedefs/typedefs.dart';
 
@@ -34,12 +35,12 @@ class RepostListItem extends ConsumerWidget {
           ionConnectEntityWithCountersProvider(eventReference: eventReference).select((value) {
             final entity = value.valueOrNull;
             if (entity != null) {
-              ListCachedEntities.updateEntity(context, entity);
+              ListCachedObjects.updateObject<IonConnectEntity, EventReference>(context, entity);
             }
             return entity;
           }),
         ) ??
-        ListCachedEntities.maybeEntityOf(context, eventReference);
+        ListCachedObjects.maybeObjectOf<IonConnectEntity, EventReference>(context, eventReference);
 
     if (repostEntity == null) {
       return const Skeleton(child: PostSkeleton());

--- a/lib/app/features/components/entities_list/components/repost_list_item.dart
+++ b/lib/app/features/components/entities_list/components/repost_list_item.dart
@@ -5,6 +5,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/skeleton/skeleton.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/components/entities_list/components/repost_author_header.dart';
+import 'package:ion/app/features/components/entities_list/list_cached_entities.dart';
 import 'package:ion/app/features/feed/data/models/entities/article_data.f.dart';
 import 'package:ion/app/features/feed/data/models/entities/generic_repost.f.dart';
 import 'package:ion/app/features/feed/data/models/entities/modifiable_post_data.f.dart';
@@ -29,8 +30,16 @@ class RepostListItem extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final repostEntity =
-        ref.watch(ionConnectEntityWithCountersProvider(eventReference: eventReference)).valueOrNull;
+    final repostEntity = ref.watch(
+          ionConnectEntityWithCountersProvider(eventReference: eventReference).select((value) {
+            final entity = value.valueOrNull;
+            if (entity != null) {
+              ListCachedEntities.updateEntity(context, entity);
+            }
+            return entity;
+          }),
+        ) ??
+        ListCachedEntities.maybeEntityOf(context, eventReference);
 
     if (repostEntity == null) {
       return const Skeleton(child: PostSkeleton());

--- a/lib/app/features/components/entities_list/entities_list.dart
+++ b/lib/app/features/components/entities_list/entities_list.dart
@@ -131,11 +131,16 @@ class _EntityListItem extends HookConsumerWidget {
 
   bool _isRepostedEntityDeleted(BuildContext context, WidgetRef ref, IonConnectEntity entity) {
     if (entity is GenericRepostEntity) {
-      final repostedEntity = ref
-              .watch(
-                ionConnectEntityWithCountersProvider(eventReference: entity.data.eventReference),
-              )
-              .valueOrNull ??
+      final repostedEntity = ref.watch(
+            ionConnectEntityWithCountersProvider(eventReference: entity.data.eventReference)
+                .select((value) {
+              final entity = value.valueOrNull;
+              if (entity != null) {
+                ListCachedEntities.updateEntity(context, entity);
+              }
+              return entity;
+            }),
+          ) ??
           ListCachedEntities.maybeEntityOf(context, eventReference);
       return repostedEntity == null ||
           (repostedEntity is SoftDeletableEntity && repostedEntity.isDeleted);
@@ -150,7 +155,15 @@ class _EntityListItem extends HookConsumerWidget {
   }
 
   bool _hasMetadata(BuildContext context, WidgetRef ref, IonConnectEntity entity) {
-    final userMetadata = ref.watch(userMetadataSyncProvider(entity.masterPubkey)) ??
+    final userMetadata = ref.watch(
+          userMetadataProvider(entity.masterPubkey).select((value) {
+            final entity = value.valueOrNull;
+            if (entity != null) {
+              ListCachedEntities.updateEntity(context, entity);
+            }
+            return entity;
+          }),
+        ) ??
         ListCachedEntities.maybeEntityOf(context, eventReference);
 
     return userMetadata != null;

--- a/lib/app/features/components/entities_list/entities_list.dart
+++ b/lib/app/features/components/entities_list/entities_list.dart
@@ -87,12 +87,12 @@ class _EntityListItem extends HookConsumerWidget {
           ionConnectEntityProvider(eventReference: eventReference).select((value) {
             final entity = value.valueOrNull;
             if (entity != null) {
-              ListCachedObjects.updateObject<IonConnectEntity, EventReference>(context, entity);
+              ListCachedObjects.updateObject<IonConnectEntity>(context, entity);
             }
             return entity;
           }),
         ) ??
-        ListCachedObjects.maybeObjectOf<IonConnectEntity, EventReference>(context, eventReference);
+        ListCachedObjects.maybeObjectOf<IonConnectEntity>(context, eventReference);
 
     if (entity == null ||
         ListEntityHelper.isUserMuted(ref, entity.masterPubkey, showMuted: showMuted) ||

--- a/lib/app/features/components/entities_list/entities_list.dart
+++ b/lib/app/features/components/entities_list/entities_list.dart
@@ -66,7 +66,7 @@ class EntitiesList extends HookWidget {
   }
 }
 
-class _EntityListItem extends ConsumerStatefulWidget {
+class _EntityListItem extends HookConsumerWidget {
   _EntityListItem({
     required this.eventReference,
     required this.displayParent,
@@ -85,22 +85,13 @@ class _EntityListItem extends ConsumerStatefulWidget {
   final bool showMuted;
 
   @override
-  ConsumerState<_EntityListItem> createState() => _EntityListItemState();
-}
+  Widget build(BuildContext context, WidgetRef ref) {
+    useAutomaticKeepAlive();
 
-class _EntityListItemState extends ConsumerState<_EntityListItem>
-    with AutomaticKeepAliveClientMixin<_EntityListItem> {
-  @override
-  bool get wantKeepAlive => true;
-
-  @override
-  Widget build(BuildContext context) {
-    super.build(context);
-    final entity =
-        ref.watch(ionConnectEntityProvider(eventReference: widget.eventReference)).valueOrNull;
+    final entity = ref.watch(ionConnectEntityProvider(eventReference: eventReference)).valueOrNull;
 
     if (entity == null ||
-        _isBlockedOrMutedOrBlocking(ref, entity, widget.showMuted) ||
+        _isBlockedOrMutedOrBlocking(ref, entity, showMuted) ||
         _isDeleted(ref, entity) ||
         _isRepostedEntityDeleted(ref, entity) ||
         !_hasMetadata(ref, entity)) {
@@ -108,17 +99,17 @@ class _EntityListItemState extends ConsumerState<_EntityListItem>
     }
 
     return _BottomSeparator(
-      height: widget.separatorHeight,
+      height: separatorHeight,
       child: switch (entity) {
         ModifiablePostEntity() || PostEntity() => PostListItem(
-            eventReference: widget.eventReference,
-            displayParent: widget.displayParent,
-            onVideoTap: widget.onVideoTap,
+            eventReference: entity.toEventReference(),
+            displayParent: displayParent,
+            onVideoTap: onVideoTap,
           ),
         final ArticleEntity article => ArticleListItem(article: article),
         GenericRepostEntity() ||
         RepostEntity() =>
-          RepostListItem(eventReference: widget.eventReference, onVideoTap: widget.onVideoTap),
+          RepostListItem(eventReference: entity.toEventReference(), onVideoTap: onVideoTap),
         _ => const SizedBox.shrink()
       },
     );

--- a/lib/app/features/components/entities_list/entities_list.dart
+++ b/lib/app/features/components/entities_list/entities_list.dart
@@ -44,27 +44,25 @@ class EntitiesList extends HookWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ListCachedEntities(
-      child: SliverList.builder(
-        itemCount: items.length,
-        itemBuilder: (BuildContext context, int index) {
-          final feedListItem = items[index];
-          return switch (feedListItem) {
-            CustomIonEntityListItem(child: final child) =>
-              _CustomListItem(separatorHeight: separatorHeight, child: child),
-            EventIonEntityListItem(eventReference: final eventReference) => _EntityListItem(
-                key: ValueKey(eventReference),
-                eventReference: eventReference,
-                displayParent: displayParent,
-                separatorHeight: separatorHeight,
-                onVideoTap: onVideoTap,
-                readFromDB: readFromDB,
-                showMuted: showMuted,
-              ),
-            IonEntityListItem() => const SizedBox.shrink()
-          };
-        },
-      ),
+    return SliverList.builder(
+      itemCount: items.length,
+      itemBuilder: (BuildContext context, int index) {
+        final feedListItem = items[index];
+        return switch (feedListItem) {
+          CustomIonEntityListItem(child: final child) =>
+            _CustomListItem(separatorHeight: separatorHeight, child: child),
+          EventIonEntityListItem(eventReference: final eventReference) => _EntityListItem(
+              key: ValueKey(eventReference),
+              eventReference: eventReference,
+              displayParent: displayParent,
+              separatorHeight: separatorHeight,
+              onVideoTap: onVideoTap,
+              readFromDB: readFromDB,
+              showMuted: showMuted,
+            ),
+          IonEntityListItem() => const SizedBox.shrink()
+        };
+      },
     );
   }
 }

--- a/lib/app/features/components/entities_list/entities_list.dart
+++ b/lib/app/features/components/entities_list/entities_list.dart
@@ -63,7 +63,7 @@ class EntitiesList extends HookWidget {
   }
 }
 
-class _EntityListItem extends HookConsumerWidget {
+class _EntityListItem extends ConsumerWidget {
   _EntityListItem({
     required this.eventReference,
     required this.displayParent,

--- a/lib/app/features/components/entities_list/list_cached_entities.dart
+++ b/lib/app/features/components/entities_list/list_cached_entities.dart
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: ice License 1.0
+
 import 'package:collection/collection.dart';
 import 'package:flutter/widgets.dart';
 import 'package:ion/app/features/ion_connect/model/event_reference.f.dart';

--- a/lib/app/features/components/entities_list/list_cached_entities.dart
+++ b/lib/app/features/components/entities_list/list_cached_entities.dart
@@ -11,10 +11,12 @@ class ListCachedEntities extends InheritedWidget {
   final List<IonConnectEntity> entities = [];
 
   static IonConnectEntity? maybeEntityOf(BuildContext context, EventReference eventReference) {
-    return context
+    final entity = context
         .dependOnInheritedWidgetOfExactType<ListCachedEntities>()
         ?.entities
         .firstWhereOrNull((entity) => entity.toEventReference() == eventReference);
+
+    return entity;
   }
 
   static void updateEntity(BuildContext context, IonConnectEntity entity) {
@@ -22,7 +24,7 @@ class ListCachedEntities extends InheritedWidget {
 
     if (entities == null) return;
 
-    final index = entities.indexWhere((e) => e.id == entity.id);
+    final index = entities.indexWhere((e) => e.toEventReference() == entity.toEventReference());
     if (index != -1) {
       if (entities[index] != entity) {
         final updatedEntities = List<IonConnectEntity>.from(entities);

--- a/lib/app/features/components/entities_list/list_cached_entities.dart
+++ b/lib/app/features/components/entities_list/list_cached_entities.dart
@@ -1,0 +1,41 @@
+import 'package:collection/collection.dart';
+import 'package:flutter/widgets.dart';
+import 'package:ion/app/features/ion_connect/model/event_reference.f.dart';
+import 'package:ion/app/features/ion_connect/model/ion_connect_entity.dart';
+
+class ListCachedEntities extends InheritedWidget {
+  ListCachedEntities({required super.child, super.key}) : super();
+
+  final List<IonConnectEntity> entities = [];
+
+  static IonConnectEntity? maybeEntityOf(BuildContext context, EventReference eventReference) {
+    return context
+        .dependOnInheritedWidgetOfExactType<ListCachedEntities>()
+        ?.entities
+        .firstWhereOrNull((entity) => entity.toEventReference() == eventReference);
+  }
+
+  static void updateEntity(BuildContext context, IonConnectEntity entity) {
+    final entities = context.dependOnInheritedWidgetOfExactType<ListCachedEntities>()?.entities;
+
+    if (entities == null) return;
+
+    final index = entities.indexWhere((e) => e.id == entity.id);
+    if (index != -1) {
+      if (entities[index] != entity) {
+        final updatedEntities = List<IonConnectEntity>.from(entities);
+        updatedEntities[index] = entity;
+        entities
+          ..clear()
+          ..addAll(updatedEntities);
+      }
+    } else {
+      entities.add(entity);
+    }
+  }
+
+  @override
+  bool updateShouldNotify(covariant InheritedWidget oldWidget) {
+    return false;
+  }
+}

--- a/lib/app/features/components/entities_list/list_cached_entities.dart
+++ b/lib/app/features/components/entities_list/list_cached_entities.dart
@@ -9,7 +9,10 @@ import 'package:ion/app/features/user_block/optimistic_ui/model/blocked_user.f.d
 class ListCachedObjects extends InheritedWidget {
   ListCachedObjects({required super.child, super.key}) : super();
 
-  final objects = <Object>[];
+  final List<Object> _objects = <Object>[];
+  List<Object> get objects => _objects;
+
+  static const equality = DeepCollectionEquality();
 
   static dynamic identifierSelector<T extends Object>(T object) {
     return switch (object) {
@@ -40,7 +43,6 @@ class ListCachedObjects extends InheritedWidget {
     final objects = context.dependOnInheritedWidgetOfExactType<ListCachedObjects>()?.objects;
     if (objects == null) return;
 
-    const equality = DeepCollectionEquality();
     final identifier = identifierSelector<T>(object);
 
     for (var i = 0; i < objects.length; i++) {
@@ -90,6 +92,11 @@ class ListCachedObjects extends InheritedWidget {
 
   @override
   bool updateShouldNotify(covariant InheritedWidget oldWidget) {
+    if (oldWidget is ListCachedObjects) {
+      const equality = DeepCollectionEquality();
+      return !equality.equals(objects, oldWidget.objects);
+    }
+
     return false;
   }
 }

--- a/lib/app/features/components/entities_list/list_cached_entities.dart
+++ b/lib/app/features/components/entities_list/list_cached_entities.dart
@@ -2,40 +2,72 @@
 
 import 'package:collection/collection.dart';
 import 'package:flutter/widgets.dart';
-import 'package:ion/app/features/ion_connect/model/event_reference.f.dart';
 import 'package:ion/app/features/ion_connect/model/ion_connect_entity.dart';
+import 'package:ion/app/features/user_block/optimistic_ui/model/blocked_user.f.dart';
 
-class ListCachedEntities extends InheritedWidget {
-  ListCachedEntities({required super.child, super.key}) : super();
+class ListCachedObjects extends InheritedWidget {
+  ListCachedObjects({required super.child, super.key}) : super();
 
-  final List<IonConnectEntity> entities = [];
+  final objects = <Object>[];
 
-  static IonConnectEntity? maybeEntityOf(BuildContext context, EventReference eventReference) {
+  static I identifierSelector<T extends Object, I>(T object) {
+    if (object is IonConnectEntity) {
+      return object.toEventReference() as I;
+    } else if (object is BlockedUser) {
+      return object.masterPubkey as I;
+    } else {
+      throw ArgumentError('Unknown type for identifierSelector');
+    }
+  }
+
+  static T? maybeObjectOf<T extends Object, I>(BuildContext context, I identifier) {
     final entity = context
-        .dependOnInheritedWidgetOfExactType<ListCachedEntities>()
-        ?.entities
-        .firstWhereOrNull((entity) => entity.toEventReference() == eventReference);
+        .dependOnInheritedWidgetOfExactType<ListCachedObjects>()
+        ?.objects
+        .whereType<T>()
+        .firstWhereOrNull((object) => identifierSelector<T, I>(object) == identifier);
 
     return entity;
   }
 
-  static void updateEntity(BuildContext context, IonConnectEntity entity) {
-    final entities = context.dependOnInheritedWidgetOfExactType<ListCachedEntities>()?.entities;
+  static List<T> maybeObjectsOf<T>(BuildContext context) {
+    final objects = context.dependOnInheritedWidgetOfExactType<ListCachedObjects>()?.objects;
+    if (objects == null) return [];
+    return objects.whereType<T>().toList();
+  }
 
-    if (entities == null) return;
+  static void updateObject<T extends Object, I>(BuildContext context, T object) {
+    final objects = context.dependOnInheritedWidgetOfExactType<ListCachedObjects>()?.objects;
 
-    final index = entities.indexWhere((e) => e.toEventReference() == entity.toEventReference());
+    if (objects == null) return;
+
+    final index = objects
+        .whereType<T>()
+        .toList()
+        .indexWhere((o) => identifierSelector<T, I>(o) == identifierSelector<T, I>(object));
+
     if (index != -1) {
-      if (entities[index] != entity) {
-        final updatedEntities = List<IonConnectEntity>.from(entities);
-        updatedEntities[index] = entity;
-        entities
-          ..clear()
-          ..addAll(updatedEntities);
+      final typedObjects = objects.whereType<T>().toList();
+      if (typedObjects[index] != object) {
+        final updatedObjects = List<T>.from(typedObjects);
+        updatedObjects[index] = object;
+        objects
+          ..removeWhere((o) => o is T)
+          ..addAll(updatedObjects);
       }
     } else {
-      entities.add(entity);
+      objects.add(object);
     }
+  }
+
+  static void updateObjects<T extends Object, I>(BuildContext context, List<T> newObjects) {
+    final objects = context.dependOnInheritedWidgetOfExactType<ListCachedObjects>()?.objects;
+    if (objects == null) return;
+
+    final newIdentifiers = newObjects.map(identifierSelector<T, I>).toSet();
+    objects
+      ..removeWhere((o) => o is T && newIdentifiers.contains(identifierSelector(o)))
+      ..addAll(newObjects);
   }
 
   @override

--- a/lib/app/features/components/entities_list/list_entity_helper.dart
+++ b/lib/app/features/components/entities_list/list_entity_helper.dart
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:flutter/widgets.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:ion/app/features/components/entities_list/list_cached_entities.dart';
+import 'package:ion/app/features/feed/data/models/entities/generic_repost.f.dart';
+import 'package:ion/app/features/feed/providers/ion_connect_entity_with_counters_provider.r.dart';
+import 'package:ion/app/features/ion_connect/model/event_reference.f.dart';
+import 'package:ion/app/features/ion_connect/model/ion_connect_entity.dart';
+import 'package:ion/app/features/ion_connect/model/soft_deletable_entity.dart';
+import 'package:ion/app/features/user/providers/muted_users_notifier.r.dart';
+import 'package:ion/app/features/user/providers/user_metadata_provider.r.dart';
+import 'package:ion/app/features/user_block/model/entities/blocked_user_entity.f.dart';
+import 'package:ion/app/features/user_block/optimistic_ui/block_user_provider.r.dart';
+import 'package:ion/app/features/user_block/optimistic_ui/model/blocked_user.f.dart';
+import 'package:ion/app/features/user_block/providers/block_list_notifier.r.dart';
+
+class ListEntityHelper {
+  static bool isEntityOrRepostedEntityDeleted(
+    BuildContext context,
+    WidgetRef ref,
+    IonConnectEntity entity,
+  ) {
+    if (entity is SoftDeletableEntity && entity.isDeleted) {
+      return true;
+    }
+    if (entity is GenericRepostEntity) {
+      final repostedEntity = ref.watch(
+            ionConnectEntityWithCountersProvider(eventReference: entity.data.eventReference)
+                .select((value) {
+              final entity = value.valueOrNull;
+              if (entity != null) {
+                ListCachedObjects.updateObject<IonConnectEntity, EventReference>(context, entity);
+              }
+              return entity;
+            }),
+          ) ??
+          ListCachedObjects.maybeObjectOf<IonConnectEntity, EventReference>(
+            context,
+            entity.data.eventReference,
+          );
+      return repostedEntity == null ||
+          (repostedEntity is SoftDeletableEntity && repostedEntity.isDeleted);
+    }
+    return false;
+  }
+
+  static bool isUserMuted(WidgetRef ref, String masterPubkey, {required bool showMuted}) {
+    final isMuted = !showMuted && ref.watch(isUserMutedProvider(masterPubkey));
+
+    return isMuted;
+  }
+
+  static bool isUserBlockedOrBlocking(
+      BuildContext context, WidgetRef ref, IonConnectEntity entity) {
+    final blockedUser = ref.watch(
+          blockedUserWatchProvider(entity.masterPubkey).select((value) {
+            final blockedObject = value.valueOrNull;
+            if (blockedObject != null) {
+              ListCachedObjects.updateObject<BlockedUser, String>(context, blockedObject);
+            }
+            return blockedObject;
+          }),
+        ) ??
+        ListCachedObjects.maybeObjectOf<BlockedUser, String>(context, entity.masterPubkey);
+
+    final isUserBlocked = blockedUser != null && blockedUser.isBlocked;
+
+    final blockedByList = ref.watch(
+          currentUserBlockedByListNotifierProvider.select((blockedUsersEntities) {
+            final blockedUsers = blockedUsersEntities.valueOrNull;
+            if (blockedUsers != null) {
+              ListCachedObjects.updateObjects<IonConnectEntity, EventReference>(
+                context,
+                blockedUsers,
+              );
+            }
+            return blockedUsers;
+          }),
+        ) ??
+        ListCachedObjects.maybeObjectsOf<BlockedUserEntity>(context);
+
+    if (isUserBlocked ||
+        blockedByList.any((blockedEntity) => blockedEntity.masterPubkey == entity.masterPubkey)) {
+      return true;
+    }
+
+    return false;
+    // if (entity is ModifiablePostEntity && entity.data.quotedEvent != null) {
+    //   final quotedEntity = ref.watch(
+    //     ionConnectInMemoryEntityProvider(
+    //       eventReference: entity.data.quotedEvent!.eventReference,
+    //     ),
+    //   );
+    //   if (quotedEntity != null) {
+    //     return ref.watch(isEntityBlockedOrBlockedByProvider(quotedEntity));
+    //   }
+    // } else if (entity is GenericRepostEntity) {
+    //   final childEntity = ref.watch(
+    //     ionConnectSyncEntityProvider(eventReference: entity.data.eventReference),
+    //   );
+    //   if (childEntity != null) {
+    //     return ref.watch(isEntityBlockedOrBlockedByProvider(childEntity));
+    //   }
+    // }
+//
+    // return false;
+  }
+
+  static bool hasMetadata(BuildContext context, WidgetRef ref, IonConnectEntity entity) {
+    final userMetadata = ref.watch(
+          userMetadataProvider(entity.masterPubkey).select((value) {
+            final entity = value.valueOrNull;
+            if (entity != null) {
+              ListCachedObjects.updateObject<IonConnectEntity, EventReference>(context, entity);
+            }
+            return entity;
+          }),
+        ) ??
+        ListCachedObjects.maybeObjectOf<IonConnectEntity, EventReference>(
+          context,
+          entity.toEventReference(),
+        );
+
+    return userMetadata != null;
+  }
+}

--- a/lib/app/features/components/entities_list/list_entity_helper.dart
+++ b/lib/app/features/components/entities_list/list_entity_helper.dart
@@ -52,7 +52,10 @@ class ListEntityHelper {
   }
 
   static bool isUserBlockedOrBlocking(
-      BuildContext context, WidgetRef ref, IonConnectEntity entity) {
+    BuildContext context,
+    WidgetRef ref,
+    IonConnectEntity entity,
+  ) {
     final blockedUser = ref.watch(
           blockedUserWatchProvider(entity.masterPubkey).select((value) {
             final blockedObject = value.valueOrNull;

--- a/lib/app/features/components/entities_list/list_entity_helper.dart
+++ b/lib/app/features/components/entities_list/list_entity_helper.dart
@@ -6,10 +6,10 @@ import 'package:ion/app/features/components/entities_list/list_cached_entities.d
 import 'package:ion/app/features/feed/data/models/entities/generic_repost.f.dart';
 import 'package:ion/app/features/feed/data/models/entities/modifiable_post_data.f.dart';
 import 'package:ion/app/features/feed/providers/ion_connect_entity_with_counters_provider.r.dart';
-import 'package:ion/app/features/ion_connect/model/event_reference.f.dart';
 import 'package:ion/app/features/ion_connect/model/ion_connect_entity.dart';
 import 'package:ion/app/features/ion_connect/model/soft_deletable_entity.dart';
 import 'package:ion/app/features/ion_connect/providers/ion_connect_entity_provider.r.dart';
+import 'package:ion/app/features/user/model/user_metadata.f.dart';
 import 'package:ion/app/features/user/providers/muted_users_notifier.r.dart';
 import 'package:ion/app/features/user/providers/user_metadata_provider.r.dart';
 import 'package:ion/app/features/user_block/model/entities/blocked_user_entity.f.dart';
@@ -32,12 +32,12 @@ class ListEntityHelper {
                 .select((value) {
               final entity = value.valueOrNull;
               if (entity != null) {
-                ListCachedObjects.updateObject<IonConnectEntity, EventReference>(context, entity);
+                ListCachedObjects.updateObject<IonConnectEntity>(context, entity);
               }
               return entity;
             }),
           ) ??
-          ListCachedObjects.maybeObjectOf<IonConnectEntity, EventReference>(
+          ListCachedObjects.maybeObjectOf<IonConnectEntity>(
             context,
             entity.data.eventReference,
           );
@@ -62,12 +62,12 @@ class ListEntityHelper {
           blockedUserWatchProvider(entity.masterPubkey).select((value) {
             final blockedObject = value.valueOrNull;
             if (blockedObject != null) {
-              ListCachedObjects.updateObject<BlockedUser, String>(context, blockedObject);
+              ListCachedObjects.updateObject<BlockedUser>(context, blockedObject);
             }
             return blockedObject;
           }),
         ) ??
-        ListCachedObjects.maybeObjectOf<BlockedUser, String>(context, entity.masterPubkey);
+        ListCachedObjects.maybeObjectOf<BlockedUser>(context, entity.masterPubkey);
 
     final isUserBlocked = blockedUser != null && blockedUser.isBlocked;
 
@@ -75,7 +75,7 @@ class ListEntityHelper {
           currentUserBlockedByListNotifierProvider.select((blockedUsersEntities) {
             final blockedUsers = blockedUsersEntities.valueOrNull;
             if (blockedUsers != null) {
-              ListCachedObjects.updateObjects<IonConnectEntity, EventReference>(
+              ListCachedObjects.updateObjects<BlockedUserEntity>(
                 context,
                 blockedUsers,
               );
@@ -97,12 +97,12 @@ class ListEntityHelper {
             ).select((value) {
               final entity = value.valueOrNull;
               if (entity != null) {
-                ListCachedObjects.updateObject<IonConnectEntity, EventReference>(context, entity);
+                ListCachedObjects.updateObject<IonConnectEntity>(context, entity);
               }
               return entity;
             }),
           ) ??
-          ListCachedObjects.maybeObjectOf<IonConnectEntity, EventReference>(
+          ListCachedObjects.maybeObjectOf<IonConnectEntity>(
             context,
             entity.data.quotedEvent!.eventReference,
           );
@@ -115,12 +115,12 @@ class ListEntityHelper {
             ionConnectEntityProvider(eventReference: entity.data.eventReference).select((value) {
               final entity = value.valueOrNull;
               if (entity != null) {
-                ListCachedObjects.updateObject<IonConnectEntity, EventReference>(context, entity);
+                ListCachedObjects.updateObject<IonConnectEntity>(context, entity);
               }
               return entity;
             }),
           ) ??
-          ListCachedObjects.maybeObjectOf<IonConnectEntity, EventReference>(
+          ListCachedObjects.maybeObjectOf<IonConnectEntity>(
             context,
             entity.data.eventReference,
           );
@@ -138,14 +138,14 @@ class ListEntityHelper {
           userMetadataProvider(entity.masterPubkey).select((value) {
             final entity = value.valueOrNull;
             if (entity != null) {
-              ListCachedObjects.updateObject<IonConnectEntity, EventReference>(context, entity);
+              ListCachedObjects.updateObject<UserMetadataEntity>(context, entity);
             }
             return entity;
           }),
         ) ??
-        ListCachedObjects.maybeObjectOf<IonConnectEntity, EventReference>(
+        ListCachedObjects.maybeObjectOf<UserMetadataEntity>(
           context,
-          entity.toEventReference(),
+          entity.masterPubkey,
         );
 
     return userMetadata != null;

--- a/lib/app/features/feed/views/components/article/article.dart
+++ b/lib/app/features/feed/views/components/article/article.dart
@@ -78,7 +78,7 @@ class Article extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final entity =
-        ref.watch(ionConnectSyncEntityWithCountersProvider(eventReference: eventReference));
+        ref.watch(ionConnectEntityWithCountersProvider(eventReference: eventReference)).valueOrNull;
 
     if (entity is! ArticleEntity) {
       return Padding(

--- a/lib/app/features/feed/views/components/article/article.dart
+++ b/lib/app/features/feed/views/components/article/article.dart
@@ -83,12 +83,12 @@ class Article extends ConsumerWidget {
           ionConnectEntityWithCountersProvider(eventReference: eventReference).select((value) {
             final entity = value.valueOrNull;
             if (entity != null) {
-              ListCachedObjects.updateObject<IonConnectEntity, EventReference>(context, entity);
+              ListCachedObjects.updateObject<IonConnectEntity>(context, entity);
             }
             return entity;
           }),
         ) ??
-        ListCachedObjects.maybeObjectOf<IonConnectEntity, EventReference>(context, eventReference);
+        ListCachedObjects.maybeObjectOf<IonConnectEntity>(context, eventReference);
 
     if (entity is! ArticleEntity) {
       return Padding(

--- a/lib/app/features/feed/views/components/article/article.dart
+++ b/lib/app/features/feed/views/components/article/article.dart
@@ -21,6 +21,7 @@ import 'package:ion/app/features/feed/views/components/post/post_skeleton.dart';
 import 'package:ion/app/features/feed/views/components/time_ago/time_ago.dart';
 import 'package:ion/app/features/feed/views/components/user_info/user_info.dart';
 import 'package:ion/app/features/ion_connect/model/event_reference.f.dart';
+import 'package:ion/app/features/ion_connect/model/ion_connect_entity.dart';
 import 'package:ion/app/utils/algorithm.dart';
 import 'package:ion/app/utils/color.dart';
 
@@ -82,12 +83,12 @@ class Article extends ConsumerWidget {
           ionConnectEntityWithCountersProvider(eventReference: eventReference).select((value) {
             final entity = value.valueOrNull;
             if (entity != null) {
-              ListCachedEntities.updateEntity(context, entity);
+              ListCachedObjects.updateObject<IonConnectEntity, EventReference>(context, entity);
             }
             return entity;
           }),
         ) ??
-        ListCachedEntities.maybeEntityOf(context, eventReference);
+        ListCachedObjects.maybeObjectOf<IonConnectEntity, EventReference>(context, eventReference);
 
     if (entity is! ArticleEntity) {
       return Padding(

--- a/lib/app/features/feed/views/components/article/article.dart
+++ b/lib/app/features/feed/views/components/article/article.dart
@@ -8,6 +8,7 @@ import 'package:ion/app/components/skeleton/skeleton.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/auth/providers/auth_provider.m.dart';
 import 'package:ion/app/features/components/entities_list/components/bookmark_button/bookmark_button.dart';
+import 'package:ion/app/features/components/entities_list/list_cached_entities.dart';
 import 'package:ion/app/features/feed/create_post/views/pages/post_form_modal/components/parent_entity.dart';
 import 'package:ion/app/features/feed/data/models/entities/article_data.f.dart';
 import 'package:ion/app/features/feed/providers/ion_connect_entity_with_counters_provider.r.dart';
@@ -77,8 +78,16 @@ class Article extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final entity =
-        ref.watch(ionConnectEntityWithCountersProvider(eventReference: eventReference)).valueOrNull;
+    final entity = ref.watch(
+          ionConnectEntityWithCountersProvider(eventReference: eventReference).select((value) {
+            final entity = value.valueOrNull;
+            if (entity != null) {
+              ListCachedEntities.updateEntity(context, entity);
+            }
+            return entity;
+          }),
+        ) ??
+        ListCachedEntities.maybeEntityOf(context, eventReference);
 
     if (entity is! ArticleEntity) {
       return Padding(

--- a/lib/app/features/feed/views/components/post/post.dart
+++ b/lib/app/features/feed/views/components/post/post.dart
@@ -74,12 +74,12 @@ class Post extends ConsumerWidget {
           ionConnectEntityWithCountersProvider(eventReference: eventReference).select((value) {
             final entity = value.valueOrNull;
             if (entity != null) {
-              ListCachedObjects.updateObject<IonConnectEntity, EventReference>(context, entity);
+              ListCachedObjects.updateObject<IonConnectEntity>(context, entity);
             }
             return entity;
           }),
         ) ??
-        ListCachedObjects.maybeObjectOf<IonConnectEntity, EventReference>(context, eventReference);
+        ListCachedObjects.maybeObjectOf<IonConnectEntity>(context, eventReference);
 
     if (entity == null) {
       return ScreenSideOffset.small(
@@ -275,12 +275,12 @@ final class _FramedEvent extends HookConsumerWidget {
           ionConnectEntityWithCountersProvider(eventReference: eventReference).select((value) {
             final entity = value.valueOrNull;
             if (entity != null) {
-              ListCachedObjects.updateObject<IonConnectEntity, EventReference>(context, entity);
+              ListCachedObjects.updateObject<IonConnectEntity>(context, entity);
             }
             return entity;
           }),
         ) ??
-        ListCachedObjects.maybeObjectOf<IonConnectEntity, EventReference>(context, eventReference);
+        ListCachedObjects.maybeObjectOf<IonConnectEntity>(context, eventReference);
 
     Widget? deletedEntity;
 
@@ -355,12 +355,12 @@ final class _QuotedPost extends ConsumerWidget {
           ionConnectEntityWithCountersProvider(eventReference: eventReference).select((value) {
             final entity = value.valueOrNull;
             if (entity != null) {
-              ListCachedObjects.updateObject<IonConnectEntity, EventReference>(context, entity);
+              ListCachedObjects.updateObject<IonConnectEntity>(context, entity);
             }
             return entity;
           }),
         ) ??
-        ListCachedObjects.maybeObjectOf<IonConnectEntity, EventReference>(context, eventReference);
+        ListCachedObjects.maybeObjectOf<IonConnectEntity>(context, eventReference);
 
     return QuotedEntityFrame.post(
       child: GestureDetector(

--- a/lib/app/features/feed/views/components/post/post.dart
+++ b/lib/app/features/feed/views/components/post/post.dart
@@ -70,7 +70,7 @@ class Post extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final entity =
-        ref.watch(ionConnectSyncEntityWithCountersProvider(eventReference: eventReference));
+        ref.watch(ionConnectEntityWithCountersProvider(eventReference: eventReference)).valueOrNull;
 
     if (entity == null) {
       return ScreenSideOffset.small(
@@ -263,7 +263,7 @@ final class _FramedEvent extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final entity =
-        ref.watch(ionConnectSyncEntityWithCountersProvider(eventReference: eventReference));
+        ref.watch(ionConnectEntityWithCountersProvider(eventReference: eventReference)).valueOrNull;
     Widget? deletedEntity;
 
     if (entity is ModifiablePostEntity && entity.isDeleted) {
@@ -334,7 +334,7 @@ final class _QuotedPost extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final postEntity =
-        ref.watch(ionConnectSyncEntityWithCountersProvider(eventReference: eventReference));
+        ref.watch(ionConnectEntityWithCountersProvider(eventReference: eventReference)).valueOrNull;
 
     return QuotedEntityFrame.post(
       child: GestureDetector(

--- a/lib/app/features/feed/views/components/post/post.dart
+++ b/lib/app/features/feed/views/components/post/post.dart
@@ -8,6 +8,7 @@ import 'package:ion/app/components/screen_offset/screen_side_offset.dart';
 import 'package:ion/app/components/skeleton/skeleton.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/auth/providers/auth_provider.m.dart';
+import 'package:ion/app/features/components/entities_list/list_cached_entities.dart';
 import 'package:ion/app/features/feed/create_post/views/pages/post_form_modal/components/parent_entity.dart';
 import 'package:ion/app/features/feed/data/models/entities/article_data.f.dart';
 import 'package:ion/app/features/feed/data/models/entities/modifiable_post_data.f.dart';
@@ -69,8 +70,16 @@ class Post extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final entity =
-        ref.watch(ionConnectEntityWithCountersProvider(eventReference: eventReference)).valueOrNull;
+    final entity = ref.watch(
+          ionConnectEntityWithCountersProvider(eventReference: eventReference).select((value) {
+            final entity = value.valueOrNull;
+            if (entity != null) {
+              ListCachedEntities.updateEntity(context, entity);
+            }
+            return entity;
+          }),
+        ) ??
+        ListCachedEntities.maybeEntityOf(context, eventReference);
 
     if (entity == null) {
       return ScreenSideOffset.small(
@@ -262,8 +271,17 @@ final class _FramedEvent extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final entity =
-        ref.watch(ionConnectEntityWithCountersProvider(eventReference: eventReference)).valueOrNull;
+    final entity = ref.watch(
+          ionConnectEntityWithCountersProvider(eventReference: eventReference).select((value) {
+            final entity = value.valueOrNull;
+            if (entity != null) {
+              ListCachedEntities.updateEntity(context, entity);
+            }
+            return entity;
+          }),
+        ) ??
+        ListCachedEntities.maybeEntityOf(context, eventReference);
+
     Widget? deletedEntity;
 
     if (entity is ModifiablePostEntity && entity.isDeleted) {
@@ -333,8 +351,16 @@ final class _QuotedPost extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final postEntity =
-        ref.watch(ionConnectEntityWithCountersProvider(eventReference: eventReference)).valueOrNull;
+    final postEntity = ref.watch(
+          ionConnectEntityWithCountersProvider(eventReference: eventReference).select((value) {
+            final entity = value.valueOrNull;
+            if (entity != null) {
+              ListCachedEntities.updateEntity(context, entity);
+            }
+            return entity;
+          }),
+        ) ??
+        ListCachedEntities.maybeEntityOf(context, eventReference);
 
     return QuotedEntityFrame.post(
       child: GestureDetector(

--- a/lib/app/features/feed/views/components/post/post.dart
+++ b/lib/app/features/feed/views/components/post/post.dart
@@ -74,12 +74,12 @@ class Post extends ConsumerWidget {
           ionConnectEntityWithCountersProvider(eventReference: eventReference).select((value) {
             final entity = value.valueOrNull;
             if (entity != null) {
-              ListCachedEntities.updateEntity(context, entity);
+              ListCachedObjects.updateObject<IonConnectEntity, EventReference>(context, entity);
             }
             return entity;
           }),
         ) ??
-        ListCachedEntities.maybeEntityOf(context, eventReference);
+        ListCachedObjects.maybeObjectOf<IonConnectEntity, EventReference>(context, eventReference);
 
     if (entity == null) {
       return ScreenSideOffset.small(
@@ -275,12 +275,12 @@ final class _FramedEvent extends HookConsumerWidget {
           ionConnectEntityWithCountersProvider(eventReference: eventReference).select((value) {
             final entity = value.valueOrNull;
             if (entity != null) {
-              ListCachedEntities.updateEntity(context, entity);
+              ListCachedObjects.updateObject<IonConnectEntity, EventReference>(context, entity);
             }
             return entity;
           }),
         ) ??
-        ListCachedEntities.maybeEntityOf(context, eventReference);
+        ListCachedObjects.maybeObjectOf<IonConnectEntity, EventReference>(context, eventReference);
 
     Widget? deletedEntity;
 
@@ -355,12 +355,12 @@ final class _QuotedPost extends ConsumerWidget {
           ionConnectEntityWithCountersProvider(eventReference: eventReference).select((value) {
             final entity = value.valueOrNull;
             if (entity != null) {
-              ListCachedEntities.updateEntity(context, entity);
+              ListCachedObjects.updateObject<IonConnectEntity, EventReference>(context, entity);
             }
             return entity;
           }),
         ) ??
-        ListCachedEntities.maybeEntityOf(context, eventReference);
+        ListCachedObjects.maybeObjectOf<IonConnectEntity, EventReference>(context, eventReference);
 
     return QuotedEntityFrame.post(
       child: GestureDetector(

--- a/lib/app/features/feed/views/pages/feed_page/feed_page.dart
+++ b/lib/app/features/feed/views/pages/feed_page/feed_page.dart
@@ -68,7 +68,7 @@ class FeedPage extends HookConsumerWidget {
         scrollController: scrollController,
         horizontalPadding: ScreenSideOffset.defaultSmallMargin,
       ),
-      body: ListCachedEntities(
+      body: ListCachedObjects(
         child: LoadMoreBuilder(
           slivers: slivers,
           hasMore: hasMorePosts,

--- a/lib/app/features/feed/views/pages/feed_page/feed_page.dart
+++ b/lib/app/features/feed/views/pages/feed_page/feed_page.dart
@@ -8,6 +8,7 @@ import 'package:ion/app/components/screen_offset/screen_top_offset.dart';
 import 'package:ion/app/components/scroll_view/load_more_builder.dart';
 import 'package:ion/app/components/scroll_view/pull_to_refresh_builder.dart';
 import 'package:ion/app/extensions/extensions.dart';
+import 'package:ion/app/features/components/entities_list/list_cached_entities.dart';
 import 'package:ion/app/features/core/model/feature_flags.dart';
 import 'package:ion/app/features/core/providers/feature_flags_provider.r.dart';
 import 'package:ion/app/features/feed/data/models/feed_category.dart';
@@ -67,36 +68,38 @@ class FeedPage extends HookConsumerWidget {
         scrollController: scrollController,
         horizontalPadding: ScreenSideOffset.defaultSmallMargin,
       ),
-      body: LoadMoreBuilder(
-        slivers: slivers,
-        hasMore: hasMorePosts,
-        onLoadMore: () => _onLoadMore(ref),
-        builder: (context, slivers) {
-          return PullToRefreshBuilder(
-            sliverAppBar: CollapsingAppBar(
-              height: Stories.height,
-              bottomOffset: 0,
-              topOffset: 8.0.s,
-              child: Column(
-                children: [
-                  if (feedCategory == FeedCategory.articles) const ArticleCategoriesMenu(),
-                  if (showStories) const Stories(),
-                ],
+      body: ListCachedEntities(
+        child: LoadMoreBuilder(
+          slivers: slivers,
+          hasMore: hasMorePosts,
+          onLoadMore: () => _onLoadMore(ref),
+          builder: (context, slivers) {
+            return PullToRefreshBuilder(
+              sliverAppBar: CollapsingAppBar(
+                height: Stories.height,
+                bottomOffset: 0,
+                topOffset: 8.0.s,
+                child: Column(
+                  children: [
+                    if (feedCategory == FeedCategory.articles) const ArticleCategoriesMenu(),
+                    if (showStories) const Stories(),
+                  ],
+                ),
               ),
-            ),
-            slivers: slivers,
-            onRefresh: () =>
-                _onRefresh(ref, showStories: showStories, showTrendingVideos: showTrendingVideos),
-            refreshIndicatorEdgeOffset: FeedControls.height +
-                MediaQuery.paddingOf(context).top +
-                ScreenTopOffset.defaultMargin,
-            builder: (context, slivers) => CustomScrollView(
-              physics: const AlwaysScrollableScrollPhysics(),
               slivers: slivers,
-              controller: scrollController,
-            ),
-          );
-        },
+              onRefresh: () =>
+                  _onRefresh(ref, showStories: showStories, showTrendingVideos: showTrendingVideos),
+              refreshIndicatorEdgeOffset: FeedControls.height +
+                  MediaQuery.paddingOf(context).top +
+                  ScreenTopOffset.defaultMargin,
+              builder: (context, slivers) => CustomScrollView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                slivers: slivers,
+                controller: scrollController,
+              ),
+            );
+          },
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Description
- ListCachedObjects Inherited widget stores and provides entities and object sync to prevent jumping during scrolling
- Get rid of sync providers in posts, articles and reposts
- Check if user is blocked in async way 

## Task ID
ION-3847

## Type of Change

- [x] Refactoring


