### PR TITLE
fix: set autoplay true for quoted event videos

### DIFF
--- a/lib/app/features/feed/views/components/post/post.dart
+++ b/lib/app/features/feed/views/components/post/post.dart
@@ -343,7 +343,6 @@ final class _QuotedPost extends ConsumerWidget {
         },
         child: AbsorbPointer(
           child: Post(
-            videoAutoplay: false,
             accentTheme: accentTheme,
             eventReference: eventReference,
             displayQuote: false,


### PR DESCRIPTION
## Description
This PR enable autoPlay as true for quoted events.

## Additional Notes
N/A

## Task ID
3878

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->

https://github.com/user-attachments/assets/11fefc83-3e14-4e95-8b12-e72af52b8675


