### PR TITLE
fix: disable share button when explorer button is not active

### DIFF
--- a/lib/app/features/wallets/views/pages/coins_flow/send_coins/components/confirmation/transaction_result_sheet.dart
+++ b/lib/app/features/wallets/views/pages/coins_flow/send_coins/components/confirmation/transaction_result_sheet.dart
@@ -15,6 +15,7 @@ import 'package:ion/app/features/wallets/model/transaction_type.dart';
 import 'package:ion/app/features/wallets/providers/transaction_provider.r.dart';
 import 'package:ion/app/features/wallets/views/components/nft_item.dart';
 import 'package:ion/app/features/wallets/views/pages/coins_flow/send_coins/components/confirmation/transaction_amount_summary.dart';
+import 'package:ion/app/features/wallets/views/pages/transaction_details/transaction_details.dart';
 import 'package:ion/app/router/components/navigation_app_bar/navigation_app_bar.dart';
 import 'package:ion/app/router/components/navigation_app_bar/navigation_close_button.dart';
 import 'package:ion/app/router/components/sheet_content/sheet_content.dart';
@@ -41,6 +42,13 @@ class TransactionResultSheet extends ConsumerWidget {
         txHash: txHash,
       ),
     );
+
+    final assetAbbreviation = transactionData.valueOrNull?.assetData
+        .mapOrNull(coin: (coin) => coin.coinsGroup)
+        ?.abbreviation;
+
+    final disableShareButton = abbreviationsToExclude.contains(assetAbbreviation) &&
+        transactionData.valueOrNull?.status != TransactionStatus.confirmed;
 
     final colors = context.theme.appColors;
     final textTheme = context.theme.appTextThemes;
@@ -163,6 +171,7 @@ class TransactionResultSheet extends ConsumerWidget {
                         ),
                         SizedBox(width: 13.0.s),
                         Button(
+                          disabled: disableShareButton,
                           type: ButtonType.outlined,
                           onPressed: () {
                             shareContent(transactionData.transactionExplorerUrl);

--- a/lib/app/features/wallets/views/pages/transaction_details/transaction_details.dart
+++ b/lib/app/features/wallets/views/pages/transaction_details/transaction_details.dart
@@ -31,7 +31,8 @@ import 'package:ion/app/router/components/sheet_content/sheet_content.dart';
 import 'package:ion/app/services/share/share.dart';
 import 'package:ion/generated/assets.gen.dart';
 
-const _abbreviationsToExclude = {'TON', 'ION', 'ICE'};
+// for those assets we can't build the explorer url right away and need to wait till confirmed
+const abbreviationsToExclude = {'TON', 'ION', 'ICE'};
 
 class TransactionDetailsPage extends ConsumerWidget {
   const TransactionDetailsPage({
@@ -105,7 +106,7 @@ class _TransactionDetailsContent extends StatelessWidget {
     final assetAbbreviation =
         transaction.assetData.mapOrNull(coin: (coin) => coin.coinsGroup)?.abbreviation;
 
-    final disableTransactionDetailsButtons = _abbreviationsToExclude.contains(assetAbbreviation) &&
+    final disableTransactionDetailsButtons = abbreviationsToExclude.contains(assetAbbreviation) &&
         transaction.status != TransactionStatus.confirmed;
 
     return CustomScrollView(


### PR DESCRIPTION
## Description
Disable share button same as explorer button

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
ION-3872

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore