### PR TITLE
fix: count only unique likes

### DIFF
--- a/lib/app/features/feed/providers/counters/likes_count_provider.r.dart
+++ b/lib/app/features/feed/providers/counters/likes_count_provider.r.dart
@@ -17,6 +17,23 @@ int likesCount(Ref ref, EventReference eventReference) {
 
   if (optimistic != null) return optimistic;
 
+  final cache = ref.watch(ionConnectCacheProvider);
+  final uniqueLikes = cache.values
+      .map((e) => e.entity)
+      .whereType<ReactionEntity>()
+      .where(
+          (reaction) =>
+              reaction.data.eventReference == eventReference &&
+              reaction.data.content == ReactionEntity.likeSymbol,
+        )
+      .map((reaction) => reaction.masterPubkey)
+      .toSet()
+      .length;
+
+  if (uniqueLikes > 0) {
+    return uniqueLikes;
+  }
+
   final counterEntity = ref.watch(
     ionConnectCacheProvider.select(
       cacheSelector<EventCountResultEntity>(


### PR DESCRIPTION
## Description
- previously it was summing up all the likes, event if master pubkey is identical
- now it filters them

## Task ID
ION-3832

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
