### PR TITLE
fix: reserve space for content in notification item

### DIFF
--- a/lib/app/features/feed/notifications/views/notifications_history_page/components/notification_item/notification_item.dart
+++ b/lib/app/features/feed/notifications/views/notifications_history_page/components/notification_item/notification_item.dart
@@ -71,7 +71,12 @@ class NotificationItem extends ConsumerWidget {
                       Padding(
                         padding: EdgeInsetsGeometry.only(top: 6.s),
                         child: ScreenSideOffset.small(
-                          child: NotificationContent(entity: entity),
+                          child: ConstrainedBox(
+                            constraints: BoxConstraints(
+                              minHeight: 18.s,
+                            ),
+                            child: NotificationContent(entity: entity),
+                          ),
                         ),
                       ),
                   ],


### PR DESCRIPTION
## Description
Fix in-app notification layout

## Additional Notes
When text content is missing or loading notification layout looks bad. Reserving space for content prevents it

## Task ID
ION-3884

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<img width="1170" height="2532" alt="IMG_0879" src="https://github.com/user-attachments/assets/3a15da85-59a7-43cc-86d0-d38547811e06" />

