### PR TITLE
fix: global notifications interrupt each other when uploading videos

### DIFF
--- a/lib/app/features/feed/global_notifications/helpers/feed_global_notifications_helper.dart
+++ b/lib/app/features/feed/global_notifications/helpers/feed_global_notifications_helper.dart
@@ -60,16 +60,19 @@ void _handleNotification(
   if (!isAuthenticated) {
     return;
   }
-  final loadingNotification = type.loading();
+
+  final loadingNotificationKey = type;
+
   if (state.isLoading) {
     ref
         .read(globalNotificationNotifierProvider.notifier)
-        .show(loadingNotification, isPermanent: true);
+        .show(type.loading(), isPermanent: true, key: loadingNotificationKey);
   } else if (state.hasError && state.error != null) {
-    ref.read(globalNotificationNotifierProvider.notifier).hide(loadingNotification);
+    ref.read(globalNotificationNotifierProvider.notifier).hide(key: loadingNotificationKey);
     showErrorModal(rootNavigatorKey.currentContext!, state.error!);
   } else if (state.hasValue) {
-    ref.read(globalNotificationNotifierProvider.notifier).hide(loadingNotification);
+    ref.read(globalNotificationNotifierProvider.notifier).hide(key: loadingNotificationKey);
+
     ref.read(globalNotificationNotifierProvider.notifier).show(type.ready());
   }
 }


### PR DESCRIPTION
## Description
Global notifications interrupt each other when uploading videos
Rework GlobalNotificationNotifier to be as queue

## Task ID
3860

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Chore

