### PR TITLE
build(content-labeler): fix info plist values

### DIFF
--- a/packages/ion_content_labeler/ios/Frameworks/fasttext_predict.xcframework/ios-arm64/fasttext_predict.framework/Info.plist
+++ b/packages/ion_content_labeler/ios/Frameworks/fasttext_predict.xcframework/ios-arm64/fasttext_predict.framework/Info.plist
@@ -5,15 +5,17 @@
     <key>CFBundleExecutable</key>
     <string>fasttext_predict</string>
     <key>CFBundleIdentifier</key>
-    <string>io.ion.fasttext_predict</string>
+    <string>io.ion.fasttext-predict</string>
     <key>CFBundleName</key>
     <string>fasttext_predict</string>
     <key>CFBundlePackageType</key>
     <string>FMWK</string>
     <key>CFBundleShortVersionString</key>
     <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
     <key>MinimumOSVersion</key>
-    <string>13.0</string>
+    <string>15.0</string>
     <key>CFBundleSupportedPlatforms</key>
     <array>
         <string>iPhoneOS</string>

--- a/packages/ion_content_labeler/ios/Frameworks/fasttext_predict.xcframework/ios-arm64_x86_64-simulator/fasttext_predict.framework/Info.plist
+++ b/packages/ion_content_labeler/ios/Frameworks/fasttext_predict.xcframework/ios-arm64_x86_64-simulator/fasttext_predict.framework/Info.plist
@@ -5,15 +5,17 @@
     <key>CFBundleExecutable</key>
     <string>fasttext_predict</string>
     <key>CFBundleIdentifier</key>
-    <string>io.ion.fasttext_predict</string>
+    <string>io.ion.fasttext-predict</string>
     <key>CFBundleName</key>
     <string>fasttext_predict</string>
     <key>CFBundlePackageType</key>
     <string>FMWK</string>
     <key>CFBundleShortVersionString</key>
     <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
     <key>MinimumOSVersion</key>
-    <string>13.0</string>
+    <string>15.0</string>
     <key>CFBundleSupportedPlatforms</key>
     <array>
         <string>iPhoneSimulator</string>


### PR DESCRIPTION
## Description
This PR fixes content labeler info plist values

## Task ID
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

