### PR TITLE
fix: hide follow btn in story when user already following

### DIFF
--- a/lib/app/features/feed/views/pages/feed_page/components/stories/components/story_item_follow_button.dart
+++ b/lib/app/features/feed/views/pages/feed_page/components/stories/components/story_item_follow_button.dart
@@ -22,7 +22,7 @@ class StoryItemFollowButton extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final isAlwaysShowButton = useState<bool>(false);
-
+    final followListState = ref.watch(currentUserFollowListProvider);
     final isFollowUser = ref.watch(
       isCurrentUserFollowingSelectorProvider(
         pubkey,
@@ -38,7 +38,7 @@ class StoryItemFollowButton extends HookConsumerWidget {
       username,
     );
 
-    if (isFollowUser && !isAlwaysShowButton.value) {
+    if (isFollowUser && !isAlwaysShowButton.value || followListState.isLoading) {
       return const SizedBox.shrink();
     }
 


### PR DESCRIPTION
## Description
- Hide button if we already followed

## Task ID
- ION-3896

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)

https://github.com/user-attachments/assets/fc6c9019-cca7-4dbf-b3bd-1fcfc208b6e8

