### PR TITLE
fix: change all providers to read in counter_cache_helpers cause in cause CircularDependencyError

### DIFF
--- a/lib/app/features/feed/providers/counters/helpers/counter_cache_helpers.r.dart
+++ b/lib/app/features/feed/providers/counters/helpers/counter_cache_helpers.r.dart
@@ -126,11 +126,11 @@ class QuoteCounterUpdater {
 @riverpod
 QuoteCounterUpdater quoteCounterUpdater(Ref ref) {
   return QuoteCounterUpdater(
-    postRepostService: ref.watch(postRepostServiceProvider),
-    removeCacheItem: ref.watch(ionConnectCacheProvider.notifier).remove,
-    getCurrentPostRepost: (id) => ref.watch(postRepostWatchProvider(id)).valueOrNull,
-    findRepostInCache: (eventRef) => ref.watch(findRepostInCacheProvider(eventRef)),
-    getRepostCounts: (eventRef) => ref.watch(repostCountsFromCacheProvider(eventRef)),
-    cacheKeys: ref.watch(ionConnectCacheProvider).keys.toList(),
+    postRepostService: ref.read(postRepostServiceProvider),
+    removeCacheItem: ref.read(ionConnectCacheProvider.notifier).remove,
+    getCurrentPostRepost: (id) => ref.read(postRepostWatchProvider(id)).valueOrNull,
+    findRepostInCache: (eventRef) => ref.read(findRepostInCacheProvider(eventRef)),
+    getRepostCounts: (eventRef) => ref.read(repostCountsFromCacheProvider(eventRef)),
+    cacheKeys: ref.read(ionConnectCacheProvider).keys.toList(),
   );
 }


### PR DESCRIPTION
## Description
- change all providers to read in counter_cache_helpers cause in cause CircularDependencyError

## Additional Notes
- I think, it's fine to use read everywhere here cause we just use this provider by read

## Task ID
- ION-3918

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)

https://github.com/user-attachments/assets/7854b2b1-0a11-4a33-904c-e72dac5e18a2


