### PR TITLE
fix: profile avatar is not fully tapable

### DIFF
--- a/lib/app/features/user/pages/profile_page/profile_page.dart
+++ b/lib/app/features/user/pages/profile_page/profile_page.dart
@@ -159,18 +159,21 @@ class ProfilePage extends HookConsumerWidget {
                 ),
               ),
             ),
-            Opacity(
-              opacity: opacity,
-              child: NavigationAppBar(
-                showBackButton: showBackButton,
-                useScreenTopOffset: true,
-                backButtonIcon: backButtonIcon,
-                scrollController: scrollController,
-                horizontalPadding: 0,
-                title: Header(
-                  opacity: opacity,
-                  pubkey: pubkey,
-                  showBackButton: !isCurrentUserProfile,
+            _IgnorePointerWrapper(
+              shouldWrap: opacity <= 0.5,
+              child: Opacity(
+                opacity: opacity,
+                child: NavigationAppBar(
+                  showBackButton: showBackButton,
+                  useScreenTopOffset: true,
+                  backButtonIcon: backButtonIcon,
+                  scrollController: scrollController,
+                  horizontalPadding: 0,
+                  title: Header(
+                    opacity: opacity,
+                    pubkey: pubkey,
+                    showBackButton: !isCurrentUserProfile,
+                  ),
                 ),
               ),
             ),
@@ -196,5 +199,17 @@ class ProfilePage extends HookConsumerWidget {
         ),
       ),
     );
+  }
+}
+
+class _IgnorePointerWrapper extends StatelessWidget {
+  const _IgnorePointerWrapper({required this.child, required this.shouldWrap});
+
+  final Widget child;
+  final bool shouldWrap;
+
+  @override
+  Widget build(BuildContext context) {
+    return shouldWrap ? IgnorePointer(child: child) : child;
   }
 }


### PR DESCRIPTION
## Description
Avatar on profile screen is overflown by the header. Wrapped it with IgnorePointer.

## Additional Notes
Add IgnorePointer conditionally depending on opacity, because it should be ignored only if it is mostly transparent

## Task ID
ION-3908

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
N/A
