### PR TITLE
refactor: update identity key name handling across app

### DIFF
--- a/lib/app/features/core/providers/main_wallet_provider.r.dart
+++ b/lib/app/features/core/providers/main_wallet_provider.r.dart
@@ -14,8 +14,7 @@ part 'main_wallet_provider.r.g.dart';
 Future<Wallet?> mainWallet(Ref ref) async {
   keepAliveWhenAuthenticated(ref);
 
-  final userAvailable =
-      await ref.watch(authProvider.selectAsync((state) => state.currentIdentityKeyName)) != null;
+  final userAvailable = ref.watch(currentIdentityKeyNameSelectorProvider) != null;
   if (!userAvailable) {
     return null;
   }

--- a/lib/app/features/protect_account/backup/providers/create_recovery_key_action_notifier.r.dart
+++ b/lib/app/features/protect_account/backup/providers/create_recovery_key_action_notifier.r.dart
@@ -20,7 +20,7 @@ class CreateRecoveryKeyActionNotifier extends _$CreateRecoveryKeyActionNotifier 
     state = const AsyncValue.loading();
 
     state = await AsyncValue.guard(() async {
-      final selectedUser = ref.read(authProvider).valueOrNull?.currentIdentityKeyName;
+      final selectedUser = ref.read(currentIdentityKeyNameSelectorProvider);
       if (selectedUser == null) {
         throw Exception('No selected user');
       }

--- a/lib/app/features/protect_account/secure_account/providers/recovery_credentials_enabled_notifier.r.dart
+++ b/lib/app/features/protect_account/secure_account/providers/recovery_credentials_enabled_notifier.r.dart
@@ -11,7 +11,7 @@ part 'recovery_credentials_enabled_notifier.r.g.dart';
 class RecoveryCredentialsEnabled extends _$RecoveryCredentialsEnabled {
   @override
   Future<bool> build() async {
-    final selectedUser = ref.watch(authProvider).valueOrNull?.currentIdentityKeyName;
+    final selectedUser = ref.watch(currentIdentityKeyNameSelectorProvider);
     if (selectedUser == null) {
       return false;
     }

--- a/lib/app/features/push_notifications/background/firebase_messaging_background_service.dart
+++ b/lib/app/features/push_notifications/background/firebase_messaging_background_service.dart
@@ -260,7 +260,7 @@ Override _backgroundIdentityKeyNameOverride(String? savedIdentityKeyName) {
     throw const CurrentUserNotFoundException();
   }
   return currentIdentityKeyNameSelectorProvider.overrideWith(
-    (_) => savedIdentityKeyName,
+    () => _BackgroundIdentityKeyNameSelector(savedIdentityKeyName),
   );
 }
 
@@ -299,5 +299,16 @@ class _BackgroundCurrentPubkeySelector extends CurrentPubkeySelector {
   @override
   String build() {
     return _pubkey;
+  }
+}
+
+class _BackgroundIdentityKeyNameSelector extends CurrentIdentityKeyNameSelector {
+  _BackgroundIdentityKeyNameSelector(this._identityKeyName);
+
+  final String _identityKeyName;
+
+  @override
+  String build() {
+    return _identityKeyName;
   }
 }

--- a/test/robots/stories/story_viewer_robot.dart
+++ b/test/robots/stories/story_viewer_robot.dart
@@ -62,7 +62,8 @@ class StoryViewerRobot extends BaseRobot with ProviderScopeMixin, StoryStateMixi
       router: router,
       overrides: [
         feedStoriesProvider.overrideWith(() => FakeFeedStories(stories)),
-        currentIdentityKeyNameSelectorProvider.overrideWith((_) => identity),
+        currentIdentityKeyNameSelectorProvider
+            .overrideWith(() => _BackgroundIdentityKeyNameSelector(identity)),
         localStorageProvider.overrideWithValue(mockStorage),
         userPreferencesServiceProvider(identityKeyName: identity)
             .overrideWith((_) => UserPreferencesService(identity, mockStorage)),
@@ -158,5 +159,16 @@ class StoryViewerRobot extends BaseRobot with ProviderScopeMixin, StoryStateMixi
       feedStoriesByPubkeyProvider(pubkey).overrideWith((_) => posts),
       userStoriesProvider(pubkey).overrideWith(() => FakeUserStories(posts)),
     ];
+  }
+}
+
+class _BackgroundIdentityKeyNameSelector extends CurrentIdentityKeyNameSelector {
+  _BackgroundIdentityKeyNameSelector(this._identityKeyName);
+
+  final String _identityKeyName;
+
+  @override
+  String build() {
+    return _identityKeyName;
   }
 }


### PR DESCRIPTION
## Description
- **Before**: On logout, both `authenticatedIdentityKeyNames` and `currentIdentityKeyName` were cleared in `AuthState`. Dependents re-initialized in the same tick with a null pubkey, causing `UserMasterPubkeyNotFound`.
- **Change**: Moved `currentIdentityKeyName` out of `AuthState` into `currentIdentityKeyNameSelectorProvider` as the single source of truth.
- **Behavior**: On logout, first emit empty `authenticatedIdentityKeyNames` so dependents dispose; after a short delay (1s), set the selector to null. This prevents re-initialization with a null pubkey during teardown.
- **Result**: Eliminates `UserMasterPubkeyNotFound` on logout and stabilizes provider lifecycle across isolates and tests.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
3910

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
