### PR TITLE
fix: show only the code of identity errors to the user

### DIFF
--- a/lib/app/extensions/ion_identity_exception.dart
+++ b/lib/app/extensions/ion_identity_exception.dart
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: ice License 1.0
 
+import 'package:dio/dio.dart';
 import 'package:flutter/widgets.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion_identity_client/ion_identity.dart';
@@ -16,7 +17,7 @@ extension IONIdentityExceptionTranslation on IONIdentityException {
       case TwoFARequiredException():
         return context.i18n.error_identity_2fa_required_title;
       default:
-        return toString();
+        return context.i18n.error_general_title;
     }
   }
 
@@ -30,8 +31,14 @@ extension IONIdentityExceptionTranslation on IONIdentityException {
         return context.i18n.error_identity_no_local_passkey_creds_found_description;
       case TwoFARequiredException():
         return context.i18n.error_identity_2fa_required_description;
+      case final RequestExecutionException exception when exception.error is DioException:
+        return context.i18n.error_general_description(
+          context.i18n.error_general_error_code(
+            (exception.error as DioException).response?.statusCode?.toString() ?? '-1',
+          ),
+        );
       default:
-        return toString();
+        return context.i18n.error_general_description('');
     }
   }
 }


### PR DESCRIPTION
## Description
This PR strips all debug info from identity errors and shows only the error code to the end user.

## Task ID
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (Before -> After)
<img width="280" alt="image" src="https://github.com/user-attachments/assets/f2be37fc-03db-48d1-b360-3cf0869dd0ce" />

<img width="280" alt="image" src="https://github.com/user-attachments/assets/fa9accf7-b1c4-4a91-906b-f4036dd2ee89" />


