### PR TITLE
fix(chat): handle null media attachment in chat message loading - StateError

### DIFF
--- a/lib/app/features/chat/e2ee/providers/chat_message_load_media_provider.r.dart
+++ b/lib/app/features/chat/e2ee/providers/chat_message_load_media_provider.r.dart
@@ -2,6 +2,7 @@
 
 import 'dart:io';
 
+import 'package:collection/collection.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/features/chat/e2ee/model/entities/private_direct_message_data.f.dart';
 import 'package:ion/app/features/ion_connect/model/media_attachment.dart';
@@ -32,12 +33,16 @@ Raw<Future<File?>> chatMessageLoadMedia(
     return null;
   }
 
-  final MediaAttachment mediaAttachmentToLoad;
+  final MediaAttachment? mediaAttachmentToLoad;
   if (loadThumbnail) {
     // Get thumbnail from media attachments
-    mediaAttachmentToLoad = entity.data.media.values.firstWhere(
+    mediaAttachmentToLoad = entity.data.media.values.firstWhereOrNull(
       (e) => e.url == mediaAttachment.thumb,
     );
+
+    if (mediaAttachmentToLoad == null) {
+      return null;
+    }
   } else {
     mediaAttachmentToLoad = mediaAttachment;
   }


### PR DESCRIPTION
## Description
- Updated the logic to safely handle cases where the media attachment to load may be null, using `firstWhereOrNull` to avoid exceptions.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
3917

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
