### PR TITLE
fix: preserve article media when editing

### DIFF
--- a/lib/app/features/feed/create_article/providers/create_article_provider.r.dart
+++ b/lib/app/features/feed/create_article/providers/create_article_provider.r.dart
@@ -245,20 +245,26 @@ class CreateArticle extends _$CreateArticle {
 
       final unusedMediaFileHashes = <String>[];
 
+      // Start with existing media from the article
       final cleanedMedia = Map<String, MediaAttachment>.from(modifiedEntity.data.media);
 
+      // Add/update with media from the editing session
+      for (final entry in modifiedMedia.entries) {
+        cleanedMedia[entry.key] = entry.value;
+      }
+
+      // Only remove media that is not referenced in content AND not in the modified media
       modifiedEntity.data.media.forEach((url, attachment) {
         final urlInContent = contentString.contains(url);
         final urlToCheck = url.replaceAll('url ', '');
-        if (!urlInContent && (originalImageUrl != null && urlToCheck != originalImageUrl)) {
+        final isInModifiedMedia = modifiedMedia.containsKey(url);
+        final isOriginalImage = originalImageUrl != null && urlToCheck == originalImageUrl;
+
+        if (!urlInContent && !isInModifiedMedia && !isOriginalImage) {
           cleanedMedia.remove(url);
           unusedMediaFileHashes.add(attachment.originalFileHash);
         }
       });
-
-      for (final attachment in updatedMediaAttachments) {
-        cleanedMedia[attachment.url] = attachment;
-      }
 
       final mentions = _buildMentions(updatedContent);
 

--- a/lib/app/features/feed/create_article/providers/draft_article_provider.m.dart
+++ b/lib/app/features/feed/create_article/providers/draft_article_provider.m.dart
@@ -7,12 +7,14 @@ import 'package:flutter_quill/flutter_quill.dart';
 import 'package:flutter_quill/quill_delta.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:ion/app/components/text_editor/utils/extract_image_ids.dart';
+import 'package:ion/app/features/ion_connect/model/media_attachment.dart';
 import 'package:ion/app/services/media_service/media_service.m.dart';
 import 'package:ion/app/utils/color.dart';
 import 'package:palette_generator/palette_generator.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'draft_article_provider.m.freezed.dart';
+
 part 'draft_article_provider.m.g.dart';
 
 @freezed
@@ -25,6 +27,7 @@ class DraftArticleState with _$DraftArticleState {
     String? imageColor,
     @Default({}) Map<String, String> codeBlocks,
     String? imageUrl,
+    @Default({}) Map<String, MediaAttachment> mediaAttachments,
   }) = _DraftArticleState;
 }
 
@@ -41,6 +44,7 @@ class DraftArticle extends _$DraftArticle {
     String title,
     String? imageUrl,
     String? imageUrlColor,
+    Map<String, MediaAttachment>? mediaAttachments,
   ) async {
     final delta = textEditorController.document.toDelta();
     final imageIds = extractImageIds(textEditorController.document.toDelta());
@@ -54,6 +58,7 @@ class DraftArticle extends _$DraftArticle {
       imageUrl: imageUrl,
       title: title.trim(),
       imageColor: colorHex,
+      mediaAttachments: mediaAttachments ?? state.mediaAttachments,
     );
   }
 

--- a/lib/app/features/feed/create_article/views/pages/article_form_modal/hooks/use_article_form.dart
+++ b/lib/app/features/feed/create_article/views/pages/article_form_modal/hooks/use_article_form.dart
@@ -189,6 +189,7 @@ ArticleFormState useArticleForm(WidgetRef ref, {EventReference? modifiedEvent}) 
           titleController.text,
           selectedImageUrl.value,
           selectedImageUrlColor.value,
+          media.value,
         );
   }
 

--- a/lib/app/features/feed/create_article/views/pages/article_preview_modal/article_preview_modal.dart
+++ b/lib/app/features/feed/create_article/views/pages/article_preview_modal/article_preview_modal.dart
@@ -64,6 +64,7 @@ class ArticlePreviewModal extends HookConsumerWidget {
       :content,
       :imageColor,
       :imageUrl,
+      :mediaAttachments,
     ) = ref.watch(draftArticleProvider);
     final whoCanReply = ref.watch(selectedWhoCanReplyOptionProvider);
     final selectedTopics = ref.watch(selectedInterestsNotifierProvider);
@@ -138,6 +139,7 @@ class ArticlePreviewModal extends HookConsumerWidget {
                                 originalImageUrl: imageUrl,
                                 eventReference: modifiedEvent!,
                                 language: detectedLanguage,
+                                mediaAttachments: mediaAttachments,
                               ),
                         );
                       } else {


### PR DESCRIPTION
## Description
Original media from article was deleted on edit

## Additional Notes
The issue was that media wasn't passed to draft and it was deleted from medias if unused in text. 

## Task ID
ION-3942

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
