### PR TITLE
fix: navigate to proper post details page on comment button tap in vertical videos page

### DIFF
--- a/lib/app/features/video/views/pages/videos_vertical_scroll_page.dart
+++ b/lib/app/features/video/views/pages/videos_vertical_scroll_page.dart
@@ -207,20 +207,27 @@ class VideosVerticalScrollPage extends HookConsumerWidget {
               _loadMore(ref, index, flattenedVideos.length);
               currentEventReference.value = flattenedVideos[index].entity.toEventReference();
             },
-            itemBuilder: (_, index) => VideoPage(
-              videoInfo: VideoPostInfo(videoPost: flattenedVideos[index].entity),
-              bottomOverlay: VideoActions(
-                eventReference: flattenedVideos[index].entity.toEventReference(),
-                onReplyTap: () =>
-                    PostDetailsRoute(eventReference: eventReference.encode()).push<void>(context),
-              ),
-              videoUrl: flattenedVideos[index].media.url,
-              authorPubkey: eventReference.masterPubkey,
-              thumbnailUrl: flattenedVideos[index].media.thumb,
-              blurhash: flattenedVideos[index].media.blurhash,
-              aspectRatio: flattenedVideos[index].media.aspectRatio,
-              framedEventReference: index == initialPage ? framedEventReference : null,
-            ),
+            itemBuilder: (_, index) {
+              final flattenedVideo = flattenedVideos[index];
+              final perPageEventReference = flattenedVideo.entity.toEventReference();
+              final media = flattenedVideo.media;
+
+              return VideoPage(
+                videoInfo: VideoPostInfo(videoPost: flattenedVideo.entity),
+                bottomOverlay: VideoActions(
+                  eventReference: perPageEventReference,
+                  onReplyTap: () => PostDetailsRoute(
+                    eventReference: perPageEventReference.encode(),
+                  ).push<void>(context),
+                ),
+                videoUrl: media.url,
+                authorPubkey: perPageEventReference.masterPubkey,
+                thumbnailUrl: media.thumb,
+                blurhash: media.blurhash,
+                aspectRatio: media.aspectRatio,
+                framedEventReference: index == initialPage ? framedEventReference : null,
+              );
+            },
           ),
         ),
       ),


### PR DESCRIPTION


## Description
This PR fixes an issue where clicking on the comment button on any of the videos in vertical videos page would always open the post details of the first video.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
<!-- Add corresponding task ID here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
