### PR TITLE
fix: prevent provider disposal during E2E message decoding

### DIFF
--- a/lib/app/features/user/providers/user_delegation_provider.r.dart
+++ b/lib/app/features/user/providers/user_delegation_provider.r.dart
@@ -15,7 +15,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'user_delegation_provider.r.g.dart';
 
-@Riverpod(keepAlive: true)
+@riverpod
 Future<UserDelegationEntity?> userDelegation(Ref ref, String pubkey, {bool cache = true}) async {
   keepAliveWhenAuthenticated(ref);
   if (cache) {


### PR DESCRIPTION
## Description
The app was throwing an exception when attempting to decode E2E messages because the userDelegationProvider was being disposed while still in a loading state, preventing value emission.

 By making the provider keep-alive and tying its lifecycle to the authentication state, we ensure the provider remains available during critical operations like E2E message decoding.


## Additional Notes
N/A

## Task ID
3916

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
