### PR TITLE
fix: gallery selected album pagination

### DIFF
--- a/lib/app/features/gallery/providers/gallery_provider.r.dart
+++ b/lib/app/features/gallery/providers/gallery_provider.r.dart
@@ -138,7 +138,7 @@ class GalleryNotifier extends _$GalleryNotifier {
         mediaData: [...currentState.mediaData, ...newMedia],
         currentPage: currentState.currentPage + 1,
         hasMore: hasMore,
-        isLoading: true,
+        isLoading: false,
       );
     });
   }


### PR DESCRIPTION
## Description
The pagination didn't go further the second page on gallery when album was selected

## Task ID
ION-3924

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

