### PR TITLE
fix: change cache strategy to use different favicons on social preview

### DIFF
--- a/lib/app/components/image/ion_network_image.dart
+++ b/lib/app/components/image/ion_network_image.dart
@@ -72,7 +72,8 @@ class IonNetworkImage extends HookWidget {
     }
 
     final fetchError = useRef<Object?>(null);
-    final cacheKey = Uri.tryParse(imageUrl)?.path ?? imageUrl;
+    // Use the full URL as cache key to avoid collisions (e.g., '/favicon.ico' across domains)
+    final cacheKey = imageUrl;
 
     if (borderRadius != null) {
       return DecoratedBox(


### PR DESCRIPTION
## Description
- Change cacheKey

## Task ID
- ION-3929

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)

https://github.com/user-attachments/assets/cbb60350-c418-42eb-9ffb-2fd30beb3479


