### PR TITLE
fix: show preview for all social posts in feed

### DIFF
--- a/lib/app/features/feed/views/components/post/components/post_body/post_body.dart
+++ b/lib/app/features/feed/views/components/post/components/post_body/post_body.dart
@@ -132,7 +132,7 @@ class PostBody extends HookConsumerWidget {
           Padding(
             padding: EdgeInsetsDirectional.symmetric(horizontal: sidePadding ?? 16.0.s),
             child: UrlPreviewContent(
-              url: firstUrlInPost!,
+              url: firstUrlInPost,
             ),
           ),
       ],


### PR DESCRIPTION
## Description
- Fix preview for social posts

## Task ID
- ION-3921

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)

https://github.com/user-attachments/assets/625c16bf-75ab-423b-8bb0-49990a2e80b1

