### PR TITLE
fix: preload image and video media in story viewer

### DIFF
--- a/lib/app/components/video_preview/video_preview.dart
+++ b/lib/app/components/video_preview/video_preview.dart
@@ -9,7 +9,7 @@ import 'package:ion/app/components/placeholder/ion_placeholder.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/components/ion_connect_network_image/ion_connect_network_image.dart';
 import 'package:ion/app/features/core/providers/mute_provider.r.dart';
-import 'package:ion/app/features/core/providers/video_player_provider.r.dart';
+import 'package:ion/app/features/core/providers/video_player_provider.m.dart';
 import 'package:ion/app/features/ion_connect/model/event_reference.f.dart';
 import 'package:ion/app/hooks/use_on_init.dart';
 import 'package:ion/app/hooks/use_route_presence.dart';

--- a/lib/app/features/auth/views/pages/intro_page/intro_page.dart
+++ b/lib/app/features/auth/views/pages/intro_page/intro_page.dart
@@ -5,7 +5,7 @@ import 'package:flutter_animate/flutter_animate.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/button/button.dart';
 import 'package:ion/app/extensions/extensions.dart';
-import 'package:ion/app/features/core/providers/video_player_provider.r.dart';
+import 'package:ion/app/features/core/providers/video_player_provider.m.dart';
 import 'package:ion/app/hooks/use_auto_play.dart';
 import 'package:ion/app/router/app_routes.gr.dart';
 import 'package:ion/generated/assets.gen.dart';

--- a/lib/app/features/chat/views/pages/chat_media_page/components/chat_media_page_view.dart
+++ b/lib/app/features/chat/views/pages/chat_media_page/components/chat_media_page_view.dart
@@ -11,7 +11,7 @@ import 'package:ion/app/features/chat/e2ee/model/entities/private_direct_message
 import 'package:ion/app/features/chat/e2ee/providers/chat_message_load_media_provider.r.dart';
 import 'package:ion/app/features/chat/model/database/chat_database.m.dart';
 import 'package:ion/app/features/core/model/media_type.dart';
-import 'package:ion/app/features/core/providers/video_player_provider.r.dart';
+import 'package:ion/app/features/core/providers/video_player_provider.m.dart';
 import 'package:ion/app/features/feed/views/pages/fullscreen_media/hooks/use_image_zoom.dart';
 import 'package:ion/app/features/ion_connect/model/event_reference.f.dart';
 import 'package:ion/app/features/ion_connect/model/media_attachment.dart';

--- a/lib/app/features/core/providers/video_player_provider.m.dart
+++ b/lib/app/features/core/providers/video_player_provider.m.dart
@@ -9,6 +9,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/exceptions/exceptions.dart';
 import 'package:ion/app/extensions/bool.dart';
@@ -18,7 +19,8 @@ import 'package:ion/app/services/logger/logger.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:video_player/video_player.dart';
 
-part 'video_player_provider.r.g.dart';
+part 'video_player_provider.m.freezed.dart';
+part 'video_player_provider.m.g.dart';
 
 class NetworkVideosCacheManager {
   static const key = 'networkVideosCacheKey';
@@ -59,32 +61,17 @@ class _ConcurrencyGate {
   }
 }
 
-@immutable
-class VideoControllerParams {
-  const VideoControllerParams({
-    required this.sourcePath,
-    this.authorPubkey,
-    this.uniqueId = '',
-    this.looping = false,
-    this.onlyOneShouldPlay = false,
-  });
-
-  final String sourcePath;
-  final String? authorPubkey;
-  final String
-      uniqueId; // an optional uniqueId parameter which should be used when needed independent controllers for the same sourcePath
-  final bool looping;
-  final bool onlyOneShouldPlay;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is VideoControllerParams &&
-          other.sourcePath == sourcePath &&
-          other.uniqueId == uniqueId;
-
-  @override
-  int get hashCode => sourcePath.hashCode ^ uniqueId.hashCode;
+@Freezed(fromJson: false, toJson: false)
+class VideoControllerParams with _$VideoControllerParams {
+  const factory VideoControllerParams({
+    required String sourcePath,
+    String? authorPubkey,
+    @Default('')
+    String?
+        uniqueId, // an optional uniqueId parameter which should be used when needed independent controllers for the same sourcePath
+    @Default(false) bool looping,
+    @Default(false) bool onlyOneShouldPlay,
+  }) = _VideoControllerParams;
 }
 
 @riverpod

--- a/lib/app/features/core/views/pages/splash_page.dart
+++ b/lib/app/features/core/views/pages/splash_page.dart
@@ -8,7 +8,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/core/providers/splash_provider.r.dart';
-import 'package:ion/app/features/core/providers/video_player_provider.r.dart';
+import 'package:ion/app/features/core/providers/video_player_provider.m.dart';
 import 'package:ion/app/hooks/use_auto_play.dart';
 import 'package:ion/app/hooks/use_on_init.dart';
 import 'package:ion/generated/assets.gen.dart';

--- a/lib/app/features/feed/create_post/views/pages/compress_test_page.f.dart
+++ b/lib/app/features/feed/create_post/views/pages/compress_test_page.f.dart
@@ -11,7 +11,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:ion/app/features/core/providers/video_player_provider.r.dart';
+import 'package:ion/app/features/core/providers/video_player_provider.m.dart';
 import 'package:ion/app/hooks/use_on_init.dart';
 import 'package:ion/app/services/compressors/image_compressor.r.dart';
 import 'package:ion/app/services/compressors/video_compressor.r.dart';

--- a/lib/app/features/feed/create_post/views/pages/post_form_modal/components/video_preview_cover.dart
+++ b/lib/app/features/feed/create_post/views/pages/post_form_modal/components/video_preview_cover.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/extensions/extensions.dart';
-import 'package:ion/app/features/core/providers/video_player_provider.r.dart';
+import 'package:ion/app/features/core/providers/video_player_provider.m.dart';
 import 'package:ion/app/features/feed/create_post/views/pages/post_form_modal/components/video_preview_duration.dart';
 import 'package:ion/app/features/feed/create_post/views/pages/post_form_modal/components/video_preview_edit_cover.dart';
 import 'package:ion/app/hooks/use_on_init.dart';

--- a/lib/app/features/feed/stories/hooks/use_story_progress_controller.dart
+++ b/lib/app/features/feed/stories/hooks/use_story_progress_controller.dart
@@ -3,10 +3,10 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/features/core/model/media_type.dart';
-import 'package:ion/app/features/core/providers/video_player_provider.r.dart';
+import 'package:ion/app/features/core/providers/video_player_provider.m.dart';
 import 'package:ion/app/features/feed/data/models/entities/modifiable_post_data.f.dart';
 import 'package:ion/app/features/feed/stories/hooks/use_story_image_progress.dart';
-import 'package:ion/app/features/feed/stories/providers/story_video_controller_provider.r.dart';
+import 'package:ion/app/features/feed/stories/providers/story_video_controller_provider.m.dart';
 import 'package:video_player/video_player.dart';
 
 class StoryProgressControllerResult {

--- a/lib/app/features/feed/stories/hooks/use_story_video_playback.dart
+++ b/lib/app/features/feed/stories/hooks/use_story_video_playback.dart
@@ -8,7 +8,8 @@ import 'package:ion/app/features/feed/stories/providers/story_viewing_provider.r
 import 'package:ion/app/features/feed/stories/providers/user_stories_provider.r.dart';
 import 'package:video_player/video_player.dart';
 
-void _post(VoidCallback action) => WidgetsBinding.instance.addPostFrameCallback((_) => action());
+void _post(VoidCallback action) =>
+    WidgetsBinding.instance.addPostFrameCallback((_) => action());
 
 void useStoryVideoPlayback({
   required WidgetRef ref,
@@ -76,8 +77,20 @@ void useStoryVideoPlayback({
         }
       }
 
-      controller.addListener(listener);
-      return () => controller.removeListener(listener);
+      var added = false;
+      try {
+        controller.addListener(listener);
+        added = true;
+      } catch (_) {
+        return null;
+      }
+
+      return () {
+        if (!added) return;
+        try {
+          controller.removeListener(listener);
+        } catch (_) {}
+      };
     },
     [controller, isCurrent, onCompleted],
   );

--- a/lib/app/features/feed/stories/hooks/use_story_video_playback.dart
+++ b/lib/app/features/feed/stories/hooks/use_story_video_playback.dart
@@ -8,8 +8,7 @@ import 'package:ion/app/features/feed/stories/providers/story_viewing_provider.r
 import 'package:ion/app/features/feed/stories/providers/user_stories_provider.r.dart';
 import 'package:video_player/video_player.dart';
 
-void _post(VoidCallback action) =>
-    WidgetsBinding.instance.addPostFrameCallback((_) => action());
+void _post(VoidCallback action) => WidgetsBinding.instance.addPostFrameCallback((_) => action());
 
 void useStoryVideoPlayback({
   required WidgetRef ref,

--- a/lib/app/features/feed/stories/providers/story_feed_prefetch_registry_provider.r.dart
+++ b/lib/app/features/feed/stories/providers/story_feed_prefetch_registry_provider.r.dart
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:flutter/foundation.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'story_feed_prefetch_registry_provider.r.g.dart';
+
+@riverpod
+class StoryFeedPrefetchRegistry extends _$StoryFeedPrefetchRegistry {
+  @override
+  Set<String> build(String pubkey) => <String>{};
+
+  void add(String storyId) {
+    if (storyId.isEmpty || state.contains(storyId)) return;
+    state = {...state, storyId};
+  }
+
+  void remove(String storyId) {
+    if (!state.contains(storyId)) return;
+    final next = {...state}..remove(storyId);
+    state = next;
+  }
+
+  void replaceWith(Iterable<String> storyIds) {
+    final next = storyIds.toSet()..removeWhere((id) => id.isEmpty);
+    if (setEquals(next, state)) return;
+    state = next;
+  }
+}

--- a/lib/app/features/feed/stories/providers/story_video_controller_provider.m.dart
+++ b/lib/app/features/feed/stories/providers/story_video_controller_provider.m.dart
@@ -1,37 +1,24 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:flutter/foundation.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:ion/app/features/core/providers/video_player_provider.r.dart';
+import 'package:ion/app/features/core/providers/video_player_provider.m.dart';
 import 'package:ion/app/features/feed/stories/providers/story_feed_prefetch_registry_provider.r.dart';
 import 'package:ion/app/features/feed/stories/providers/story_video_prefetch_targets_provider.r.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:video_player/video_player.dart';
 
-part 'story_video_controller_provider.r.g.dart';
+part 'story_video_controller_provider.m.freezed.dart';
+part 'story_video_controller_provider.m.g.dart';
 
-@immutable
-class StoryVideoControllerParams {
-  const StoryVideoControllerParams({
-    required this.storyId,
-    required this.sessionPubkey,
-    required this.baseParams,
-  });
-
-  final String storyId;
-  final String sessionPubkey;
-  final VideoControllerParams baseParams;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is StoryVideoControllerParams &&
-          other.storyId == storyId &&
-          other.sessionPubkey == sessionPubkey &&
-          other.baseParams == baseParams;
-
-  @override
-  int get hashCode => Object.hash(storyId, sessionPubkey, baseParams);
+@Freezed(fromJson: false, toJson: false)
+class StoryVideoControllerParams with _$StoryVideoControllerParams {
+  const factory StoryVideoControllerParams({
+    required String storyId,
+    required String sessionPubkey,
+    required VideoControllerParams baseParams,
+  }) = _StoryVideoControllerParams;
 }
 
 @riverpod

--- a/lib/app/features/feed/stories/providers/story_video_controller_provider.r.dart
+++ b/lib/app/features/feed/stories/providers/story_video_controller_provider.r.dart
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:flutter/foundation.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:ion/app/features/core/providers/video_player_provider.r.dart';
+import 'package:ion/app/features/feed/stories/providers/story_video_prefetch_targets_provider.r.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:video_player/video_player.dart';
+
+part 'story_video_controller_provider.r.g.dart';
+
+@immutable
+class StoryVideoControllerParams {
+  const StoryVideoControllerParams({
+    required this.storyId,
+    required this.sessionPubkey,
+    required this.baseParams,
+  });
+
+  final String storyId;
+  final String sessionPubkey;
+  final VideoControllerParams baseParams;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is StoryVideoControllerParams &&
+          other.storyId == storyId &&
+          other.sessionPubkey == sessionPubkey &&
+          other.baseParams == baseParams;
+
+  @override
+  int get hashCode => Object.hash(storyId, sessionPubkey, baseParams);
+}
+
+@riverpod
+Future<Raw<VideoPlayerController>> storyVideoController(
+  Ref ref,
+  StoryVideoControllerParams params,
+) async {
+  KeepAliveLink? keepAliveLink;
+
+  void ensureKeepAlive() {
+    keepAliveLink ??= ref.keepAlive();
+  }
+
+  ref
+    ..listen<Set<String>>(
+      storyVideoPrefetchTargetsProvider(params.sessionPubkey),
+      (_, targets) {
+        if (targets.contains(params.storyId)) {
+          ensureKeepAlive();
+        } else {
+          keepAliveLink?.close();
+          keepAliveLink = null;
+        }
+      },
+      fireImmediately: true,
+    )
+    ..onDispose(() {
+      keepAliveLink?.close();
+      keepAliveLink = null;
+    });
+
+  return ref.watch(videoControllerProvider(params.baseParams).future);
+}

--- a/lib/app/features/feed/stories/providers/story_video_prefetch_targets_provider.r.dart
+++ b/lib/app/features/feed/stories/providers/story_video_prefetch_targets_provider.r.dart
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'story_video_prefetch_targets_provider.r.g.dart';
+
+@riverpod
+class StoryVideoPrefetchTargets extends _$StoryVideoPrefetchTargets {
+  @override
+  Set<String> build(String pubkey) => <String>{};
+
+  void replaceWith(Iterable<String> storyIds) {
+    final next = storyIds.toSet()..removeWhere((id) => id.isEmpty);
+    if (next.length == state.length && state.containsAll(next)) {
+      return;
+    }
+    state = next;
+  }
+
+  void clear() {
+    if (state.isEmpty) {
+      return;
+    }
+    state = <String>{};
+  }
+}

--- a/lib/app/features/feed/stories/providers/story_video_prefetch_targets_provider.r.dart
+++ b/lib/app/features/feed/stories/providers/story_video_prefetch_targets_provider.r.dart
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: ice License 1.0
 
+import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'story_video_prefetch_targets_provider.r.g.dart';
@@ -22,5 +23,11 @@ class StoryVideoPrefetchTargets extends _$StoryVideoPrefetchTargets {
       return;
     }
     state = <String>{};
+  }
+
+  void remove(String storyId) {
+    if (!state.contains(storyId)) return;
+    final next = {...state}..remove(storyId);
+    state = next;
   }
 }

--- a/lib/app/features/feed/stories/views/components/story_preview/media/story_video_preview.dart
+++ b/lib/app/features/feed/stories/views/components/story_preview/media/story_video_preview.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/progress_bar/centered_loading_indicator.dart';
 import 'package:ion/app/extensions/extensions.dart';
-import 'package:ion/app/features/core/providers/video_player_provider.r.dart';
+import 'package:ion/app/features/core/providers/video_player_provider.m.dart';
 import 'package:ion/app/hooks/use_auto_play.dart';
 import 'package:ion/app/services/media_service/aspect_ratio.dart';
 import 'package:video_player/video_player.dart';

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/core/hooks/use_story_viewer_story_preload.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/core/hooks/use_story_viewer_story_preload.dart
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:ion/app/features/feed/data/models/entities/modifiable_post_data.f.dart';
+import 'package:ion/app/features/feed/stories/providers/story_video_prefetch_targets_provider.r.dart';
+import 'package:ion/app/features/feed/views/pages/feed_page/components/stories/hooks/use_preload_story_media.dart';
+import 'package:ion/app/hooks/use_on_init.dart';
+
+typedef StoryPrefetchReset = VoidCallback;
+
+StoryPrefetchReset useStoryViewerStoryPreload({
+  required WidgetRef ref,
+  required String sessionPubkey,
+  required List<ModifiablePostEntity> stories,
+  required int currentStoryIndex,
+}) {
+  final context = useContext();
+
+  final prefetchTargetsProvider = storyVideoPrefetchTargetsProvider(sessionPubkey);
+
+  String? storyIdAt(int index) {
+    if (index < 0 || index >= stories.length) {
+      return null;
+    }
+    return stories[index].id;
+  }
+
+  List<ModifiablePostEntity> computeWindowStories() {
+    final windowStories = <ModifiablePostEntity>[];
+    for (var offset = -2; offset <= 2; offset++) {
+      if (offset == 0) continue;
+      final targetIndex = currentStoryIndex + offset;
+      if (targetIndex < 0 || targetIndex >= stories.length) continue;
+      windowStories.add(stories[targetIndex]);
+    }
+    return windowStories;
+  }
+
+  useEffect(
+    () {
+      final notifier = ref.read(prefetchTargetsProvider.notifier);
+      return () {
+        Future.microtask(notifier.clear);
+      };
+    },
+    [ref, sessionPubkey],
+  );
+
+  useOnInit(
+    () {
+      if (!context.mounted) return;
+      if (stories.isEmpty) return;
+
+      final windowStories = computeWindowStories();
+      ref
+          .read(prefetchTargetsProvider.notifier)
+          .replaceWith(windowStories.map((story) => story.id));
+
+      for (final story in windowStories) {
+        unawaited(
+          preloadStoryMedia(
+            ref: ref,
+            context: context,
+            story: story,
+            sessionPubkey: sessionPubkey,
+          ),
+        );
+      }
+    },
+    [
+      sessionPubkey,
+      currentStoryIndex,
+      stories.length,
+      storyIdAt(currentStoryIndex - 2),
+      storyIdAt(currentStoryIndex - 1),
+      storyIdAt(currentStoryIndex + 1),
+      storyIdAt(currentStoryIndex + 2),
+    ],
+  );
+
+  return useCallback(
+    () {
+      ref.read(prefetchTargetsProvider.notifier).clear();
+    },
+    [ref, sessionPubkey],
+  );
+}

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/core/user_story_page_view.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/core/user_story_page_view.dart
@@ -54,17 +54,14 @@ class UserStoryPageView extends HookConsumerWidget {
     final currentStory = isCurrentUser ? stories[currentIndex] : stories.first;
     useOnInit(
       () {
-        ref
-            .read(viewedStoriesProvider.notifier)
-            .markStoryAsViewed(currentStory);
+        ref.read(viewedStoriesProvider.notifier).markStoryAsViewed(currentStory);
       },
       [currentStory.id],
     );
 
     useEffect(
       () {
-        final notifier =
-            ref.read(storyVideoPrefetchTargetsProvider(pubkey).notifier);
+        final notifier = ref.read(storyVideoPrefetchTargetsProvider(pubkey).notifier);
         return () {
           Future.microtask(notifier.clear);
         };
@@ -108,7 +105,6 @@ class UserStoryPageView extends HookConsumerWidget {
               context: context,
               story: story,
               sessionPubkey: pubkey,
-              keepAliveForSession: true,
             ),
           );
         }

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/core/user_story_page_view.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/core/user_story_page_view.dart
@@ -1,9 +1,15 @@
 // SPDX-License-Identifier: ice License 1.0
 
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/progress_bar/ion_loading_indicator.dart';
+import 'package:ion/app/features/feed/data/models/entities/modifiable_post_data.f.dart';
+import 'package:ion/app/features/feed/stories/providers/story_video_prefetch_targets_provider.r.dart';
 import 'package:ion/app/features/feed/stories/providers/story_viewing_provider.r.dart';
 import 'package:ion/app/features/feed/stories/providers/user_stories_provider.r.dart';
 import 'package:ion/app/features/feed/stories/providers/viewed_stories_provider.r.dart';
@@ -37,6 +43,7 @@ class UserStoryPageView extends HookConsumerWidget {
       singleUserStoryViewingControllerProvider(pubkey).notifier,
     );
     final stories = ref.watch(userStoriesProvider(pubkey))?.toList() ?? [];
+    final currentIndex = singleUserStoriesViewingState.currentStoryIndex;
 
     if (stories.isEmpty) {
       return const Center(
@@ -44,28 +51,94 @@ class UserStoryPageView extends HookConsumerWidget {
       );
     }
 
-    final currentStory =
-        isCurrentUser ? stories[singleUserStoriesViewingState.currentStoryIndex] : stories.first;
+    final currentStory = isCurrentUser ? stories[currentIndex] : stories.first;
     useOnInit(
       () {
-        ref.read(viewedStoriesProvider.notifier).markStoryAsViewed(currentStory);
+        ref
+            .read(viewedStoriesProvider.notifier)
+            .markStoryAsViewed(currentStory);
       },
       [currentStory.id],
     );
 
-    usePreloadStoryMedia(
-      ref,
-      stories.elementAtOrNull(singleUserStoriesViewingState.currentStoryIndex + 1),
+    useEffect(
+      () {
+        final notifier =
+            ref.read(storyVideoPrefetchTargetsProvider(pubkey).notifier);
+        return () {
+          Future.microtask(notifier.clear);
+        };
+      },
+      [pubkey],
     );
+
+    String? storyIdAt(int index) {
+      if (index < 0 || index >= stories.length) {
+        return null;
+      }
+      return stories[index].id;
+    }
+
+    final windowStories = <ModifiablePostEntity>[];
+    for (var offset = -2; offset <= 2; offset++) {
+      if (offset == 0) continue;
+      final targetIndex = currentIndex + offset;
+      if (targetIndex < 0 || targetIndex >= stories.length) continue;
+      windowStories.add(stories[targetIndex]);
+    }
+
+    useOnInit(
+      () {
+        if (!context.mounted) return;
+
+        final nextIds = windowStories.map((story) => story.id).toSet();
+        final currentIds = ref.read(storyVideoPrefetchTargetsProvider(pubkey));
+        if (setEquals(nextIds, currentIds)) {
+          return;
+        }
+
+        ref
+            .read(storyVideoPrefetchTargetsProvider(pubkey).notifier)
+            .replaceWith(windowStories.map((story) => story.id));
+
+        for (final story in windowStories) {
+          unawaited(
+            preloadStoryMedia(
+              ref: ref,
+              context: context,
+              story: story,
+              sessionPubkey: pubkey,
+              keepAliveForSession: true,
+            ),
+          );
+        }
+      },
+      [
+        pubkey,
+        currentIndex,
+        stories.length,
+        storyIdAt(currentIndex - 2),
+        storyIdAt(currentIndex - 1),
+        storyIdAt(currentIndex + 1),
+        storyIdAt(currentIndex + 2),
+      ],
+    );
+
+    void handleUserExit(VoidCallback callback) {
+      ref.read(storyVideoPrefetchTargetsProvider(pubkey).notifier).clear();
+      callback();
+    }
 
     return KeyboardVisibilityProvider(
       child: StoryGestureHandler(
         key: storyGestureKeyFor(pubkey),
         viewerPubkey: pubkey,
-        onTapLeft: () => singleUserStoriesNotifier.rewind(onRewoundAll: onPreviousUser),
+        onTapLeft: () => singleUserStoriesNotifier.rewind(
+          onRewoundAll: () => handleUserExit(onPreviousUser),
+        ),
         onTapRight: () => singleUserStoriesNotifier.advance(
           storiesLength: stories.length,
-          onSeenAll: onNextUser,
+          onSeenAll: () => handleUserExit(onNextUser),
         ),
         child: StoryContent(
           key: Key(currentStory.id),
@@ -73,7 +146,7 @@ class UserStoryPageView extends HookConsumerWidget {
           viewerPubkey: pubkey,
           onNext: () => singleUserStoriesNotifier.advance(
             storiesLength: stories.length,
-            onSeenAll: onNextUser,
+            onSeenAll: () => handleUserExit(onNextUser),
           ),
         ),
       ),

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/progress/story_progress_bar_container.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/progress/story_progress_bar_container.dart
@@ -76,6 +76,7 @@ class StoryProgressBarContainer extends ConsumerWidget {
                         storiesLength: stories.length,
                         onSeenAll: () => userStoriesNotifier.advance(onClose: () => context.pop()),
                       ),
+              sessionPubkey: currentUserPubkey,
               margin: index > 0 ? EdgeInsetsDirectional.only(start: 4.0.s) : null,
             ),
           );

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/progress/story_progress_tracker.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/progress/story_progress_tracker.dart
@@ -14,6 +14,7 @@ class StoryProgressTracker extends HookConsumerWidget {
     required this.isCurrent,
     required this.isPreviousStory,
     required this.onCompleted,
+    required this.sessionPubkey,
     this.margin,
     super.key,
   });
@@ -24,13 +25,15 @@ class StoryProgressTracker extends HookConsumerWidget {
     this.margin,
     super.key,
   })  : post = null,
-        onCompleted = null;
+        onCompleted = null,
+        sessionPubkey = null;
 
   final ModifiablePostEntity? post;
   final bool isCurrent;
   final bool isPreviousStory;
   final VoidCallback? onCompleted;
   final EdgeInsetsGeometry? margin;
+  final String? sessionPubkey;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -50,6 +53,7 @@ class StoryProgressTracker extends HookConsumerWidget {
       isCurrent: isCurrent,
       isPaused: isPaused,
       onCompleted: onCompleted ?? () {},
+      sessionPubkey: sessionPubkey,
     );
 
     return StoryProgressSegment(

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/video_story_viewer.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/video_story_viewer.dart
@@ -3,9 +3,9 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/progress_bar/centered_loading_indicator.dart';
-import 'package:ion/app/features/core/providers/video_player_provider.r.dart';
+import 'package:ion/app/features/core/providers/video_player_provider.m.dart';
 import 'package:ion/app/features/feed/stories/hooks/use_story_video_playback.dart';
-import 'package:ion/app/features/feed/stories/providers/story_video_controller_provider.r.dart';
+import 'package:ion/app/features/feed/stories/providers/story_video_controller_provider.m.dart';
 import 'package:video_player/video_player.dart';
 
 class VideoStoryViewer extends HookConsumerWidget {

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/video_story_viewer.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/video_story_viewer.dart
@@ -5,6 +5,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/progress_bar/centered_loading_indicator.dart';
 import 'package:ion/app/features/core/providers/video_player_provider.r.dart';
 import 'package:ion/app/features/feed/stories/hooks/use_story_video_playback.dart';
+import 'package:ion/app/features/feed/stories/providers/story_video_controller_provider.r.dart';
 import 'package:video_player/video_player.dart';
 
 class VideoStoryViewer extends HookConsumerWidget {
@@ -25,10 +26,20 @@ class VideoStoryViewer extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final baseParams = VideoControllerParams(
+      sourcePath: videoPath,
+      authorPubkey: authorPubkey,
+      uniqueId: storyId,
+    );
+
     final videoController = ref
         .watch(
-          videoControllerProvider(
-            VideoControllerParams(sourcePath: videoPath, authorPubkey: authorPubkey),
+          storyVideoControllerProvider(
+            StoryVideoControllerParams(
+              storyId: storyId,
+              sessionPubkey: viewerPubkey,
+              baseParams: baseParams,
+            ),
           ),
         )
         .valueOrNull;

--- a/lib/app/features/feed/views/pages/feed_page/components/stories/components/story_list_item.dart
+++ b/lib/app/features/feed/views/pages/feed_page/components/stories/components/story_list_item.dart
@@ -32,17 +32,26 @@ class StoryListItem extends HookConsumerWidget {
     final userStory = ref.watch(feedStoriesByPubkeyProvider(pubkey, showOnlySelectedUser: true));
     final storyReference = userStory.firstOrNull?.toEventReference();
 
-    final gradient = useRef(storyBorderGradients[Random().nextInt(storyBorderGradients.length)]);
+    final gradient = useRef(
+      storyBorderGradients[Random().nextInt(storyBorderGradients.length)],
+    );
 
-    usePreloadStoryMedia(ref, userStory.firstOrNull);
+    final firstStory = userStory.firstOrNull;
+
+    usePreloadStoryMedia(
+      ref,
+      firstStory,
+      sessionPubkey: pubkey,
+    );
 
     if (userMetadata == null || storyReference == null) {
       return const SizedBox.shrink();
     }
 
     final isViewed = ref.watch(
-      viewedStoriesProvider
-          .select((viewedStories) => viewedStories?.contains(storyReference) ?? false),
+      viewedStoriesProvider.select(
+        (viewedStories) => viewedStories?.contains(storyReference) ?? false,
+      ),
     );
 
     return Padding(

--- a/lib/app/features/feed/views/pages/feed_page/components/stories/hooks/use_preload_story_media.dart
+++ b/lib/app/features/feed/views/pages/feed_page/components/stories/hooks/use_preload_story_media.dart
@@ -8,12 +8,13 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/features/core/model/media_type.dart';
 import 'package:ion/app/features/core/providers/ion_connect_media_url_fallback_provider.r.dart';
-import 'package:ion/app/features/core/providers/video_player_provider.r.dart';
+import 'package:ion/app/features/core/providers/video_player_provider.m.dart';
 import 'package:ion/app/features/feed/data/models/entities/modifiable_post_data.f.dart';
 import 'package:ion/app/features/feed/stories/providers/story_feed_prefetch_registry_provider.r.dart';
 import 'package:ion/app/features/feed/stories/providers/story_image_loading_provider.r.dart';
-import 'package:ion/app/features/feed/stories/providers/story_video_controller_provider.r.dart';
+import 'package:ion/app/features/feed/stories/providers/story_video_controller_provider.m.dart';
 import 'package:ion/app/hooks/use_on_init.dart';
+import 'package:ion/app/services/logger/logger.dart';
 
 void usePreloadStoryMedia(
   WidgetRef ref,
@@ -87,8 +88,12 @@ Future<void> preloadStoryMedia({
       );
 
       await precacheImage(imageProvider, context);
-    } catch (_) {
-      // Fall back to the standard loading path when prefetch fails.
+    } catch (e, stackTrace) {
+      Logger.error(
+        e,
+        stackTrace: stackTrace,
+        message: 'Failed to precache story image: $resolvedUrl',
+      );
     }
     return;
   }

--- a/lib/app/features/feed/views/pages/feed_page/components/stories/hooks/use_preload_story_media.dart
+++ b/lib/app/features/feed/views/pages/feed_page/components/stories/hooks/use_preload_story_media.dart
@@ -11,51 +11,105 @@ import 'package:ion/app/features/core/providers/ion_connect_media_url_fallback_p
 import 'package:ion/app/features/core/providers/video_player_provider.r.dart';
 import 'package:ion/app/features/feed/data/models/entities/modifiable_post_data.f.dart';
 import 'package:ion/app/features/feed/stories/providers/story_image_loading_provider.r.dart';
+import 'package:ion/app/features/feed/stories/providers/story_video_controller_provider.r.dart';
 import 'package:ion/app/hooks/use_on_init.dart';
 
-void usePreloadStoryMedia(WidgetRef ref, ModifiablePostEntity? story) {
+Future<void> _preloadStoryMedia({
+  required WidgetRef ref,
+  required BuildContext context,
+  required ModifiablePostEntity story,
+  String? sessionPubkey,
+  bool keepAliveForSession = false,
+}) async {
+  final media = story.data.primaryMedia;
+  if (media == null) return;
+
+  if (media.mediaType == MediaType.image) {
+    final cacheManager = ref.read(storyImageCacheManagerProvider);
+    final resolvedUrl = ref.read(iONConnectMediaUrlFallbackProvider)[media.url] ?? media.url;
+
+    try {
+      await cacheManager.getSingleFile(resolvedUrl);
+      if (!context.mounted) return;
+
+      final cacheKey = Uri.tryParse(resolvedUrl)?.path ?? resolvedUrl;
+      final imageProvider = CachedNetworkImageProvider(
+        resolvedUrl,
+        cacheManager: cacheManager,
+        cacheKey: cacheKey,
+      );
+
+      await precacheImage(imageProvider, context);
+    } catch (_) {
+      // Fall back to the standard loading path when prefetch fails.
+    }
+    return;
+  }
+
+  if (media.mediaType == MediaType.video) {
+    final params = VideoControllerParams(
+      sourcePath: media.url,
+      authorPubkey: story.masterPubkey,
+      uniqueId: story.id,
+    );
+
+    final session = sessionPubkey;
+
+    if (keepAliveForSession && session != null) {
+      ref.read(
+        storyVideoControllerProvider(
+          StoryVideoControllerParams(
+            storyId: story.id,
+            sessionPubkey: session,
+            baseParams: params,
+          ),
+        ),
+      );
+    } else {
+      ref.read(
+        videoControllerProvider(params),
+      );
+    }
+  }
+}
+
+void usePreloadStoryMedia(
+  WidgetRef ref,
+  ModifiablePostEntity? story, {
+  String? sessionPubkey,
+  bool keepAliveForSession = false,
+}) {
   final context = useContext();
 
   useOnInit(
     () {
       if (story == null) return;
-      final media = story.data.primaryMedia;
-      if (media == null) return;
-      if (media.mediaType == MediaType.image) {
-        final cacheManager = ref.read(storyImageCacheManagerProvider);
-        final resolvedUrl = ref.read(iONConnectMediaUrlFallbackProvider)[media.url] ?? media.url;
-
-        unawaited(
-          () async {
-            try {
-              // getSingleFile downloads when needed and refreshes the disk cache.
-              await cacheManager.getSingleFile(resolvedUrl);
-              if (!context.mounted) return;
-
-              final cacheKey = Uri.tryParse(resolvedUrl)?.path ?? resolvedUrl;
-              final provider = CachedNetworkImageProvider(
-                resolvedUrl,
-                cacheManager: cacheManager,
-                cacheKey: cacheKey,
-              );
-
-              await precacheImage(provider, context);
-            } catch (_) {
-              // fall back to regular loading path.
-            }
-          }(),
-        );
-      } else if (media.mediaType == MediaType.video) {
-        ref.read(
-          videoControllerProvider(
-            VideoControllerParams(
-              sourcePath: media.url,
-              authorPubkey: story.masterPubkey,
-            ),
-          ),
-        );
-      }
+      unawaited(
+        _preloadStoryMedia(
+          ref: ref,
+          context: context,
+          story: story,
+          sessionPubkey: sessionPubkey,
+          keepAliveForSession: keepAliveForSession,
+        ),
+      );
     },
-    [story?.id],
+    [story?.id, sessionPubkey, keepAliveForSession],
+  );
+}
+
+Future<void> preloadStoryMedia({
+  required WidgetRef ref,
+  required BuildContext context,
+  required ModifiablePostEntity story,
+  String? sessionPubkey,
+  bool keepAliveForSession = false,
+}) {
+  return _preloadStoryMedia(
+    ref: ref,
+    context: context,
+    story: story,
+    sessionPubkey: sessionPubkey,
+    keepAliveForSession: keepAliveForSession,
   );
 }

--- a/lib/app/features/feed/views/pages/feed_page/components/stories/hooks/use_preload_story_media.dart
+++ b/lib/app/features/feed/views/pages/feed_page/components/stories/hooks/use_preload_story_media.dart
@@ -10,16 +10,64 @@ import 'package:ion/app/features/core/model/media_type.dart';
 import 'package:ion/app/features/core/providers/ion_connect_media_url_fallback_provider.r.dart';
 import 'package:ion/app/features/core/providers/video_player_provider.r.dart';
 import 'package:ion/app/features/feed/data/models/entities/modifiable_post_data.f.dart';
+import 'package:ion/app/features/feed/stories/providers/story_feed_prefetch_registry_provider.r.dart';
 import 'package:ion/app/features/feed/stories/providers/story_image_loading_provider.r.dart';
 import 'package:ion/app/features/feed/stories/providers/story_video_controller_provider.r.dart';
 import 'package:ion/app/hooks/use_on_init.dart';
 
-Future<void> _preloadStoryMedia({
+void usePreloadStoryMedia(
+  WidgetRef ref,
+  ModifiablePostEntity? story, {
+  required String sessionPubkey,
+}) {
+  final context = useContext();
+  final hasRegistered = useRef(false);
+  final registeredStoryId = useRef<String?>(null);
+  useOnInit(
+    () {
+      if (story == null) return;
+      final storyId = story.id;
+      final feedRegistry = ref.read(storyFeedPrefetchRegistryProvider(sessionPubkey));
+      if (feedRegistry.contains(storyId)) {
+        return;
+      }
+      ref.read(storyFeedPrefetchRegistryProvider(sessionPubkey).notifier).add(storyId);
+      hasRegistered.value = true;
+      registeredStoryId.value = storyId;
+      unawaited(
+        preloadStoryMedia(
+          ref: ref,
+          context: context,
+          story: story,
+          sessionPubkey: sessionPubkey,
+        ),
+      );
+    },
+    [story?.id, sessionPubkey],
+  );
+
+  useEffect(
+    () {
+      if (story == null) return null;
+      final storyId = story.id;
+      return () {
+        if (!hasRegistered.value || registeredStoryId.value != storyId) {
+          return;
+        }
+        ref.read(storyFeedPrefetchRegistryProvider(sessionPubkey).notifier).remove(storyId);
+        hasRegistered.value = false;
+        registeredStoryId.value = null;
+      };
+    },
+    [story?.id, sessionPubkey],
+  );
+}
+
+Future<void> preloadStoryMedia({
   required WidgetRef ref,
   required BuildContext context,
   required ModifiablePostEntity story,
-  String? sessionPubkey,
-  bool keepAliveForSession = false,
+  required String sessionPubkey,
 }) async {
   final media = story.data.primaryMedia;
   if (media == null) return;
@@ -32,11 +80,10 @@ Future<void> _preloadStoryMedia({
       await cacheManager.getSingleFile(resolvedUrl);
       if (!context.mounted) return;
 
-      final cacheKey = Uri.tryParse(resolvedUrl)?.path ?? resolvedUrl;
       final imageProvider = CachedNetworkImageProvider(
         resolvedUrl,
         cacheManager: cacheManager,
-        cacheKey: cacheKey,
+        cacheKey: resolvedUrl,
       );
 
       await precacheImage(imageProvider, context);
@@ -53,63 +100,14 @@ Future<void> _preloadStoryMedia({
       uniqueId: story.id,
     );
 
-    final session = sessionPubkey;
-
-    if (keepAliveForSession && session != null) {
-      ref.read(
-        storyVideoControllerProvider(
-          StoryVideoControllerParams(
-            storyId: story.id,
-            sessionPubkey: session,
-            baseParams: params,
-          ),
-        ),
-      );
-    } else {
-      ref.read(
-        videoControllerProvider(params),
-      );
-    }
-  }
-}
-
-void usePreloadStoryMedia(
-  WidgetRef ref,
-  ModifiablePostEntity? story, {
-  String? sessionPubkey,
-  bool keepAliveForSession = false,
-}) {
-  final context = useContext();
-
-  useOnInit(
-    () {
-      if (story == null) return;
-      unawaited(
-        _preloadStoryMedia(
-          ref: ref,
-          context: context,
-          story: story,
+    await ref.read(
+      storyVideoControllerProvider(
+        StoryVideoControllerParams(
+          storyId: story.id,
           sessionPubkey: sessionPubkey,
-          keepAliveForSession: keepAliveForSession,
+          baseParams: params,
         ),
-      );
-    },
-    [story?.id, sessionPubkey, keepAliveForSession],
-  );
-}
-
-Future<void> preloadStoryMedia({
-  required WidgetRef ref,
-  required BuildContext context,
-  required ModifiablePostEntity story,
-  String? sessionPubkey,
-  bool keepAliveForSession = false,
-}) {
-  return _preloadStoryMedia(
-    ref: ref,
-    context: context,
-    story: story,
-    sessionPubkey: sessionPubkey,
-    keepAliveForSession: keepAliveForSession,
-  );
+      ).future,
+    );
+  }
 }

--- a/lib/app/features/feed/views/pages/feed_page/components/stories/hooks/use_preload_story_media.dart
+++ b/lib/app/features/feed/views/pages/feed_page/components/stories/hooks/use_preload_story_media.dart
@@ -1,25 +1,57 @@
 // SPDX-License-Identifier: ice License 1.0
 
+import 'dart:async';
+
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/features/core/model/media_type.dart';
+import 'package:ion/app/features/core/providers/ion_connect_media_url_fallback_provider.r.dart';
 import 'package:ion/app/features/core/providers/video_player_provider.r.dart';
 import 'package:ion/app/features/feed/data/models/entities/modifiable_post_data.f.dart';
 import 'package:ion/app/features/feed/stories/providers/story_image_loading_provider.r.dart';
 import 'package:ion/app/hooks/use_on_init.dart';
 
 void usePreloadStoryMedia(WidgetRef ref, ModifiablePostEntity? story) {
+  final context = useContext();
+
   useOnInit(
     () {
       if (story == null) return;
       final media = story.data.primaryMedia;
       if (media == null) return;
       if (media.mediaType == MediaType.image) {
-        // .getSingleFile() downloads a file if it's not cached yet
-        ref.read(storyImageCacheManagerProvider).getSingleFile(media.url);
+        final cacheManager = ref.read(storyImageCacheManagerProvider);
+        final resolvedUrl = ref.read(iONConnectMediaUrlFallbackProvider)[media.url] ?? media.url;
+
+        unawaited(
+          () async {
+            try {
+              // getSingleFile downloads when needed and refreshes the disk cache.
+              await cacheManager.getSingleFile(resolvedUrl);
+              if (!context.mounted) return;
+
+              final cacheKey = Uri.tryParse(resolvedUrl)?.path ?? resolvedUrl;
+              final provider = CachedNetworkImageProvider(
+                resolvedUrl,
+                cacheManager: cacheManager,
+                cacheKey: cacheKey,
+              );
+
+              await precacheImage(provider, context);
+            } catch (_) {
+              // fall back to regular loading path.
+            }
+          }(),
+        );
       } else if (media.mediaType == MediaType.video) {
         ref.read(
           videoControllerProvider(
-            VideoControllerParams(sourcePath: media.url, authorPubkey: story.masterPubkey),
+            VideoControllerParams(
+              sourcePath: media.url,
+              authorPubkey: story.masterPubkey,
+            ),
           ),
         );
       }

--- a/lib/app/features/video/views/pages/video_page.dart
+++ b/lib/app/features/video/views/pages/video_page.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/progress_bar/centered_loading_indicator.dart';
 import 'package:ion/app/extensions/extensions.dart';
-import 'package:ion/app/features/core/providers/video_player_provider.r.dart';
+import 'package:ion/app/features/core/providers/video_player_provider.m.dart';
 import 'package:ion/app/features/ion_connect/model/event_reference.f.dart';
 import 'package:ion/app/features/video/views/components/video_button.dart';
 import 'package:ion/app/features/video/views/components/video_not_found.dart';

--- a/lib/app/features/wallets/views/components/coins_list/coin_item.dart
+++ b/lib/app/features/wallets/views/components/coins_list/coin_item.dart
@@ -36,7 +36,9 @@ class CoinsGroupItem extends HookConsumerWidget {
 
     useEffect(
       () {
-        precachePictures([coinsGroup.iconUrl]).whenComplete(() => isContentReady.value = true);
+        precachePictures(context, [coinsGroup.iconUrl]).whenComplete(
+          () => isContentReady.value = true,
+        );
         return null;
       },
       [coinsGroup.iconUrl],

--- a/lib/app/features/wallets/views/pages/wallet_page.dart
+++ b/lib/app/features/wallets/views/pages/wallet_page.dart
@@ -42,8 +42,8 @@ class WalletPage extends HookConsumerWidget {
         ref.read(networksByTierProvider(tier: 1).future).then((networks) {
           final iconUrls =
               networks.map((network) => network.image).where((url) => url.isNotEmpty).toList();
-          if (iconUrls.isNotEmpty) {
-            precachePictures(iconUrls);
+          if (iconUrls.isNotEmpty && context.mounted) {
+            precachePictures(context, iconUrls);
           }
         });
         return null;

--- a/test/app/features/stories/hooks/use_story_progress_controller_test.dart
+++ b/test/app/features/stories/hooks/use_story_progress_controller_test.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/features/core/model/media_type.dart';
-import 'package:ion/app/features/core/providers/video_player_provider.r.dart';
+import 'package:ion/app/features/core/providers/video_player_provider.m.dart';
 import 'package:ion/app/features/feed/data/models/entities/modifiable_post_data.f.dart';
 import 'package:ion/app/features/feed/stories/hooks/use_story_progress_controller.dart';
 import 'package:ion/app/features/feed/stories/hooks/use_story_video_playback.dart';

--- a/test/app/features/stories/widgets/story_video_tests.dart
+++ b/test/app/features/stories/widgets/story_video_tests.dart
@@ -5,7 +5,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:ion/app/features/core/model/media_type.dart';
-import 'package:ion/app/features/core/providers/video_player_provider.r.dart';
+import 'package:ion/app/features/core/providers/video_player_provider.m.dart';
 import 'package:ion/app/features/feed/stories/providers/feed_stories_provider.r.dart';
 import 'package:ion/app/features/feed/stories/providers/user_stories_provider.r.dart';
 import 'package:ion/app/features/feed/stories/views/pages/story_viewer_page.dart';

--- a/test/app/features/stories/widgets/story_viewer_close_test.dart
+++ b/test/app/features/stories/widgets/story_viewer_close_test.dart
@@ -5,7 +5,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:ion/app/features/core/model/media_type.dart';
-import 'package:ion/app/features/core/providers/video_player_provider.r.dart';
+import 'package:ion/app/features/core/providers/video_player_provider.m.dart';
 import 'package:ion/app/features/feed/stories/providers/user_stories_provider.r.dart';
 import 'package:ion/app/features/feed/stories/views/pages/story_viewer_page.dart';
 import 'package:ion/app/router/providers/go_router_provider.r.dart';

--- a/test/app/features/stories/widgets/story_viewer_page_tests.dart
+++ b/test/app/features/stories/widgets/story_viewer_page_tests.dart
@@ -5,7 +5,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:ion/app/features/core/model/media_type.dart';
-import 'package:ion/app/features/core/providers/video_player_provider.r.dart';
+import 'package:ion/app/features/core/providers/video_player_provider.m.dart';
 import 'package:ion/app/features/feed/stories/providers/story_pause_provider.r.dart';
 import 'package:ion/app/features/feed/stories/providers/user_stories_provider.r.dart';
 import 'package:ion/app/features/feed/stories/views/pages/story_viewer_page.dart';

--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -6,7 +6,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/features/core/providers/env_provider.r.dart';
-import 'package:ion/app/features/core/providers/video_player_provider.r.dart';
+import 'package:ion/app/features/core/providers/video_player_provider.m.dart';
 import 'package:ion/app/features/wallets/model/wallet_view_data.f.dart';
 import 'package:ion/app/features/wallets/providers/selected_wallet_view_id_provider.r.dart';
 import 'package:ion/app/features/wallets/providers/wallet_view_data_provider.r.dart';

--- a/test/robots/stories/video_playback_robot.dart
+++ b/test/robots/stories/video_playback_robot.dart
@@ -3,7 +3,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:ion/app/features/core/providers/video_player_provider.r.dart';
+import 'package:ion/app/features/core/providers/video_player_provider.m.dart';
 import 'package:ion/app/features/feed/data/models/entities/modifiable_post_data.f.dart';
 import 'package:ion/app/features/feed/stories/hooks/use_story_video_playback.dart';
 import 'package:ion/app/features/feed/stories/providers/story_viewing_provider.r.dart';


### PR DESCRIPTION
## Description
This PR:

- Introduces two Riverpod registries: StoryFeedPrefetchRegistry (tracks which story tiles in the horizontal feed stories list have requested media) and StoryVideoPrefetchTargets (tracks the stories inside the viewer). These registries let the app coordinate prefetch work and decide which video controllers must stay alive.
- Wraps the existing videoControllerProvider in a new storyVideoControllerProvider that is keyed by story ID + viewer session. It keeps controllers warm while either registry references them and releases keep-alive links as soon as both drop the story, preventing leaks.
- Reworks usePreloadStoryMedia and the feed StoryListItem so tiles register themselves in the feed registry, skip duplicate fetches by consulting the registry, and asynchronously pre-load both images and videos.
- Updates the story viewer (UserStoryPageView) to keep a ±2 story window preloaded by syncing StoryVideoPrefetchTargets and firing preloadStoryMedia for each neighbor, plus clears the window when leaving; also hardens useStoryVideoPlayback’s listener management to avoid duplicate completion callbacks.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
3897

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
Before:

https://github.com/user-attachments/assets/7b1df3a7-c4f3-41e7-a944-fb2fc7db5004

After:

https://github.com/user-attachments/assets/54218b60-24e1-4bf8-8ba9-f52c1e02a061


