### PR TITLE
fix: multiple reserved nickname warnings

### DIFF
--- a/lib/app/features/user/hooks/use_nickname_availability_error_message.dart
+++ b/lib/app/features/user/hooks/use_nickname_availability_error_message.dart
@@ -9,6 +9,8 @@ import 'package:ion/app/hooks/use_on_init.dart';
 import 'package:ion/app/router/utils/show_simple_bottom_sheet.dart';
 import 'package:ion_identity_client/ion_identity.dart';
 
+bool _reservedWarningShown = false;
+
 ValueNotifier<String?> useNicknameAvailabilityErrorMessage(
   WidgetRef ref,
   ProviderListenable<AsyncValue<Object?>> provider,
@@ -25,7 +27,11 @@ ValueNotifier<String?> useNicknameAvailabilityErrorMessage(
     )
     ..listenError(provider, (error) {
       if (error is NicknameReservedException) {
-        showSimpleBottomSheet<void>(context: ref.context, child: const NicknameReservedModal());
+        if (!_reservedWarningShown) {
+          _reservedWarningShown = true;
+          showSimpleBottomSheet<void>(context: ref.context, child: const NicknameReservedModal())
+              .whenComplete(() => _reservedWarningShown = false);
+        }
       }
     });
 


### PR DESCRIPTION
## Description
This PR prevents showing multiple nickname reserved modals  - automatic on the field nickname entering and on button press response.

## Task ID
ION-3882

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

