### PR TITLE
fix: do not request individual user metadata in the lists

### DIFF
--- a/lib/app/features/components/entities_list/list_entity_helper.dart
+++ b/lib/app/features/components/entities_list/list_entity_helper.dart
@@ -135,7 +135,7 @@ class ListEntityHelper {
 
   static bool hasMetadata(BuildContext context, WidgetRef ref, IonConnectEntity entity) {
     final userMetadata = ref.watch(
-          userMetadataProvider(entity.masterPubkey).select((value) {
+          userMetadataProvider(entity.masterPubkey, network: false).select((value) {
             final entity = value.valueOrNull;
             if (entity != null) {
               ListCachedObjects.updateObject<UserMetadataEntity>(context, entity);

--- a/lib/app/features/ion_connect/providers/entities_paged_data_provider.m.dart
+++ b/lib/app/features/ion_connect/providers/entities_paged_data_provider.m.dart
@@ -85,6 +85,11 @@ final class DataSourceFetchResult {
   const DataSourceFetchResult({
     required this.entry,
     required this.missingEvents,
+    // Tracking the pending inserts to keep the initial order when fetching missing events.
+    // It is currently needed only for the case with the following users where we keep kind0 events in the state
+    // and some kind0 events might be missing so we fetch those manually and then insert to the initial positions.
+    // For other use-cases it is not needed since we store other event kinds and using kind0 only as secondary data.
+    // So missing kind0 do not break the initial order.
     required this.pendingInserts,
   });
 


### PR DESCRIPTION
## Description
This PR changes the way we're using user metadata in the lists. We don't request the events individually - we just wait for them to appear in cache from either `search` ext OR from fetching missing events if relay returns `21750` for the metadata and we fetch those in batches.

## Task ID
ION-3992

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore