### PR TITLE
fix: add local objects cache for all lists to fix scroll up issue

### DIFF
--- a/lib/app/features/components/entities_list/list_entity_helper.dart
+++ b/lib/app/features/components/entities_list/list_entity_helper.dart
@@ -135,6 +135,9 @@ class ListEntityHelper {
 
   static bool hasMetadata(BuildContext context, WidgetRef ref, IonConnectEntity entity) {
     final userMetadata = ref.watch(
+          // We don't request the events individually - we just wait for them to appear in cache
+          // from either search ext OR from fetching missing events if relay returns 21750
+          // for the metadata and we fetch those in batches.
           userMetadataProvider(entity.masterPubkey, network: false).select((value) {
             final entity = value.valueOrNull;
             if (entity != null) {

--- a/lib/app/features/feed/views/components/reply_list/reply_list.dart
+++ b/lib/app/features/feed/views/components/reply_list/reply_list.dart
@@ -9,6 +9,7 @@ import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/components/entities_list/entities_list.dart';
 import 'package:ion/app/features/components/entities_list/entities_list_skeleton.dart';
 import 'package:ion/app/features/components/entities_list/entity_list_item.f.dart';
+import 'package:ion/app/features/components/entities_list/list_cached_entities.dart';
 import 'package:ion/app/features/core/model/paged.f.dart';
 import 'package:ion/app/features/feed/providers/replies_data_source_provider.r.dart';
 import 'package:ion/app/features/feed/providers/replies_provider.r.dart';
@@ -38,39 +39,45 @@ class ReplyList extends ConsumerWidget {
 
     final isLoading = replies?.data is PagedLoading;
 
-    return LoadMoreBuilder(
-      hasMore: hasMoreReplies,
-      onLoadMore: () => ref.read(repliesProvider(eventReference).notifier).loadMore(eventReference),
-      showIndicator: !isLoading,
-      slivers: [
-        if (headers != null) ...headers!,
-        if (entities == null)
-          const EntitiesListSkeleton()
-        else if (entities.isEmpty)
-          const _EmptyState()
-        else
-          EntitiesList(
-            items: entities
-                .map((entity) => IonEntityListItem.event(eventReference: entity.toEventReference()))
-                .toList(),
-            separatorHeight: 1.0.s,
-            onVideoTap: ({
-              required String eventReference,
-              required int initialMediaIndex,
-              String? framedEventReference,
-            }) =>
-                ReplyListVideosRoute(
-              eventReference: eventReference,
-              initialMediaIndex: initialMediaIndex,
-              parentEventReference: this.eventReference.encode(),
-              framedEventReference: framedEventReference,
-            ).push<void>(context),
-          ),
-      ],
-      builder: (context, slivers) => PullToRefreshBuilder(
-        slivers: slivers,
-        onRefresh: () => _onRefresh(ref),
-        builder: (BuildContext context, List<Widget> slivers) => CustomScrollView(slivers: slivers),
+    return ListCachedObjects(
+      child: LoadMoreBuilder(
+        hasMore: hasMoreReplies,
+        onLoadMore: () =>
+            ref.read(repliesProvider(eventReference).notifier).loadMore(eventReference),
+        showIndicator: !isLoading,
+        slivers: [
+          if (headers != null) ...headers!,
+          if (entities == null)
+            const EntitiesListSkeleton()
+          else if (entities.isEmpty)
+            const _EmptyState()
+          else
+            EntitiesList(
+              items: entities
+                  .map(
+                    (entity) => IonEntityListItem.event(eventReference: entity.toEventReference()),
+                  )
+                  .toList(),
+              separatorHeight: 1.0.s,
+              onVideoTap: ({
+                required String eventReference,
+                required int initialMediaIndex,
+                String? framedEventReference,
+              }) =>
+                  ReplyListVideosRoute(
+                eventReference: eventReference,
+                initialMediaIndex: initialMediaIndex,
+                parentEventReference: this.eventReference.encode(),
+                framedEventReference: framedEventReference,
+              ).push<void>(context),
+            ),
+        ],
+        builder: (context, slivers) => PullToRefreshBuilder(
+          slivers: slivers,
+          onRefresh: () => _onRefresh(ref),
+          builder: (BuildContext context, List<Widget> slivers) =>
+              CustomScrollView(slivers: slivers),
+        ),
       ),
     );
   }

--- a/lib/app/features/feed/views/pages/articles_from_author_page/articles_from_author_page.dart
+++ b/lib/app/features/feed/views/pages/articles_from_author_page/articles_from_author_page.dart
@@ -6,6 +6,7 @@ import 'package:ion/app/components/scroll_view/load_more_builder.dart';
 import 'package:ion/app/features/components/entities_list/entities_list.dart';
 import 'package:ion/app/features/components/entities_list/entities_list_skeleton.dart';
 import 'package:ion/app/features/components/entities_list/entity_list_item.f.dart';
+import 'package:ion/app/features/components/entities_list/list_cached_entities.dart';
 import 'package:ion/app/features/feed/providers/user_articles_data_source_provider.r.dart';
 import 'package:ion/app/features/ion_connect/providers/entities_paged_data_provider.m.dart';
 import 'package:ion/app/features/user/providers/user_metadata_provider.r.dart';
@@ -30,21 +31,24 @@ class ArticlesFromAuthorPage extends ConsumerWidget {
       appBar: NavigationAppBar.screen(
         title: Text(userMetadata?.data.displayName ?? ''),
       ),
-      body: LoadMoreBuilder(
-        hasMore: entitiesPagedData?.hasMore ?? false,
-        onLoadMore: ref.read(entitiesPagedDataProvider(dataSource).notifier).fetchEntities,
-        slivers: [
-          if (entities == null)
-            const EntitiesListSkeleton()
-          else
-            EntitiesList(
-              items: entities
-                  .map(
-                    (entity) => IonEntityListItem.event(eventReference: entity.toEventReference()),
-                  )
-                  .toList(),
-            ),
-        ],
+      body: ListCachedObjects(
+        child: LoadMoreBuilder(
+          hasMore: entitiesPagedData?.hasMore ?? false,
+          onLoadMore: ref.read(entitiesPagedDataProvider(dataSource).notifier).fetchEntities,
+          slivers: [
+            if (entities == null)
+              const EntitiesListSkeleton()
+            else
+              EntitiesList(
+                items: entities
+                    .map(
+                      (entity) =>
+                          IonEntityListItem.event(eventReference: entity.toEventReference()),
+                    )
+                    .toList(),
+              ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/app/features/feed/views/pages/articles_from_topic_page/articles_from_topic_page.dart
+++ b/lib/app/features/feed/views/pages/articles_from_topic_page/articles_from_topic_page.dart
@@ -6,6 +6,7 @@ import 'package:ion/app/components/scroll_view/load_more_builder.dart';
 import 'package:ion/app/features/components/entities_list/entities_list.dart';
 import 'package:ion/app/features/components/entities_list/entities_list_skeleton.dart';
 import 'package:ion/app/features/components/entities_list/entity_list_item.f.dart';
+import 'package:ion/app/features/components/entities_list/list_cached_entities.dart';
 import 'package:ion/app/features/feed/data/models/feed_type.dart';
 import 'package:ion/app/features/feed/providers/feed_user_interests_provider.r.dart';
 import 'package:ion/app/features/feed/providers/topic_articles_data_source_provider.r.dart';
@@ -35,21 +36,24 @@ class ArticlesFromTopicPage extends ConsumerWidget {
       appBar: NavigationAppBar.screen(
         title: Text(topicName),
       ),
-      body: LoadMoreBuilder(
-        hasMore: entitiesPagedData?.hasMore ?? false,
-        onLoadMore: ref.read(entitiesPagedDataProvider(dataSource).notifier).fetchEntities,
-        slivers: [
-          if (entities == null)
-            const EntitiesListSkeleton()
-          else
-            EntitiesList(
-              items: entities
-                  .map(
-                    (entity) => IonEntityListItem.event(eventReference: entity.toEventReference()),
-                  )
-                  .toList(),
-            ),
-        ],
+      body: ListCachedObjects(
+        child: LoadMoreBuilder(
+          hasMore: entitiesPagedData?.hasMore ?? false,
+          onLoadMore: ref.read(entitiesPagedDataProvider(dataSource).notifier).fetchEntities,
+          slivers: [
+            if (entities == null)
+              const EntitiesListSkeleton()
+            else
+              EntitiesList(
+                items: entities
+                    .map(
+                      (entity) =>
+                          IonEntityListItem.event(eventReference: entity.toEventReference()),
+                    )
+                    .toList(),
+              ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/app/features/search/views/pages/feed_advanced_search_page/components/feed_advanced_search_posts/feed_advanced_search_posts.dart
+++ b/lib/app/features/search/views/pages/feed_advanced_search_page/components/feed_advanced_search_posts/feed_advanced_search_posts.dart
@@ -10,6 +10,7 @@ import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/components/entities_list/entities_list.dart';
 import 'package:ion/app/features/components/entities_list/entities_list_skeleton.dart';
 import 'package:ion/app/features/components/entities_list/entity_list_item.f.dart';
+import 'package:ion/app/features/components/entities_list/list_cached_entities.dart';
 import 'package:ion/app/features/ion_connect/providers/entities_paged_data_provider.m.dart';
 import 'package:ion/app/features/search/model/advanced_search_category.dart';
 import 'package:ion/app/features/search/providers/feed_search_posts_data_source_provider.r.dart';
@@ -35,36 +36,40 @@ class FeedAdvancedSearchPosts extends HookConsumerWidget {
     final entitiesPagedData = ref.watch(entitiesPagedDataProvider(dataSource));
     final entities = entitiesPagedData?.data.items?.toList();
 
-    return PullToRefreshBuilder(
-      slivers: [
-        if (entities == null)
-          const EntitiesListSkeleton()
-        else if (entities.isEmpty)
-          NothingIsFound(title: context.i18n.search_nothing_found)
-        else
-          EntitiesList(
-            items: entities
-                .map((entity) => IonEntityListItem.event(eventReference: entity.toEventReference()))
-                .toList(),
-            onVideoTap: ({
-              required String eventReference,
-              required int initialMediaIndex,
-              String? framedEventReference,
-            }) =>
-                FeedAdvancedSearchVideosRoute(
-              eventReference: eventReference,
-              initialMediaIndex: initialMediaIndex,
-              framedEventReference: framedEventReference,
-              query: query,
-              category: category,
-            ).push<void>(context),
-          ),
-      ],
-      onRefresh: () async => ref.invalidate(entitiesPagedDataProvider(dataSource)),
-      builder: (context, slivers) => LoadMoreBuilder(
-        slivers: slivers,
-        onLoadMore: ref.read(entitiesPagedDataProvider(dataSource).notifier).fetchEntities,
-        hasMore: entitiesPagedData?.hasMore ?? false,
+    return ListCachedObjects(
+      child: PullToRefreshBuilder(
+        slivers: [
+          if (entities == null)
+            const EntitiesListSkeleton()
+          else if (entities.isEmpty)
+            NothingIsFound(title: context.i18n.search_nothing_found)
+          else
+            EntitiesList(
+              items: entities
+                  .map(
+                    (entity) => IonEntityListItem.event(eventReference: entity.toEventReference()),
+                  )
+                  .toList(),
+              onVideoTap: ({
+                required String eventReference,
+                required int initialMediaIndex,
+                String? framedEventReference,
+              }) =>
+                  FeedAdvancedSearchVideosRoute(
+                eventReference: eventReference,
+                initialMediaIndex: initialMediaIndex,
+                framedEventReference: framedEventReference,
+                query: query,
+                category: category,
+              ).push<void>(context),
+            ),
+        ],
+        onRefresh: () async => ref.invalidate(entitiesPagedDataProvider(dataSource)),
+        builder: (context, slivers) => LoadMoreBuilder(
+          slivers: slivers,
+          onLoadMore: ref.read(entitiesPagedDataProvider(dataSource).notifier).fetchEntities,
+          hasMore: entitiesPagedData?.hasMore ?? false,
+        ),
       ),
     );
   }

--- a/lib/app/features/user/pages/bookmarks_page/bookmarks_page.dart
+++ b/lib/app/features/user/pages/bookmarks_page/bookmarks_page.dart
@@ -9,6 +9,7 @@ import 'package:ion/app/extensions/build_context.dart';
 import 'package:ion/app/features/components/entities_list/entities_list.dart';
 import 'package:ion/app/features/components/entities_list/entities_list_skeleton.dart';
 import 'package:ion/app/features/components/entities_list/entity_list_item.f.dart';
+import 'package:ion/app/features/components/entities_list/list_cached_entities.dart';
 import 'package:ion/app/features/feed/data/models/bookmarks/bookmarks_set.f.dart';
 import 'package:ion/app/features/feed/providers/feed_bookmarks_notifier.r.dart';
 import 'package:ion/app/features/user/pages/bookmarks_page/components/bookmarks_filters.dart';
@@ -61,9 +62,12 @@ class BookmarksPage extends HookConsumerWidget {
                 ];
               } else {
                 return [
-                  EntitiesList(
-                    items: refs.map((ref) => IonEntityListItem.event(eventReference: ref)).toList(),
-                    readFromDB: true,
+                  ListCachedObjects(
+                    child: EntitiesList(
+                      items:
+                          refs.map((ref) => IonEntityListItem.event(eventReference: ref)).toList(),
+                      readFromDB: true,
+                    ),
                   ),
                 ];
               }


### PR DESCRIPTION
## Description
This PR wraps all lists with `ListCachedObjects` to prevent issue on scroll up. Without it it scrolls to the top immediately. 

## Task ID
ION-3995

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Videos
Before:

https://github.com/user-attachments/assets/6be5a264-cbca-4900-ac10-abd149785db2

After:


https://github.com/user-attachments/assets/98ece83e-1662-4212-b360-94bfe1304ffc


