### PR TITLE
chore: change permissions dialog buttons

### DIFF
--- a/lib/app/features/core/permissions/views/components/permission_dialogs/permission_request_sheet.dart
+++ b/lib/app/features/core/permissions/views/components/permission_dialogs/permission_request_sheet.dart
@@ -52,26 +52,10 @@ class PermissionRequestSheet extends ConsumerWidget {
         ),
         SizedBox(height: 32.0.s),
         ScreenSideOffset.small(
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Flexible(
-                child: Button(
-                  type: ButtonType.outlined,
-                  mainAxisSize: MainAxisSize.max,
-                  label: Text(context.i18n.button_dont_allow),
-                  onPressed: () => Navigator.of(context).pop(false),
-                ),
-              ),
-              SizedBox(width: 16.0.s),
-              Flexible(
-                child: Button(
-                  mainAxisSize: MainAxisSize.max,
-                  label: Text(context.i18n.button_continue),
-                  onPressed: () => Navigator.of(context).pop(true),
-                ),
-              ),
-            ],
+          child: Button(
+            mainAxisSize: MainAxisSize.max,
+            label: Text(context.i18n.button_continue),
+            onPressed: () => Navigator.of(context).pop(true),
           ),
         ),
         ScreenBottomOffset(),

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -37,7 +37,6 @@
   "button_schedule": "جدولة",
   "button_go_to_settings": "اذهب إلى الإعدادات",
   "button_allow": "اسمح",
-  "button_dont_allow": "لا تسمح",
   "button_share_story": "مشاركة القصة",
   "button_add_answer": "أضف إجابة",
   "button_link": "رابط",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -37,7 +37,6 @@
   "button_schedule": "Planen",
   "button_go_to_settings": "Zu Einstellungen",
   "button_allow": "Erlauben",
-  "button_dont_allow": "Nicht erlauben",
   "button_share_story": "Story teilen",
   "button_add_answer": "Antwort hinzufügen",
   "button_link": "Link",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -37,7 +37,6 @@
   "button_schedule": "Schedule",
   "button_go_to_settings": "Go to Settings",
   "button_allow": "Allow",
-  "button_dont_allow": "Don't allow",
   "button_share_story": "Share story",
   "button_add_answer": "Add answer",
   "button_link": "Link",


### PR DESCRIPTION
## Description
This PR removes the "Don't allow" button from the permissions dialog

## Task ID
N/A

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [x] Chore

## Screenshots
<img width="280" height="972" alt="image" src="https://github.com/user-attachments/assets/0e996451-d80e-4cdb-b618-c7ae78768dc5" />

