### PR TITLE
fix: remove duplicates in message media stream

### DIFF
--- a/lib/app/features/chat/model/database/dao/message_media_dao.r.dart
+++ b/lib/app/features/chat/model/database/dao/message_media_dao.r.dart
@@ -49,10 +49,8 @@ class MessageMediaDao extends DatabaseAccessor<ChatDatabase> with _$MessageMedia
           ..where((t) => t.messageEventReference.equalsValue(eventReference)))
         .watch()
         .map((items) {
-      // Remove duplicates based on remoteUrl
       final seen = <String?>{};
       return items.where((item) {
-        // Keep nulls (or skip them based on your needs)
         if (item.remoteUrl == null) return true;
         return seen.add(item.remoteUrl);
       }).toList();

--- a/lib/app/features/chat/model/database/dao/message_media_dao.r.dart
+++ b/lib/app/features/chat/model/database/dao/message_media_dao.r.dart
@@ -48,11 +48,11 @@ class MessageMediaDao extends DatabaseAccessor<ChatDatabase> with _$MessageMedia
     return (select(messageMediaTable)
           ..where((t) => t.messageEventReference.equalsValue(eventReference)))
         .watch()
-        .map((items) {
-      final seen = <String?>{};
-      return items.where((item) {
-        if (item.remoteUrl == null) return true;
-        return seen.add(item.remoteUrl);
+        .map((messageMedia) {
+      final mediaUrls = <String?>{};
+      return messageMedia.where((media) {
+        if (media.remoteUrl == null) return true;
+        return mediaUrls.add(media.remoteUrl);
       }).toList();
     });
   }

--- a/lib/app/features/chat/model/database/dao/message_media_dao.r.dart
+++ b/lib/app/features/chat/model/database/dao/message_media_dao.r.dart
@@ -47,7 +47,16 @@ class MessageMediaDao extends DatabaseAccessor<ChatDatabase> with _$MessageMedia
   Stream<List<MessageMediaTableData>> watchByEventId(EventReference eventReference) {
     return (select(messageMediaTable)
           ..where((t) => t.messageEventReference.equalsValue(eventReference)))
-        .watch();
+        .watch()
+        .map((items) {
+      // Remove duplicates based on remoteUrl
+      final seen = <String?>{};
+      return items.where((item) {
+        // Keep nulls (or skip them based on your needs)
+        if (item.remoteUrl == null) return true;
+        return seen.add(item.remoteUrl);
+      }).toList();
+    });
   }
 
   Future<void> updateById(


### PR DESCRIPTION
## Description
Enhance the `watchByEventId` method in `MessageMediaDao` to filter out duplicate entries based on `remoteUrl`, ensuring a cleaner stream of message media data. I could not find the root cause so did this workaround solution.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
3962

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
