### PR TITLE
fix: add 1 event replay to optimistic service watch stream

### DIFF
--- a/lib/app/features/optimistic_ui/core/optimistic_service.dart
+++ b/lib/app/features/optimistic_ui/core/optimistic_service.dart
@@ -13,9 +13,13 @@ class OptimisticService<T extends OptimisticModel> {
 
   final OptimisticOperationManager<T> _manager;
 
-  Stream<T?> watch(String id) => _manager.stream.map(
-        (l) => l.firstWhereOrNull((e) => e.optimisticId == id),
-      );
+  Stream<T?> watch(String id) async* {
+    yield get(id);
+
+    yield* _manager.stream.map(
+      (l) => l.firstWhereOrNull((e) => e.optimisticId == id),
+    );
+  }
 
   T? get(String id) => _manager.snapshot.firstWhereOrNull((e) => e.optimisticId == id);
 


### PR DESCRIPTION
## Description
This PR fixes an issue where UI elements could subscribe to optmistic ui provider after it has emitted some events, causing them to not have most accurate state.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
<!-- Add corresponding task ID here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
