### PR TITLE
fix: integrate user metadata insertion on chat search result item initalization

### DIFF
--- a/lib/app/features/search/views/pages/chat/components/chat_search_results_list_item.dart
+++ b/lib/app/features/search/views/pages/chat/components/chat_search_results_list_item.dart
@@ -10,11 +10,13 @@ import 'package:ion/app/features/chat/providers/user_chat_privacy_provider.r.dar
 import 'package:ion/app/features/chat/views/components/chat_privacy_tooltip.dart';
 import 'package:ion/app/features/search/model/chat_search_result_item.f.dart';
 import 'package:ion/app/features/search/providers/chat_search/chat_search_history_provider.m.dart';
+import 'package:ion/app/features/user_profile/database/dao/user_metadata_dao.m.dart';
+import 'package:ion/app/hooks/use_on_init.dart';
 import 'package:ion/app/router/app_routes.gr.dart';
 import 'package:ion/app/utils/username.dart';
 import 'package:ion/generated/assets.gen.dart';
 
-class ChatSearchResultListItem extends ConsumerWidget {
+class ChatSearchResultListItem extends HookConsumerWidget {
   const ChatSearchResultListItem({
     required this.showLastMessage,
     required this.item,
@@ -26,6 +28,10 @@ class ChatSearchResultListItem extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    useOnInit(() {
+      ref.read(userMetadataDaoProvider).insert(item.userMetadata);
+    });
+
     final userMetadata = item.userMetadata;
     final canSendMessage =
         ref.watch(canSendMessageProvider(userMetadata.masterPubkey)).valueOrNull ?? false;

--- a/lib/app/features/user_profile/database/dao/user_metadata_dao.m.dart
+++ b/lib/app/features/user_profile/database/dao/user_metadata_dao.m.dart
@@ -31,6 +31,11 @@ class UserMetadataDao extends DatabaseAccessor<UserProfileDatabase> with _$UserM
     });
   }
 
+  Future<void> insert(UserMetadataEntity userMetadata) async {
+    final eventMessageDbModel = await userMetadata.toEventMessageDbModel();
+    await into(db.userMetadataTable).insert(eventMessageDbModel, mode: InsertMode.insertOrReplace);
+  }
+
   Future<UserMetadataEntity?> get(String masterPubkey) async {
     final query = select(db.userMetadataTable)
       ..where((user) => user.masterPubkey.equals(masterPubkey))


### PR DESCRIPTION
## Description
<!-- Briefly explain the purpose of this PR and what it accomplishes. -->

## Additional Notes
- Updated `ChatSearchResultListItem` to extend HookConsumerWidget and utilize useOnInit for inserting user metadata into the database upon initialization.
- Added insert method in `UserMetadataDao` to handle user metadata storage.

## Task ID
4001

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)

https://github.com/user-attachments/assets/c4d93a0c-9a04-4710-a918-09fb723f2eb3



