### PR TITLE
fix: remove own story from feed after story deletion

### DIFF
--- a/lib/app/features/feed/stories/providers/current_user_feed_story_provider.r.dart
+++ b/lib/app/features/feed/stories/providers/current_user_feed_story_provider.r.dart
@@ -30,6 +30,7 @@ class CurrentUserFeedStory extends _$CurrentUserFeedStory {
         ?.data
         .items
         ?.whereType<ModifiablePostEntity>()
+        .where((story) => !story.isDeleted)
         .firstOrNull;
   }
 

--- a/lib/app/features/feed/stories/providers/feed_stories_provider.r.dart
+++ b/lib/app/features/feed/stories/providers/feed_stories_provider.r.dart
@@ -34,9 +34,12 @@ class FeedStories extends _$FeedStories with DelegatedPagedNotifier {
         ),
     };
 
-    final userStories = data.items?.whereType<ModifiablePostEntity>();
+    final userStories =
+        data.items?.whereType<ModifiablePostEntity>().where((story) => !story.isDeleted);
+    final filteredCurrentUserStory =
+        currentUserStory != null && !currentUserStory.isDeleted ? currentUserStory : null;
     final stories = {
-      if (currentUserStory != null) currentUserStory,
+      if (filteredCurrentUserStory != null) filteredCurrentUserStory,
       if (userStories != null) ...userStories,
     };
 
@@ -44,7 +47,7 @@ class FeedStories extends _$FeedStories with DelegatedPagedNotifier {
       items: stories,
       hasMore: data.hasMore,
       // Approx number of items needed to fill the viewport
-      ready: stories.length >= (currentUserStory != null ? 5 : 4) || !data.isLoading
+      ready: stories.length >= (filteredCurrentUserStory != null ? 5 : 4) || !data.isLoading
     );
   }
 

--- a/lib/app/features/feed/views/pages/feed_page/components/stories/components/current_user_story_list_item.dart
+++ b/lib/app/features/feed/views/pages/feed_page/components/stories/components/current_user_story_list_item.dart
@@ -20,9 +20,9 @@ class CurrentUserStoryListItem extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final currentUserMetadata = ref.watch(currentUserMetadataProvider);
     final userStory = ref.watch(currentUserFeedStoryProvider);
-    final storyReference = userStory?.toEventReference();
-
-    final hasStories = userStory != null;
+    final activeStory = userStory != null && !userStory.isDeleted ? userStory : null;
+    final hasStories = activeStory != null;
+    final storyReference = activeStory?.toEventReference();
 
     final isViewed = ref.watch(
       viewedStoriesProvider

--- a/test/fixtures/posts/post_fixtures.dart
+++ b/test/fixtures/posts/post_fixtures.dart
@@ -51,6 +51,7 @@ ModifiablePostEntity buildPost(
       expiration != null ? EntityExpiration(value: expiration.microsecondsSinceEpoch) : null,
     ),
   );
+  when(() => post.isDeleted).thenReturn(false);
   when(post.toEventReference).thenReturn(FakeEventReference());
   return post;
 }


### PR DESCRIPTION
## Description
This PR fixes an issue where after own story deletion, it was still visible on stories list on feed and was clickable.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
4000

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
