### PR TITLE
feat: fetch chat user metadata from write relay 

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 77;
 	objects = {
 
 /* Begin PBXBuildFile section */

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 77;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */

--- a/lib/app/features/ion_connect/providers/ion_connect_entity_provider.r.dart
+++ b/lib/app/features/ion_connect/providers/ion_connect_entity_provider.r.dart
@@ -160,10 +160,13 @@ class IonConnectNetworkEntitiesManager extends _$IonConnectNetworkEntitiesManage
     required ActionSource actionSource,
     required List<EventReference> eventReferences,
     String? search,
+    ActionType? actionType,
   }) async* {
     if (eventReferences.isEmpty) {
       yield* const Stream.empty();
     }
+
+    final aType = actionType ?? ActionType.read;
 
     final immutableRefs = eventReferences.whereType<ImmutableEventReference>().toList();
     final replaceableRefs = eventReferences.whereType<ReplaceableEventReference>().toList();
@@ -181,6 +184,7 @@ class IonConnectNetworkEntitiesManager extends _$IonConnectNetworkEntitiesManage
 
     final entityStream = ref.read(ionConnectNotifierProvider.notifier).requestEntities(
           requestMessage,
+          actionType: aType,
           actionSource: actionSource,
         );
 
@@ -314,6 +318,8 @@ class IonConnectEntitiesManager extends _$IonConnectEntitiesManager {
     String? search,
     bool cache = true,
     bool network = true,
+    ActionType? actionType,
+    ActionSource? actionSource,
     Duration? expirationDuration,
   }) async {
     final remainingEvents = eventReferences.toSet();
@@ -356,11 +362,13 @@ class IonConnectEntitiesManager extends _$IonConnectEntitiesManager {
           .read(ionConnectNetworkEntitiesManagerProvider.notifier)
           .fetch(
             search: search,
+            actionType: actionType,
             eventReferences: notCachedEvents,
-            actionSource: ActionSource.optimalRelays(
-              strategy: OptimalRelaysStrategy.mostUsers,
-              masterPubkeys: notCachedEvents.map((e) => e.masterPubkey).toSet().toList(),
-            ),
+            actionSource: actionSource ??
+                ActionSource.optimalRelays(
+                  strategy: OptimalRelaysStrategy.mostUsers,
+                  masterPubkeys: notCachedEvents.map((e) => e.masterPubkey).toSet().toList(),
+                ),
           )
           .handleError((Object e, StackTrace stack) {
         Logger.log(

--- a/lib/app/features/user_profile/providers/user_profile_sync_provider.r.dart
+++ b/lib/app/features/user_profile/providers/user_profile_sync_provider.r.dart
@@ -7,9 +7,11 @@ import 'package:ion/app/exceptions/exceptions.dart';
 import 'package:ion/app/features/auth/providers/auth_provider.m.dart';
 import 'package:ion/app/features/auth/providers/delegation_complete_provider.r.dart';
 import 'package:ion/app/features/core/providers/env_provider.r.dart';
+import 'package:ion/app/features/ion_connect/model/action_source.f.dart';
 import 'package:ion/app/features/ion_connect/model/event_reference.f.dart';
 import 'package:ion/app/features/ion_connect/model/search_extension.dart';
 import 'package:ion/app/features/ion_connect/providers/ion_connect_entity_provider.r.dart';
+import 'package:ion/app/features/ion_connect/providers/relays/relay_picker_provider.r.dart';
 import 'package:ion/app/features/user/model/badges/badge_award.f.dart';
 import 'package:ion/app/features/user/model/badges/badge_definition.f.dart';
 import 'package:ion/app/features/user/model/badges/profile_badges.f.dart';
@@ -72,22 +74,25 @@ class UserProfileSync extends _$UserProfileSync {
     }
   }
 
-  Future<void> _fetchUsersProfiles(
-    Ref ref, {
-    required Set<String> masterPubkeysToSync,
-  }) async {
+  Future<void> _fetchUsersProfiles(Ref ref, {required Set<String> masterPubkeysToSync}) async {
+    if (masterPubkeysToSync.isEmpty) return;
+
     final userBadgesDao = ref.read(userBadgeInfoDaoProvider);
     final userMetadataDao = ref.read(userMetadataDaoProvider);
     final userDelegationDao = ref.read(userDelegationDaoProvider);
 
-    if (masterPubkeysToSync.isEmpty) return;
+    // Helper to extract entities by type
+    List<T> extractEntities<T>(List<dynamic> entities) => entities.whereType<T>().toList();
 
-    final usersProfileEntities = await ref.read(ionConnectEntitiesManagerProvider.notifier).fetch(
+    // Fetch from read relays
+    final entitiesFromReadRelay = await ref.read(ionConnectEntitiesManagerProvider.notifier).fetch(
           cache: false,
           eventReferences: masterPubkeysToSync
               .map(
-                (pubkey) =>
-                    ReplaceableEventReference(masterPubkey: pubkey, kind: UserMetadataEntity.kind),
+                (pubkey) => ReplaceableEventReference(
+                  masterPubkey: pubkey,
+                  kind: UserMetadataEntity.kind,
+                ),
               )
               .toList(),
           search: SearchExtensions([
@@ -99,16 +104,56 @@ class UserProfileSync extends _$UserProfileSync {
           ]).toString(),
         );
 
-    final usersMetadata = usersProfileEntities.whereType<UserMetadataEntity>().toList();
-    final usersDelegation = usersProfileEntities.whereType<UserDelegationEntity>().toList();
-    final profileBadges = usersProfileEntities.whereType<ProfileBadgesEntity>().toList();
-    final badgeDefinitions = usersProfileEntities.whereType<BadgeDefinitionEntity>().toList();
-    final badgeAwards = usersProfileEntities.whereType<BadgeAwardEntity>().toList();
+    // Insert all fetched entities
+    await userMetadataDao.insertAll(extractEntities<UserMetadataEntity>(entitiesFromReadRelay));
+    await userDelegationDao.insertAll(extractEntities<UserDelegationEntity>(entitiesFromReadRelay));
+    await userBadgesDao
+        .insertAllProfileBadges(extractEntities<ProfileBadgesEntity>(entitiesFromReadRelay));
+    await userBadgesDao
+        .insertAllBadgeDefinitions(extractEntities<BadgeDefinitionEntity>(entitiesFromReadRelay));
+    await userBadgesDao
+        .insertAllBadgeAwards(extractEntities<BadgeAwardEntity>(entitiesFromReadRelay));
 
-    await userMetadataDao.insertAll(usersMetadata);
-    await userDelegationDao.insertAll(usersDelegation);
-    await userBadgesDao.insertAllProfileBadges(profileBadges);
-    await userBadgesDao.insertAllBadgeDefinitions(badgeDefinitions);
-    await userBadgesDao.insertAllBadgeAwards(badgeAwards);
+    // Find missing master pubkeys
+    final fetchedMasterPubkeys = extractEntities<UserMetadataEntity>(entitiesFromReadRelay)
+        .map((e) => e.masterPubkey)
+        .toSet();
+    final missingMasterPubkeys = masterPubkeysToSync.difference(fetchedMasterPubkeys);
+
+    // Try to fetch missing entities from write relays
+    for (final missingPubkey in missingMasterPubkeys) {
+      final entitiesFromWriteRelay =
+          await ref.read(ionConnectEntitiesManagerProvider.notifier).fetch(
+                cache: false,
+                actionType: ActionType.write,
+                actionSource: ActionSource.user(missingPubkey),
+                eventReferences: [
+                  ReplaceableEventReference(
+                    masterPubkey: missingPubkey,
+                    kind: UserMetadataEntity.kind,
+                  ),
+                ],
+                search: SearchExtensions([
+                  GenericIncludeSearchExtension(
+                    forKind: UserMetadataEntity.kind,
+                    includeKind: UserDelegationEntity.kind,
+                  ),
+                  ProfileBadgesSearchExtension(forKind: UserMetadataEntity.kind),
+                ]).toString(),
+              );
+
+      if (entitiesFromWriteRelay.isNotEmpty) {
+        await userMetadataDao
+            .insertAll(extractEntities<UserMetadataEntity>(entitiesFromWriteRelay));
+        await userDelegationDao
+            .insertAll(extractEntities<UserDelegationEntity>(entitiesFromWriteRelay));
+        await userBadgesDao
+            .insertAllProfileBadges(extractEntities<ProfileBadgesEntity>(entitiesFromWriteRelay));
+        await userBadgesDao.insertAllBadgeDefinitions(
+            extractEntities<BadgeDefinitionEntity>(entitiesFromWriteRelay));
+        await userBadgesDao
+            .insertAllBadgeAwards(extractEntities<BadgeAwardEntity>(entitiesFromWriteRelay));
+      }
+    }
   }
 }

--- a/lib/app/features/user_profile/providers/user_profile_sync_provider.r.dart
+++ b/lib/app/features/user_profile/providers/user_profile_sync_provider.r.dart
@@ -150,7 +150,8 @@ class UserProfileSync extends _$UserProfileSync {
         await userBadgesDao
             .insertAllProfileBadges(extractEntities<ProfileBadgesEntity>(entitiesFromWriteRelay));
         await userBadgesDao.insertAllBadgeDefinitions(
-            extractEntities<BadgeDefinitionEntity>(entitiesFromWriteRelay));
+          extractEntities<BadgeDefinitionEntity>(entitiesFromWriteRelay),
+        );
         await userBadgesDao
             .insertAllBadgeAwards(extractEntities<BadgeAwardEntity>(entitiesFromWriteRelay));
       }


### PR DESCRIPTION
## Description
When we load chat users metadata in bulk from most optimal relays some metadata can be missing, so additionally we will try to load it from write relay of each user individually

## Type of Change
- [x] Bug fix