### PR TITLE
fix: reposts counter

### DIFF
--- a/lib/app/features/feed/reposts/providers/optimistic/post_repost_provider.r.dart
+++ b/lib/app/features/feed/reposts/providers/optimistic/post_repost_provider.r.dart
@@ -123,9 +123,8 @@ OptimisticService<PostRepost> postRepostService(Ref ref) {
   keepAliveWhenAuthenticated(ref);
 
   final manager = ref.watch(postRepostManagerProvider);
-  final postReposts = ref.watch(loadRepostsFromCacheProvider);
-
-  final service = OptimisticService<PostRepost>(manager: manager)..initialize(postReposts);
+  // optimistic state items are added only though dispatch and removed by the service itself
+  final service = OptimisticService<PostRepost>(manager: manager);
 
   return service;
 }
@@ -167,6 +166,7 @@ OptimisticOperationManager<PostRepost> postRepostManager(Ref ref) {
       return true;
     },
     enableLocal: localEnabled,
+    clearOnSuccessfulSync: true,
   );
 
   ref.onDispose(manager.dispose);


### PR DESCRIPTION
## Description
Reposts by current user appear with 1 reposts counter

## Additional Notes
Wrong data came from optimistic state. Which was uses as a cache, always initialised and had higher priority then cache.
Optimistic state should be temporary short living till successful sync.  Cache should be the primary source of repost data, not optimistic state. 
Also the tests are updated accordingly 

## Task ID
ION-4004

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
