### PR TITLE
fix: refactor in-app notification layout to insure that media never overlaps with other content

### DIFF
--- a/lib/app/features/feed/notifications/views/notifications_history_page/components/notification_item/notification_item.dart
+++ b/lib/app/features/feed/notifications/views/notifications_history_page/components/notification_item/notification_item.dart
@@ -68,19 +68,19 @@ class NotificationItem extends HookConsumerWidget {
       behavior: HitTestBehavior.opaque,
       child: Column(
         children: [
+          SizedBox(height: 16.0.s),
+          ScreenSideOffset.small(
+            child: NotificationIcons(notification: notification),
+          ),
+          SizedBox(height: 8.0.s),
           Row(
-            crossAxisAlignment: CrossAxisAlignment.end,
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Expanded(
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    SizedBox(height: 16.0.s),
-                    ScreenSideOffset.small(
-                      child: NotificationIcons(notification: notification),
-                    ),
-                    SizedBox(height: 8.0.s),
                     ScreenSideOffset.small(
                       child: NotificationInfo(
                         notification: notification,
@@ -90,12 +90,7 @@ class NotificationItem extends HookConsumerWidget {
                       Padding(
                         padding: EdgeInsetsGeometry.only(top: 6.s),
                         child: ScreenSideOffset.small(
-                          child: ConstrainedBox(
-                            constraints: BoxConstraints(
-                              minHeight: 18.s,
-                            ),
-                            child: NotificationContent(entity: entity),
-                          ),
+                          child: NotificationContent(entity: entity),
                         ),
                       ),
                   ],


### PR DESCRIPTION

## Description
Refactor in-app notification layout 

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
ION-4025

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<img width="1170" height="2532" alt="IMG_0908" src="https://github.com/user-attachments/assets/8cd5a84e-04c4-4fb2-b556-83851b97c55d" />
>

