### PR TITLE
fix: default cache strategy for database

### DIFF
--- a/lib/app/features/ion_connect/providers/ion_connect_database_cache_notifier.r.dart
+++ b/lib/app/features/ion_connect/providers/ion_connect_database_cache_notifier.r.dart
@@ -82,7 +82,7 @@ class IonConnectDatabaseCache extends _$IonConnectDatabaseCache {
     List<int> kinds = const [],
     List<String> cacheKeys = const [],
     Duration? expirationDuration,
-    DatabaseCacheStrategy cacheStrategy = DatabaseCacheStrategy.alwaysReturn,
+    DatabaseCacheStrategy cacheStrategy = DatabaseCacheStrategy.returnIfNotExpired,
   }) async {
     final parser = ref.read(eventParserProvider);
     final cacheService = await ref.read(ionConnectPersistentCacheServiceProvider.future);


### PR DESCRIPTION
## Description
In-memory cache and database cache should follow same login when saving & returning values

## Task ID
ION-3996

## Type of Change
- [x] Bug fix

