### PR TITLE
fix: networks order on the manage nfts page

### DIFF
--- a/lib/app/features/wallets/views/pages/manage_nfts/components/manage_nft_item.dart
+++ b/lib/app/features/wallets/views/pages/manage_nfts/components/manage_nft_item.dart
@@ -6,36 +6,35 @@ import 'package:ion/app/components/icons/network_icon_widget.dart';
 import 'package:ion/app/components/icons/wallet_item_icon_type.dart';
 import 'package:ion/app/components/list_item/list_item.dart';
 import 'package:ion/app/extensions/extensions.dart';
-import 'package:ion/app/features/wallets/providers/networks_provider.r.dart';
+import 'package:ion/app/features/wallets/model/network_data.f.dart';
 import 'package:ion/app/features/wallets/views/pages/wallet_page/view_models/nft_networks_view_model.dart';
 import 'package:ion/generated/assets.gen.dart';
 
 class ManageNftNetworkItem extends ConsumerWidget {
   const ManageNftNetworkItem({required this.network, super.key});
 
-  final String network;
+  final NetworkData network;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final viewModel = ref.watch(nftNetworksViewModelProvider);
-    final networkData = ref.watch(networkByIdProvider(network)).valueOrNull;
 
     return ValueListenableBuilder(
       valueListenable: viewModel.selectedNetworkIds,
       builder: (context, selectedNetworkIds, _) {
-        final isSelected = selectedNetworkIds.contains(network);
+        final isSelected = selectedNetworkIds.contains(network.id);
 
         return ListItem(
-          title: Text(networkData?.displayName ?? ''),
+          title: Text(network.displayName),
           backgroundColor: context.theme.appColors.tertiaryBackground,
           leading: NetworkIconWidget(
             type: WalletItemIconType.big(),
-            imageUrl: networkData?.image ?? '',
+            imageUrl: network.image,
           ),
           trailing: isSelected
               ? Assets.svg.iconBlockCheckboxOn.icon()
               : Assets.svg.iconBlockCheckboxOff.icon(),
-          onTap: () => viewModel.toggleNetwork(network),
+          onTap: () => viewModel.toggleNetwork(network.id),
         );
       },
     );

--- a/test/app/features/feed/reposts/providers/load_initial_reposts_merge_test.dart
+++ b/test/app/features/feed/reposts/providers/load_initial_reposts_merge_test.dart
@@ -230,7 +230,7 @@ void main() {
       // Service starts empty - no initial state
       final initialManager = container.read(postRepostManagerProvider);
       expect(initialManager.snapshot.length, 0); // Manager should be empty
-      
+
       // postRepostWatch should return AsyncValue.data(null) when there's no optimistic state
       final initialState = container.read(postRepostWatchProvider(postRef1.toString()));
       expect(initialState.hasValue, isTrue); // Should have completed


### PR DESCRIPTION
## Description
1. Sort networks in the view model.
2. Change a bit the networks managing in the view model to avoid reloading network icons from the database.

## Task ID
ION-3993

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<img width="200" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-30 at 11 22 26" src="https://github.com/user-attachments/assets/7fcd8703-b3f6-46e3-ab7c-921a9cbf5121" />

