### PR TITLE
fix: refactor useHideOnTabChange to streamline tabPressStream init

### DIFF
--- a/lib/app/components/overlay_menu/hooks/use_hide_on_tab_change.dart
+++ b/lib/app/components/overlay_menu/hooks/use_hide_on_tab_change.dart
@@ -8,10 +8,10 @@ void useHideOnTabChange(
   BuildContext context,
   OverlayPortalController overlayPortalController,
 ) {
+  final tabPressStream = MainTabNavigationContainer.of(context).tabPressStream;
+
   useEffect(
     () {
-      final tabPressStream = MainTabNavigationContainer.of(context).tabPressStream;
-
       final listener = tabPressStream.listen((tabPressData) {
         if (!overlayPortalController.isShowing) return;
 


### PR DESCRIPTION
## Description
- Fix 'Cannot listen to inherited widgets inside HookState.initState'

## Task ID
NA

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
NA