### PR TITLE
fix: remove cancel button border on money request in chat

### DIFF
--- a/lib/app/features/chat/views/components/message_items/message_types/money_message/components/money_message_button.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/money_message/components/money_message_button.dart
@@ -83,6 +83,9 @@ class _CancelMoneyRequestButton extends ConsumerWidget {
       child: Button.compact(
         type: ButtonType.outlined,
         backgroundColor: context.theme.appColors.tertiaryBackground,
+        style: ButtonStyle(
+          side: WidgetStateProperty.all(BorderSide.none),
+        ),
         minimumSize: RequestedMoneyMessageButton._defaultMinimumSize,
         disabled: isDisabled,
         label: isLoading


### PR DESCRIPTION
## Description
Removing the border for the money request cancel button

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
ION-4026

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)

<img width="1170" height="2532" alt="IMG_0910" src="https://github.com/user-attachments/assets/6bca00e2-8707-4005-a1ac-4dc23e409d97" />
![IMG_0911](https://github.com/user-attachments/assets/8c636ff2-1000-467a-935e-52d6069a8fd9)
<img width="1170" height="2532" alt="IMG_0910" src="https://github.com/user-attachments/assets/ee81af4b-4cc0-4506-a2a6-87b25b403b74" />


