### PR TITLE
refactor: remove extra bottom offset, add comments

### DIFF
--- a/lib/app/features/chat/views/pages/chat_media_page/components/chat_media_page_view.dart
+++ b/lib/app/features/chat/views/pages/chat_media_page/components/chat_media_page_view.dart
@@ -142,7 +142,6 @@ class _ChatMediaItem extends HookConsumerWidget {
             authorPubkey: entity.masterPubkey,
             blurhash: media.blurhash,
             aspectRatio: media.aspectRatio,
-            videoBottomPadding: 0,
             hideBottomOverlay: true,
             playerController: playerController,
           ),


### PR DESCRIPTION
## Description
This PR removes the extra bottom offset, refactor the `video_page`

## Task ID
ION-4024

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots

# Tall aspect ratio video (feed view -> chat view)

<img width="280" height="972" alt="image" src="https://github.com/user-attachments/assets/3da7e428-bc3c-470c-af72-220e5f655e2f" />
<img width="280" height="972" alt="image" src="https://github.com/user-attachments/assets/ad83b0fc-b710-47bd-9465-876804096688" />

# Wide aspect ratio video (feed view -> chat view)

<img width="280" height="972" alt="image" src="https://github.com/user-attachments/assets/90247603-446a-4981-b4f7-20f56c33b4b9" />
<img width="280" height="972" alt="image" src="https://github.com/user-attachments/assets/bcbb37d1-7d09-43a5-8057-8c8e1fb4cd9c" />

# No bottom notch (iOS -> Android)

<img width="280" height="972" alt="image" src="https://github.com/user-attachments/assets/499cef1e-c838-4853-8d19-c99a0f34b407" />
<img width="280" height="972" alt="image" src="https://github.com/user-attachments/assets/580c17f8-90ac-44b8-9a00-fef7cf757a61" />
