### PR TITLE
fix(chat): restore context menu on full-screen media preview

### DIFF
--- a/lib/app/components/overlay_menu/hooks/use_hide_on_tab_change.dart
+++ b/lib/app/components/overlay_menu/hooks/use_hide_on_tab_change.dart
@@ -10,9 +10,9 @@ void useHideOnTabChange(
   BuildContext context,
   OverlayPortalController overlayPortalController,
 ) {
-  // Use useMemoized to get the container in build, not in initState
-  final container = useMemoized(() => MainTabNavigationContainer.maybeOf(context), [context]);
-  final tabPressStream = container?.tabPressStream;
+  final mainTabNavigationContainer =
+      useMemoized(() => MainTabNavigationContainer.maybeOf(context), [context]);
+  final tabPressStream = mainTabNavigationContainer?.tabPressStream;
 
   useEffect(
     () {

--- a/lib/app/components/overlay_menu/hooks/use_hide_on_tab_change.dart
+++ b/lib/app/components/overlay_menu/hooks/use_hide_on_tab_change.dart
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: ice License 1.0
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:ion/app/router/main_tabs/components/main_tab_navigation_container.dart';
@@ -8,20 +10,27 @@ void useHideOnTabChange(
   BuildContext context,
   OverlayPortalController overlayPortalController,
 ) {
-  final tabPressStream = MainTabNavigationContainer.of(context).tabPressStream;
+  // Use useMemoized to get the container in build, not in initState
+  final container = useMemoized(() => MainTabNavigationContainer.maybeOf(context), [context]);
+  final tabPressStream = container?.tabPressStream;
 
   useEffect(
     () {
-      final listener = tabPressStream.listen((tabPressData) {
-        if (!overlayPortalController.isShowing) return;
+      StreamSubscription<TabPressSteamData>? listener;
+      if (tabPressStream != null) {
+        listener = tabPressStream.listen((tabPressData) {
+          if (overlayPortalController.isShowing && context.mounted) {
+            overlayPortalController.hide();
+          }
+        });
+      }
 
-        if (context.mounted && overlayPortalController.isShowing) {
-          overlayPortalController.hide();
+      return () async {
+        if (listener != null) {
+          await listener.cancel();
         }
-      });
-
-      return listener.cancel;
+      };
     },
-    [overlayPortalController],
+    [overlayPortalController, tabPressStream, context],
   );
 }

--- a/lib/app/router/main_tabs/components/main_tab_navigation_container.dart
+++ b/lib/app/router/main_tabs/components/main_tab_navigation_container.dart
@@ -22,6 +22,10 @@ class MainTabNavigationContainer extends InheritedWidget {
     return result!;
   }
 
+  static MainTabNavigationContainer? maybeOf(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<MainTabNavigationContainer>();
+  }
+
   @override
   bool updateShouldNotify(MainTabNavigationContainer oldWidget) =>
       oldWidget.tabPressStream != tabPressStream;


### PR DESCRIPTION
## Description
The context menu on the full-screen chat media preview page was not showing.  
This PR restores the context menu so users can access actions (e.g., save, share, delete) as expected.  

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
4039

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<img width="380" height="2796" alt="Simulator Screenshot - iPhone 16 Plus - 2025-10-01 at 11 26 27" src="https://github.com/user-attachments/assets/1d36db9b-3002-4bcf-a146-a5038f982d24" />

<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
