### PR TITLE
feat: add Sentry.logException method, apply to unsubscribe exceptions

### DIFF
--- a/lib/app/features/ion_connect/providers/ion_connect_subscription_provider.r.dart
+++ b/lib/app/features/ion_connect/providers/ion_connect_subscription_provider.r.dart
@@ -6,6 +6,7 @@ import 'package:ion/app/features/ion_connect/ion_connect.dart';
 import 'package:ion/app/features/ion_connect/model/action_source.f.dart';
 import 'package:ion/app/features/ion_connect/providers/ion_connect_notifier.r.dart';
 import 'package:ion/app/services/logger/logger.dart';
+import 'package:ion/app/services/sentry/sentry_service.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'ion_connect_subscription_provider.r.g.dart';
@@ -24,8 +25,13 @@ Raw<Stream<EventMessage>> ionConnectEventsSubscription(
       final subscription = relay.subscribe(requestMessage);
       try {
         ref.onDispose(() => relay.unsubscribe(subscription.id));
-      } on Exception catch (ex) {
-        Logger.error('Caught error during unsubscribing from relay: $ex');
+      } catch (error, stackTrace) {
+        SentryService.logException(error, stackTrace: stackTrace, tag: 'ion_connect_subscription');
+        Logger.error(
+          error,
+          stackTrace: stackTrace,
+          message: 'Caught error during unsubscribing from relay',
+        );
       }
       return subscription.messages;
     },

--- a/lib/app/services/sentry/sentry_service.dart
+++ b/lib/app/services/sentry/sentry_service.dart
@@ -27,4 +27,30 @@ mixin SentryService {
       appRunner: appRunner,
     );
   }
+
+  /// Manually log an exception to Sentry
+  ///
+  /// [exception] - The exception to log
+  /// [stackTrace] - Optional stack trace for the exception
+  /// [level] - Optional severity level (defaults to SentryLevel.error)
+  /// [tag] - Optional tag to categorize the exception
+  static Future<SentryId> logException(
+    dynamic exception, {
+    StackTrace? stackTrace,
+    SentryLevel? level,
+    String? tag,
+  }) async {
+    return Sentry.captureException(
+      exception,
+      stackTrace: stackTrace,
+      withScope: (scope) {
+        if (level != null) {
+          scope.level = level;
+        }
+        if (tag != null) {
+          scope.setTag('manual_log', tag);
+        }
+      },
+    );
+  }
 }


### PR DESCRIPTION
## Description
This PR introduces a method to log exceptions to sentry manually.
And logs an exception that might happen during the global subscription unsubscribe. If something happens and we keep the subscription then it might explain why the OS kills the app in background.

## Task ID
N/A

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [x] Chore
