### PR TITLE
build(android): add tensorflow gradle dependency

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -138,5 +138,6 @@ dependencies {
     implementation "com.banuba.sdk:ve-audio-browser-sdk:${banubaSdkVersion}"
     implementation "com.banuba.sdk:ve-export-sdk:${banubaSdkVersion}"
     implementation "com.banuba.sdk:ve-playback-sdk:${banubaSdkVersion}"
+    implementation "org.tensorflow:tensorflow-lite-gpu-api:2.12.0"
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.4'
 }


### PR DESCRIPTION
## Description
This PR fixes build on android that requires `tensorflow-lite-gpu-api` used by [tflite_flutter](https://pub.dev/packages/tflite_flutter)

## Task ID
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
