### PR TITLE
fix: android biometrics crash

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -332,8 +332,9 @@ PODS:
   - OrderedSet (6.0.3)
   - package_info_plus (0.4.5):
     - Flutter
-  - passkeys_ios (0.0.1):
+  - passkeys_darwin (0.0.1):
     - Flutter
+    - FlutterMacOS
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -468,7 +469,7 @@ DEPENDENCIES:
   - local_auth_crypto (from `.symlinks/plugins/local_auth_crypto/ios`)
   - local_auth_darwin (from `.symlinks/plugins/local_auth_darwin/darwin`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
-  - passkeys_ios (from `.symlinks/plugins/passkeys_ios/ios`)
+  - passkeys_darwin (from `.symlinks/plugins/passkeys_darwin/darwin`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - photo_manager (from `.symlinks/plugins/photo_manager/ios`)
@@ -603,8 +604,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/local_auth_darwin/darwin"
   package_info_plus:
     :path: ".symlinks/plugins/package_info_plus/ios"
-  passkeys_ios:
-    :path: ".symlinks/plugins/passkeys_ios/ios"
+  passkeys_darwin:
+    :path: ".symlinks/plugins/passkeys_darwin/darwin"
   path_provider_foundation:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
   permission_handler_apple:
@@ -712,7 +713,7 @@ SPEC CHECKSUMS:
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   OrderedSet: e539b66b644ff081c73a262d24ad552a69be3a94
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
-  passkeys_ios: 939d7d44f825048c8dffd4644f52444164c80ecd
+  passkeys_darwin: 0a09d3b26cea8de1ec3bb8f8c7c159981f63bbc7
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
   permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
   photo_manager: 1d80ae07a89a67dfbcae95953a1e5a24af7c3e62

--- a/lib/app/features/components/biometrics/hooks/use_on_suggest_biometrics.dart
+++ b/lib/app/features/components/biometrics/hooks/use_on_suggest_biometrics.dart
@@ -26,7 +26,7 @@ Future<void> Function({required String username, required String password})
         // local_auth_crypto.authenticate then. So we should not even suggest to add biometrics
         // in this case.
         if (!Platform.isAndroid ||
-            await ref.read(isBiometricsAvailableProvider.future) && context.mounted) {
+            await ref.read(biometricsServiceProvider).isBiometricsAvailable() && context.mounted) {
           // Show suggest to add biometrics popup
           await showSimpleBottomSheet<void>(
             context: context,

--- a/lib/app/features/components/biometrics/hooks/use_on_suggest_biometrics.dart
+++ b/lib/app/features/components/biometrics/hooks/use_on_suggest_biometrics.dart
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: ice License 1.0
 
+import 'dart:io';
+
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/features/components/biometrics/suggest_to_add_biometrics_popup.dart';
@@ -17,14 +19,31 @@ Future<void> Function({required String username, required String password})
     }) async {
       final userBiometricsState =
           await ref.read(userBiometricsStateProvider(username: username).future);
+
       if (userBiometricsState == BiometricsState.canSuggest && context.mounted) {
-        await showSimpleBottomSheet<void>(
-          context: context,
-          child: SuggestToAddBiometricsPopup(
-            username: username,
-            password: password,
-          ),
-        );
+
+        // Additional check on Android, because local_auth.authorize() allows to authenticate 
+        // even if biometrics are not set up on the device and it leads to native crush in 
+        // local_auth_crypto.authenticate then. So we should not even suggest to add biometrics
+        // in this case. 
+        if (!Platform.isAndroid ||
+            await const BiometricsService().isBiometricsAvailable() && context.mounted) {
+
+          // Show suggest to add biometrics popup
+          await showSimpleBottomSheet<void>(
+            context: context,
+            child: SuggestToAddBiometricsPopup(
+              username: username,
+              password: password,
+            ),
+          );
+        } else {
+
+          // If biometrics are not available on Android then we should reject to use biometrics
+          await ref
+              .read(rejectToUseBiometricsNotifierProvider.notifier)
+              .rejectToUseBiometrics(username: username, password: password);
+        }
       }
     },
     [context],

--- a/lib/app/features/components/biometrics/hooks/use_on_suggest_biometrics.dart
+++ b/lib/app/features/components/biometrics/hooks/use_on_suggest_biometrics.dart
@@ -21,14 +21,12 @@ Future<void> Function({required String username, required String password})
           await ref.read(userBiometricsStateProvider(username: username).future);
 
       if (userBiometricsState == BiometricsState.canSuggest && context.mounted) {
-
-        // Additional check on Android, because local_auth.authorize() allows to authenticate 
-        // even if biometrics are not set up on the device and it leads to native crush in 
+        // Additional check on Android, because local_auth.authorize() allows to authenticate
+        // even if biometrics are not set up on the device and it leads to native crush in
         // local_auth_crypto.authenticate then. So we should not even suggest to add biometrics
-        // in this case. 
+        // in this case.
         if (!Platform.isAndroid ||
             await const BiometricsService().isBiometricsAvailable() && context.mounted) {
-
           // Show suggest to add biometrics popup
           await showSimpleBottomSheet<void>(
             context: context,
@@ -38,7 +36,6 @@ Future<void> Function({required String username, required String password})
             ),
           );
         } else {
-
           // If biometrics are not available on Android then we should reject to use biometrics
           await ref
               .read(rejectToUseBiometricsNotifierProvider.notifier)

--- a/lib/app/features/components/biometrics/hooks/use_on_suggest_biometrics.dart
+++ b/lib/app/features/components/biometrics/hooks/use_on_suggest_biometrics.dart
@@ -26,7 +26,7 @@ Future<void> Function({required String username, required String password})
         // local_auth_crypto.authenticate then. So we should not even suggest to add biometrics
         // in this case.
         if (!Platform.isAndroid ||
-            await const BiometricsService().isBiometricsAvailable() && context.mounted) {
+            await ref.read(isBiometricsAvailableProvider.future) && context.mounted) {
           // Show suggest to add biometrics popup
           await showSimpleBottomSheet<void>(
             context: context,

--- a/lib/app/features/user/providers/biometrics_provider.r.dart
+++ b/lib/app/features/user/providers/biometrics_provider.r.dart
@@ -86,11 +86,6 @@ Future<void> _performPasswordDelegation(Ref ref, String password) async {
 }
 
 @riverpod
-Future<bool> isBiometricsAvailable(Ref ref) async {
-  try {
-    return await const BiometricsService().isBiometricsAvailable();
-  } catch (error, stackTrace) {
-    Logger.log('Biometrics availability check exception', error: error, stackTrace: stackTrace);
-    return false;
-  }
+BiometricsService biometricsService(Ref ref) {
+  return const BiometricsService();
 }

--- a/lib/app/features/user/providers/biometrics_provider.r.dart
+++ b/lib/app/features/user/providers/biometrics_provider.r.dart
@@ -84,3 +84,13 @@ Future<void> _performPasswordDelegation(Ref ref, String password) async {
     );
   }
 }
+
+@riverpod
+Future<bool> isBiometricsAvailable(Ref ref) async {
+  try {
+    return await const BiometricsService().isBiometricsAvailable();
+  } catch (error, stackTrace) {
+    Logger.log('Biometrics availability check exception', error: error, stackTrace: stackTrace);
+    return false;
+  }
+}

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -22,6 +22,7 @@ import google_sign_in_ios
 import icloud_storage
 import local_auth_darwin
 import package_info_plus
+import passkeys_darwin
 import path_provider_foundation
 import photo_manager
 import quill_native_bridge_macos
@@ -54,6 +55,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   IcloudStoragePlugin.register(with: registry.registrar(forPlugin: "IcloudStoragePlugin"))
   LocalAuthPlugin.register(with: registry.registrar(forPlugin: "LocalAuthPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
+  PasskeysPlugin.register(with: registry.registrar(forPlugin: "PasskeysPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   PhotoManagerPlugin.register(with: registry.registrar(forPlugin: "PhotoManagerPlugin"))
   QuillNativeBridgePlugin.register(with: registry.registrar(forPlugin: "QuillNativeBridgePlugin"))

--- a/packages/ion_identity_client/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/ion_identity_client/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -9,6 +9,7 @@ import device_info_plus
 import flutter_secure_storage_macos
 import local_auth_darwin
 import package_info_plus
+import passkeys_darwin
 import path_provider_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
@@ -16,5 +17,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   LocalAuthPlugin.register(with: registry.registrar(forPlugin: "LocalAuthPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
+  PasskeysPlugin.register(with: registry.registrar(forPlugin: "PasskeysPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
 }

--- a/packages/ion_identity_client/example/pubspec.lock
+++ b/packages/ion_identity_client/example/pubspec.lock
@@ -724,26 +724,34 @@ packages:
     dependency: transitive
     description:
       name: passkeys
-      sha256: "0cea3937dfd1ccd14450b50e54f404e4903de390d90cf80e780ebfaaa617a8cc"
+      sha256: "8b3ccf8b3f6a67aa2820e8dd6413fde2e16a225edd11076db9f8c6c9d53e801d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.15.1"
   passkeys_android:
     dependency: transitive
     description:
       name: passkeys_android
-      sha256: a06851f8e6a51bd08c249d5e47d6f0e3e36f9b8db68b53a6cc6d4001c5755b40
+      sha256: "88aaab86a362cc2b562753680de5e2d346fec121e6b99032e329aba1fb83dcf0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
+  passkeys_darwin:
+    dependency: transitive
+    description:
+      name: passkeys_darwin
+      sha256: dca2349992cd5cadbe34d7cf1d9bfa6cb3dbd2578b59418130b7d5d7a6992d9d
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   passkeys_doctor:
     dependency: transitive
     description:
       name: passkeys_doctor
-      sha256: e380712ec530d8c1fbaa6d64cdc390767a505864c5f653812df3fdb0ce54a22b
+      sha256: "6e700f957053505eeb57b021dd4c0825a05af163fe059015a006908a5ee6bbaa"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   passkeys_ios:
     dependency: transitive
     description:
@@ -756,18 +764,18 @@ packages:
     dependency: transitive
     description:
       name: passkeys_platform_interface
-      sha256: "6003fafa1da65b3d73c582fc7f7ada358d38f2d511b98f8b8fd3077786f4b71c"
+      sha256: "69f3c499a035add59995f4a978f28f76100f96cf7d19eda459be15779ff1d5d1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.4.0"
   passkeys_web:
     dependency: transitive
     description:
       name: passkeys_web
-      sha256: "98d28223292738a9fbb24db33cdba00609675d54521694fdde45b7e5caf59b19"
+      sha256: "4e08fb93ae8a1c0e62d37ce851db428e52bd5be3e523c4759e88b2f4d7534e84"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.0"
+    version: "2.7.0"
   path:
     dependency: transitive
     description:

--- a/packages/ion_identity_client/lib/ion_identity.dart
+++ b/packages/ion_identity_client/lib/ion_identity.dart
@@ -4,6 +4,7 @@ library ion_identity_client;
 
 export 'src/auth/dtos/dtos.dart';
 export 'src/auth/ion_identity_auth.dart';
+export 'src/auth/services/biometrics_service.dart';
 export 'src/auth/services/credentials/models/recovery_credentials.j.dart';
 export 'src/auth/services/twofa/models/twofa_type.f.dart';
 export 'src/coins/models/coin.f.dart';

--- a/packages/ion_identity_client/lib/src/auth/services/biometrics_service.dart
+++ b/packages/ion_identity_client/lib/src/auth/services/biometrics_service.dart
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: ice License 1.0
+import 'dart:io';
+
+import 'package:local_auth/local_auth.dart';
+
+class BiometricsService {
+  const BiometricsService();
+
+  /// Checks if biometrics are available and enabled on the device
+  Future<bool> isBiometricsAvailable() async {
+    final localAuth = LocalAuthentication();
+
+    final results = await Future.wait<bool>([
+      localAuth.canCheckBiometrics,
+      localAuth.isDeviceSupported(),
+      // We need to check additionally if the device has at least one type of biometrics set up.
+      if (Platform.isAndroid) localAuth.getAvailableBiometrics().then((list) => list.isNotEmpty),
+    ]);
+
+    return results.every((element) => element);
+  }
+}

--- a/packages/ion_identity_client/lib/src/auth/services/credentials/create_new_credentials_service.dart
+++ b/packages/ion_identity_client/lib/src/auth/services/credentials/create_new_credentials_service.dart
@@ -24,7 +24,7 @@ class CreateNewCredentialsService {
   final IdentitySigner identitySigner;
   final LocalPasskeyCredsStateStorage localPasskeyCredsStateStorage;
 
-  Future<void> createNewCredentials(
+  Future<void> _createNewCredentials(
     OnVerifyIdentity<CredentialRequestData> onVerifyIdentity,
   ) async {
     final credentialChallenge = await dataSource.createCredentialInit(username: username);
@@ -79,7 +79,7 @@ class CreateNewCredentialsService {
 
   Future<void> createLocalPasskeyCredentials() async {
     try {
-      await createNewCredentials(
+      await _createNewCredentials(
         ({required onPasskeyFlow, required onPasswordFlow, required onBiometricsFlow}) =>
             onPasskeyFlow(),
       );

--- a/packages/ion_identity_client/lib/src/auth/services/key_service.dart
+++ b/packages/ion_identity_client/lib/src/auth/services/key_service.dart
@@ -33,7 +33,9 @@ class KeyService {
   }
 
   /// Reconstructs a KeyPairData object from a hex-encoded Ed25519 private key (seed).
-  Future<KeyPairData> reconstructKeyPairFromPrivateKeyBytes(String hexEncodedPrivateKeyBytes) async {
+  Future<KeyPairData> reconstructKeyPairFromPrivateKeyBytes(
+    String hexEncodedPrivateKeyBytes,
+  ) async {
     final privateKeyBytes = Uint8List.fromList(hex.decode(hexEncodedPrivateKeyBytes));
 
     if (privateKeyBytes.length != 32) {

--- a/packages/ion_identity_client/lib/src/core/service_locator/ion_identity_clients/auth_client_service_locator.dart
+++ b/packages/ion_identity_client/lib/src/core/service_locator/ion_identity_clients/auth_client_service_locator.dart
@@ -58,7 +58,7 @@ class AuthClientServiceLocator {
         identitySigner: identitySigner,
       ),
       getCredentialsService: getCredentials(username: username, config: config),
-      createNewCredentialsService: createNewCredentials(
+      createNewCredentialsService: _createNewCredentials(
         username: username,
         config: config,
         identitySigner: identitySigner,
@@ -172,7 +172,7 @@ class AuthClientServiceLocator {
     );
   }
 
-  CreateNewCredentialsService createNewCredentials({
+  CreateNewCredentialsService _createNewCredentials({
     required String username,
     required IONIdentityConfig config,
     required IdentitySigner identitySigner,

--- a/packages/ion_identity_client/lib/src/signer/password_signer.dart
+++ b/packages/ion_identity_client/lib/src/signer/password_signer.dart
@@ -7,6 +7,7 @@ import 'package:crypto/crypto.dart';
 import 'package:cryptography/cryptography.dart' as crypto;
 import 'package:ion_identity_client/ion_identity.dart';
 import 'package:ion_identity_client/src/auth/dtos/private_key_data.j.dart';
+import 'package:ion_identity_client/src/auth/services/biometrics_service.dart';
 import 'package:ion_identity_client/src/auth/services/key_service.dart';
 import 'package:ion_identity_client/src/core/storage/biometrics_state_storage.dart';
 import 'package:ion_identity_client/src/core/storage/private_key_storage.dart';
@@ -211,27 +212,13 @@ class PasswordSigner {
   }
 
   Future<void> _updateStateToCanSuggest(String username) async {
-    final biometricsAvailable = await isBiometricsAvailable();
+    final biometricsAvailable = await const BiometricsService().isBiometricsAvailable();
     if (biometricsAvailable) {
       await biometricsStateStorage.updateBiometricsState(
         username: username,
         biometricsState: BiometricsState.canSuggest,
       );
     }
-  }
-
-  Future<bool> isBiometricsAvailable() async {
-    final localAuth = LocalAuthentication();
-
-    final results = await Future.wait<bool>([
-      localAuth.canCheckBiometrics,
-      localAuth.isDeviceSupported(),
-    ]);
-
-    final canCheckBiometrics = results[0];
-    final isDeviceSupported = results[1];
-
-    return canCheckBiometrics && isDeviceSupported;
   }
 
   String _buildClientData({

--- a/packages/ion_identity_client/lib/src/signer/password_signer.dart
+++ b/packages/ion_identity_client/lib/src/signer/password_signer.dart
@@ -7,7 +7,6 @@ import 'package:crypto/crypto.dart';
 import 'package:cryptography/cryptography.dart' as crypto;
 import 'package:ion_identity_client/ion_identity.dart';
 import 'package:ion_identity_client/src/auth/dtos/private_key_data.j.dart';
-import 'package:ion_identity_client/src/auth/services/biometrics_service.dart';
 import 'package:ion_identity_client/src/auth/services/key_service.dart';
 import 'package:ion_identity_client/src/core/storage/biometrics_state_storage.dart';
 import 'package:ion_identity_client/src/core/storage/private_key_storage.dart';

--- a/packages/ion_identity_client/pubspec.yaml
+++ b/packages/ion_identity_client/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   local_auth: ^2.3.0
   local_auth_crypto: ^1.1.1
   on_chain: ^6.0.0
-  passkeys: ^2.11.0
+  passkeys: ^2.15.0
   pointycastle: ^3.9.1
   rxdart: ^0.28.0
   sprintf: ^7.0.0

--- a/packages/ion_identity_client/pubspec.yaml
+++ b/packages/ion_identity_client/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   local_auth: ^2.3.0
   local_auth_crypto: ^1.1.1
   on_chain: ^6.0.0
-  passkeys: ^2.15.0
+  passkeys: ^2.15.1
   pointycastle: ^3.9.1
   rxdart: ^0.28.0
   sprintf: ^7.0.0

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1991,26 +1991,34 @@ packages:
     dependency: transitive
     description:
       name: passkeys
-      sha256: "0cea3937dfd1ccd14450b50e54f404e4903de390d90cf80e780ebfaaa617a8cc"
+      sha256: "8b3ccf8b3f6a67aa2820e8dd6413fde2e16a225edd11076db9f8c6c9d53e801d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.15.1"
   passkeys_android:
     dependency: transitive
     description:
       name: passkeys_android
-      sha256: a06851f8e6a51bd08c249d5e47d6f0e3e36f9b8db68b53a6cc6d4001c5755b40
+      sha256: "88aaab86a362cc2b562753680de5e2d346fec121e6b99032e329aba1fb83dcf0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
+  passkeys_darwin:
+    dependency: transitive
+    description:
+      name: passkeys_darwin
+      sha256: dca2349992cd5cadbe34d7cf1d9bfa6cb3dbd2578b59418130b7d5d7a6992d9d
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   passkeys_doctor:
     dependency: transitive
     description:
       name: passkeys_doctor
-      sha256: e380712ec530d8c1fbaa6d64cdc390767a505864c5f653812df3fdb0ce54a22b
+      sha256: "6e700f957053505eeb57b021dd4c0825a05af163fe059015a006908a5ee6bbaa"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   passkeys_ios:
     dependency: transitive
     description:
@@ -2023,18 +2031,18 @@ packages:
     dependency: transitive
     description:
       name: passkeys_platform_interface
-      sha256: "6003fafa1da65b3d73c582fc7f7ada358d38f2d511b98f8b8fd3077786f4b71c"
+      sha256: "69f3c499a035add59995f4a978f28f76100f96cf7d19eda459be15779ff1d5d1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.4.0"
   passkeys_web:
     dependency: transitive
     description:
       name: passkeys_web
-      sha256: "98d28223292738a9fbb24db33cdba00609675d54521694fdde45b7e5caf59b19"
+      sha256: "4e08fb93ae8a1c0e62d37ce851db428e52bd5be3e523c4759e88b2f4d7534e84"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.0"
+    version: "2.7.0"
   path:
     dependency: "direct main"
     description:


### PR DESCRIPTION
## Description
Add Additional check on Android, because local_auth.authorize() allows to authenticate 
even if biometrics are not set up on the device and it leads to native crush in 
local_auth_crypto.authenticate then. So we should not even suggest user to add biometrics
in this rare case. 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

