### PR TITLE
fix: make sure there is only one request filter

### DIFF
--- a/lib/app/features/feed/providers/feed_data_source_builders.dart
+++ b/lib/app/features/feed/providers/feed_data_source_builders.dart
@@ -74,18 +74,16 @@ FeedEntitiesDataSource buildArticlesDataSource({
 
       return entity is ArticleEntity || entity is GenericRepostEntity;
     },
-    requestFilters: [
-      RequestFilter(
-        kinds: const [
-          ArticleEntity.kind,
-          GenericRepostEntity.articleRepostKind,
-        ],
-        authors: authors,
-        limit: limit,
-        tags: tags,
-        search: search,
-      ),
-    ],
+    requestFilter: RequestFilter(
+      kinds: const [
+        ArticleEntity.kind,
+        GenericRepostEntity.articleRepostKind,
+      ],
+      authors: authors,
+      limit: limit,
+      tags: tags,
+      search: search,
+    ),
   );
 
   return FeedEntitiesDataSource(dataSource: dataSource);
@@ -137,20 +135,18 @@ FeedEntitiesDataSource buildVideosDataSource({
           entity is RepostEntity ||
           entity is GenericRepostEntity;
     },
-    requestFilters: [
-      RequestFilter(
-        kinds: const [
-          PostEntity.kind,
-          ModifiablePostEntity.kind,
-          RepostEntity.kind,
-          GenericRepostEntity.modifiablePostRepostKind,
-        ],
-        search: search,
-        authors: authors,
-        limit: limit,
-        tags: tags,
-      ),
-    ],
+    requestFilter: RequestFilter(
+      kinds: const [
+        PostEntity.kind,
+        ModifiablePostEntity.kind,
+        RepostEntity.kind,
+        GenericRepostEntity.modifiablePostRepostKind,
+      ],
+      search: search,
+      authors: authors,
+      limit: limit,
+      tags: tags,
+    ),
   );
 
   return FeedEntitiesDataSource(dataSource: dataSource);
@@ -201,22 +197,20 @@ FeedEntitiesDataSource buildPostsDataSource({
           entity is GenericRepostEntity ||
           entity is ArticleEntity;
     },
-    requestFilters: [
-      RequestFilter(
-        kinds: const [
-          PostEntity.kind,
-          ModifiablePostEntity.kind,
-          RepostEntity.kind,
-          ArticleEntity.kind,
-          GenericRepostEntity.modifiablePostRepostKind,
-          GenericRepostEntity.articleRepostKind,
-        ],
-        search: search,
-        authors: authors,
-        limit: limit,
-        tags: tags,
-      ),
-    ],
+    requestFilter: RequestFilter(
+      kinds: const [
+        PostEntity.kind,
+        ModifiablePostEntity.kind,
+        RepostEntity.kind,
+        ArticleEntity.kind,
+        GenericRepostEntity.modifiablePostRepostKind,
+        GenericRepostEntity.articleRepostKind,
+      ],
+      search: search,
+      authors: authors,
+      limit: limit,
+      tags: tags,
+    ),
   );
 
   return FeedEntitiesDataSource(dataSource: dataSource);
@@ -255,15 +249,13 @@ FeedEntitiesDataSource buildStoriesDataSource({
         (entity is ModifiablePostEntity &&
             entity.data.parentEvent == null &&
             entity.data.expiration != null),
-    requestFilters: [
-      RequestFilter(
-        kinds: const [ModifiablePostEntity.kind],
-        authors: authors,
-        limit: limit,
-        search: search,
-        tags: tags,
-      ),
-    ],
+    requestFilter: RequestFilter(
+      kinds: const [ModifiablePostEntity.kind],
+      authors: authors,
+      limit: limit,
+      search: search,
+      tags: tags,
+    ),
   );
 
   return FeedEntitiesDataSource(dataSource: dataSource);

--- a/lib/app/features/feed/providers/feed_following_content_provider.m.dart
+++ b/lib/app/features/feed/providers/feed_following_content_provider.m.dart
@@ -351,22 +351,21 @@ class FeedFollowingContent extends _$FeedFollowingContent implements PagedNotifi
 
     final until = lastEventCreatedAt != null ? lastEventCreatedAt - 1 : null;
     final requestMessage = RequestMessage();
-    for (final filter in dataSource.requestFilters) {
-      requestMessage.addFilter(
-        // Do not use `since` here (from feedConfig.followingReqMaxAge),
-        // as we want to request one overflow entity (if it exists),
-        // to avoid the unnecessary requests in the future.
-        filter.copyWith(
-          limit: () => 1,
-          until: () => until,
-          tags: () => selectedArticleCategories.isEmpty
-              ? null
-              : {
-                  '#${RelatedHashtag.tagName}': selectedArticleCategories.toList(),
-                },
-        ),
-      );
-    }
+    final filter = dataSource.requestFilter;
+    requestMessage.addFilter(
+      // Do not use `since` here (from feedConfig.followingReqMaxAge),
+      // as we want to request one overflow entity (if it exists),
+      // to avoid the unnecessary requests in the future.
+      filter.copyWith(
+        limit: () => 1,
+        until: () => until,
+        tags: () => selectedArticleCategories.isEmpty
+            ? null
+            : {
+                '#${RelatedHashtag.tagName}': selectedArticleCategories.toList(),
+              },
+      ),
+    );
 
     final entities = await ionConnectNotifier
         .requestEntities(requestMessage, actionSource: dataSource.actionSource)

--- a/lib/app/features/feed/providers/feed_for_you_content_provider.m.dart
+++ b/lib/app/features/feed/providers/feed_for_you_content_provider.m.dart
@@ -36,6 +36,7 @@ import 'package:ion/app/utils/pagination.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'feed_for_you_content_provider.m.freezed.dart';
+
 part 'feed_for_you_content_provider.m.g.dart';
 
 @riverpod
@@ -596,15 +597,14 @@ class FeedForYouContent extends _$FeedForYouContent implements PagedNotifier {
     final since = DateTime.now().subtract(maxAge).microsecondsSinceEpoch;
     final until = lastEventCreatedAt != null ? lastEventCreatedAt - 1 : null;
     final requestMessage = RequestMessage();
-    for (final filter in dataSource.requestFilters) {
-      requestMessage.addFilter(
-        filter.copyWith(
-          limit: () => 1,
-          until: () => until,
-          since: () => since,
-        ),
-      );
-    }
+    final filter = dataSource.requestFilter;
+    requestMessage.addFilter(
+      filter.copyWith(
+        limit: () => 1,
+        until: () => until,
+        since: () => since,
+      ),
+    );
 
     final entities = await ionConnectNotifier
         .requestEntities(requestMessage, actionSource: dataSource.actionSource)

--- a/lib/app/features/feed/providers/replies_data_source_provider.r.dart
+++ b/lib/app/features/feed/providers/replies_data_source_provider.r.dart
@@ -39,35 +39,23 @@ List<EntitiesDataSource>? repliesDataSource(
           (entity is ModifiablePostEntity &&
               entity.data.parentEvent?.eventReference == eventReference) ||
           (entity is PostEntity && entity.data.parentEvent?.eventReference == eventReference),
-      requestFilters: [
-        RequestFilter(
-          kinds: const [ModifiablePostEntity.kind],
-          tags: Map.fromEntries([relatedTags]),
-          search: SearchExtensions(
-            [
-              ...SearchExtensions.withCounters(currentPubkey: currentPubkey).extensions,
-              ...SearchExtensions.withAuthors().extensions,
-              ExpirationSearchExtension(expiration: false),
-            ],
-          ).toString(),
-          limit: 10,
-        ),
-        RequestFilter(
-          kinds: const [PostEntity.kind],
-          tags: Map.fromEntries([relatedTags]),
-          search: SearchExtensions(
-            [
-              ...SearchExtensions.withCounters(
-                currentPubkey: currentPubkey,
-                forKind: PostEntity.kind,
-              ).extensions,
-              ...SearchExtensions.withAuthors(forKind: PostEntity.kind).extensions,
-              ExpirationSearchExtension(expiration: false),
-            ],
-          ).toString(),
-          limit: 10,
-        ),
-      ],
+      requestFilter: RequestFilter(
+        kinds: const [ModifiablePostEntity.kind, PostEntity.kind],
+        tags: Map.fromEntries([relatedTags]),
+        search: SearchExtensions(
+          [
+            ...SearchExtensions.withCounters(currentPubkey: currentPubkey).extensions,
+            ...SearchExtensions.withAuthors().extensions,
+            ...SearchExtensions.withCounters(
+              currentPubkey: currentPubkey,
+              forKind: PostEntity.kind,
+            ).extensions,
+            ...SearchExtensions.withAuthors(forKind: PostEntity.kind).extensions,
+            ExpirationSearchExtension(expiration: false),
+          ],
+        ).toString(),
+        limit: 10,
+      ),
     ),
   ];
 

--- a/lib/app/features/feed/providers/topic_articles_data_source_provider.r.dart
+++ b/lib/app/features/feed/providers/topic_articles_data_source_provider.r.dart
@@ -46,22 +46,20 @@ EntitiesDataSource _buildArticlesDataSource({
   return EntitiesDataSource(
     actionSource: actionSource,
     entityFilter: (entity) => entity is ArticleEntity,
-    requestFilters: [
-      RequestFilter(
-        kinds: const [ArticleEntity.kind],
-        authors: authors,
-        search: SearchExtensions([
-          ...SearchExtensions.withCounters(
-            currentPubkey: currentPubkey,
-            forKind: ArticleEntity.kind,
-          ).extensions,
-          ...SearchExtensions.withAuthors(forKind: ArticleEntity.kind).extensions,
-        ]).toString(),
-        limit: 20,
-        tags: {
-          '#t': [topic],
-        },
-      ),
-    ],
+    requestFilter: RequestFilter(
+      kinds: const [ArticleEntity.kind],
+      authors: authors,
+      search: SearchExtensions([
+        ...SearchExtensions.withCounters(
+          currentPubkey: currentPubkey,
+          forKind: ArticleEntity.kind,
+        ).extensions,
+        ...SearchExtensions.withAuthors(forKind: ArticleEntity.kind).extensions,
+      ]).toString(),
+      limit: 20,
+      tags: {
+        '#t': [topic],
+      },
+    ),
   );
 }

--- a/lib/app/features/feed/providers/user_articles_data_source_provider.r.dart
+++ b/lib/app/features/feed/providers/user_articles_data_source_provider.r.dart
@@ -31,23 +31,12 @@ List<EntitiesDataSource>? userArticlesDataSource(Ref ref, String pubkey) {
       entityFilter: (entity) =>
           entity.masterPubkey == pubkey &&
           (entity is ArticleEntity || entity is GenericRepostEntity),
-      requestFilters: [
-        RequestFilter(
-          kinds: const [ArticleEntity.kind],
-          authors: [pubkey],
-          search: search,
-          limit: 10,
-        ),
-        RequestFilter(
-          kinds: const [GenericRepostEntity.kind],
-          authors: [pubkey],
-          tags: {
-            '#k': [ArticleEntity.kind.toString()],
-          },
-          search: search,
-          limit: 10,
-        ),
-      ],
+      requestFilter: RequestFilter(
+        kinds: const [ArticleEntity.kind, GenericRepostEntity.articleRepostKind],
+        authors: [pubkey],
+        search: search,
+        limit: 10,
+      ),
     ),
   ];
 }

--- a/lib/app/features/feed/providers/user_posts_data_source_provider.r.dart
+++ b/lib/app/features/feed/providers/user_posts_data_source_provider.r.dart
@@ -43,23 +43,17 @@ List<EntitiesDataSource>? userPostsDataSource(Ref ref, String pubkey) {
               entity is GenericRepostEntity ||
               (entity is PostEntity && entity.data.parentEvent == null) ||
               entity is RepostEntity),
-      requestFilters: [
-        RequestFilter(
-          kinds: const [ModifiablePostEntity.kind, PostEntity.kind, RepostEntity.kind],
-          authors: [pubkey],
-          search: search,
-          limit: 10,
-        ),
-        RequestFilter(
-          kinds: const [GenericRepostEntity.kind],
-          authors: [pubkey],
-          search: search,
-          tags: {
-            '#k': [ModifiablePostEntity.kind.toString()],
-          },
-          limit: 10,
-        ),
-      ],
+      requestFilter: RequestFilter(
+        kinds: const [
+          ModifiablePostEntity.kind,
+          PostEntity.kind,
+          RepostEntity.kind,
+          GenericRepostEntity.modifiablePostRepostKind,
+        ],
+        authors: [pubkey],
+        search: search,
+        limit: 10,
+      ),
     ),
   ];
 }

--- a/lib/app/features/feed/providers/user_replies_data_source_provider.r.dart
+++ b/lib/app/features/feed/providers/user_replies_data_source_provider.r.dart
@@ -37,14 +37,12 @@ List<EntitiesDataSource>? userRepliesDataSource(Ref ref, String pubkey) {
       actionSource: ActionSourceUser(pubkey),
       entityFilter: (entity) =>
           entity.masterPubkey == pubkey && (entity is ModifiablePostEntity || entity is PostEntity),
-      requestFilters: [
-        RequestFilter(
-          kinds: const [ModifiablePostEntity.kind, PostEntity.kind],
-          authors: [pubkey],
-          search: search,
-          limit: 10,
-        ),
-      ],
+      requestFilter: RequestFilter(
+        kinds: const [ModifiablePostEntity.kind, PostEntity.kind],
+        authors: [pubkey],
+        search: search,
+        limit: 10,
+      ),
     ),
   ];
 }

--- a/lib/app/features/feed/providers/user_videos_data_source_provider.r.dart
+++ b/lib/app/features/feed/providers/user_videos_data_source_provider.r.dart
@@ -44,23 +44,17 @@ List<EntitiesDataSource>? userVideosDataSource(Ref ref, String pubkey) {
               entity is GenericRepostEntity ||
               entity is PostEntity ||
               entity is RepostEntity),
-      requestFilters: [
-        RequestFilter(
-          kinds: const [ModifiablePostEntity.kind, PostEntity.kind, RepostEntity.kind],
-          authors: [pubkey],
-          search: search,
-          limit: 10,
-        ),
-        RequestFilter(
-          kinds: const [GenericRepostEntity.kind],
-          authors: [pubkey],
-          search: search,
-          tags: {
-            '#k': [ModifiablePostEntity.kind.toString()],
-          },
-          limit: 10,
-        ),
-      ],
+      requestFilter: RequestFilter(
+        kinds: const [
+          ModifiablePostEntity.kind,
+          PostEntity.kind,
+          RepostEntity.kind,
+          GenericRepostEntity.modifiablePostRepostKind,
+        ],
+        authors: [pubkey],
+        search: search,
+        limit: 10,
+      ),
     ),
   ];
 }

--- a/lib/app/features/ion_connect/providers/entities_paged_data_provider.m.dart
+++ b/lib/app/features/ion_connect/providers/entities_paged_data_provider.m.dart
@@ -62,7 +62,7 @@ mixin DelegatedPagedNotifier implements PagedNotifier {
 class EntitiesDataSource with _$EntitiesDataSource {
   const factory EntitiesDataSource({
     required ActionSource actionSource,
-    required List<RequestFilter> requestFilters,
+    required RequestFilter requestFilter,
     required bool Function(IonConnectEntity entity) entityFilter,
     bool Function(IonConnectEntity entity)? pagedFilter,
   }) = _EntitiesDataSource;
@@ -200,11 +200,10 @@ class EntitiesPagedData extends _$EntitiesPagedData implements PagedNotifier {
       }
 
       final requestMessage = RequestMessage();
-      for (final filter in dataSource.requestFilters) {
-        requestMessage.addFilter(
-          filter.copyWith(until: () => paginationParams.until?.microsecondsSinceEpoch),
-        );
-      }
+      final filter = dataSource.requestFilter;
+      requestMessage.addFilter(
+        filter.copyWith(until: () => paginationParams.until?.microsecondsSinceEpoch),
+      );
 
       final entitiesStream = ref.read(ionConnectNotifierProvider.notifier).requestEntities(
             requestMessage,

--- a/lib/app/features/search/providers/feed_search_posts_data_source_provider.r.dart
+++ b/lib/app/features/search/providers/feed_search_posts_data_source_provider.r.dart
@@ -71,7 +71,7 @@ List<EntitiesDataSource>? feedSearchPostsDataSource(
           strategy: OptimalRelaysStrategy.mostUsers,
         ),
         authors: filters.source == FeedSearchSource.following ? filterRelayMasterPubkeys : null,
-        filters: _buildFilters(
+        filter: _buildFilter(
           authors: filters.source == FeedSearchSource.following ? filterRelayMasterPubkeys : null,
           currentPubkey: currentPubkey,
           tags: tags,
@@ -89,7 +89,7 @@ List<EntitiesDataSource>? feedSearchPostsDataSource(
 EntitiesDataSource _buildSearchDataSource({
   required ActionSource actionSource,
   required List<String>? authors,
-  required List<RequestFilter> filters,
+  required RequestFilter filter,
 }) {
   return EntitiesDataSource(
     actionSource: actionSource,
@@ -104,11 +104,11 @@ EntitiesDataSource _buildSearchDataSource({
           entity is GenericRepostEntity ||
           entity is ArticleEntity;
     },
-    requestFilters: filters,
+    requestFilter: filter,
   );
 }
 
-List<RequestFilter> _buildFilters({
+RequestFilter _buildFilter({
   required List<String>? authors,
   required String currentPubkey,
   required bool includePosts,
@@ -143,33 +143,22 @@ List<RequestFilter> _buildFilters({
     ...SearchExtensions.withAuthors(forKind: ArticleEntity.kind).extensions,
   ]).toString();
 
-  return [
-    RequestFilter(
-      kinds: [
-        if (includePosts) ...[
-          PostEntity.kind,
-          ModifiablePostEntity.kind,
-          RepostEntity.kind,
-        ],
-        if (includeArticles) ArticleEntity.kind,
+  return RequestFilter(
+    kinds: [
+      if (includePosts) ...[
+        PostEntity.kind,
+        ModifiablePostEntity.kind,
+        RepostEntity.kind,
+        GenericRepostEntity.modifiablePostRepostKind,
       ],
-      tags: tags,
-      search: search,
-      authors: authors,
-      limit: 20,
-    ),
-    RequestFilter(
-      kinds: const [GenericRepostEntity.kind],
-      authors: authors,
-      search: search,
-      tags: {
-        ...tags,
-        '#k': [
-          if (includePosts) ModifiablePostEntity.kind.toString(),
-          if (includeArticles) ArticleEntity.kind.toString(),
-        ],
-      },
-      limit: 20,
-    ),
-  ];
+      if (includeArticles) ...[
+        ArticleEntity.kind,
+        GenericRepostEntity.articleRepostKind,
+      ],
+    ],
+    tags: tags,
+    search: search,
+    authors: authors,
+    limit: 20,
+  );
 }

--- a/lib/app/features/user/providers/followers_data_source_provider.r.dart
+++ b/lib/app/features/user/providers/followers_data_source_provider.r.dart
@@ -22,25 +22,23 @@ List<EntitiesDataSource>? followersDataSource(
       actionSource: ActionSourceUser(pubkey),
       entityFilter: (entity) => entity is UserMetadataEntity || entity is FollowListEntity,
       pagedFilter: (entity) => entity is FollowListEntity,
-      requestFilters: [
-        RequestFilter(
-          kinds: const [FollowListEntity.kind],
-          tags: {
-            '#p': [pubkey],
-          },
-          search: SearchExtensions(
-            [
-              GenericIncludeSearchExtension(
-                forKind: FollowListEntity.kind,
-                includeKind: UserMetadataEntity.kind,
-              ),
-              if (ref.watch(cachedProfileBadgesDataProvider(pubkey)) == null)
-                ProfileBadgesSearchExtension(forKind: FollowListEntity.kind),
-            ],
-          ).toString(),
-          limit: 20,
-        ),
-      ],
+      requestFilter: RequestFilter(
+        kinds: const [FollowListEntity.kind],
+        tags: {
+          '#p': [pubkey],
+        },
+        search: SearchExtensions(
+          [
+            GenericIncludeSearchExtension(
+              forKind: FollowListEntity.kind,
+              includeKind: UserMetadataEntity.kind,
+            ),
+            if (ref.watch(cachedProfileBadgesDataProvider(pubkey)) == null)
+              ProfileBadgesSearchExtension(forKind: FollowListEntity.kind),
+          ],
+        ).toString(),
+        limit: 20,
+      ),
     ),
   ];
 }

--- a/lib/app/features/user/providers/relevant_followers_data_source_provider.r.dart
+++ b/lib/app/features/user/providers/relevant_followers_data_source_provider.r.dart
@@ -16,20 +16,18 @@ List<EntitiesDataSource>? relevantFollowersDataSource(Ref ref, String pubkey, {i
     EntitiesDataSource(
       actionSource: ActionSourceUser(pubkey),
       entityFilter: (entity) => entity is UserMetadataEntity,
-      requestFilters: [
-        RequestFilter(
-          kinds: const [UserMetadataEntity.kind],
-          tags: {
-            '#p': [pubkey],
-          },
-          search: SearchExtensions(
-            [
-              MostRelevantFollowersSearchExtension(),
-            ],
-          ).toString(),
-          limit: limit,
-        ),
-      ],
+      requestFilter: RequestFilter(
+        kinds: const [UserMetadataEntity.kind],
+        tags: {
+          '#p': [pubkey],
+        },
+        search: SearchExtensions(
+          [
+            MostRelevantFollowersSearchExtension(),
+          ],
+        ).toString(),
+        limit: limit,
+      ),
     ),
   ];
 }

--- a/lib/app/features/user/providers/search_following_users_data_source_provider.r.dart
+++ b/lib/app/features/user/providers/search_following_users_data_source_provider.r.dart
@@ -7,7 +7,6 @@ import 'package:ion/app/features/ion_connect/model/search_extension.dart';
 import 'package:ion/app/features/ion_connect/providers/entities_paged_data_provider.m.dart';
 import 'package:ion/app/features/user/model/user_metadata.f.dart';
 import 'package:ion/app/features/user/providers/follow_list_provider.r.dart';
-
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'search_following_users_data_source_provider.r.g.dart';
@@ -28,18 +27,16 @@ List<EntitiesDataSource>? searchFollowingUsersDataSource(
     EntitiesDataSource(
       actionSource: const ActionSourceCurrentUser(),
       entityFilter: (entity) => entity is UserMetadataEntity,
-      requestFilters: [
-        RequestFilter(
-          kinds: const [UserMetadataEntity.kind],
-          authors: followingList.masterPubkeys,
-          search: SearchExtensions(
-            [
-              QuerySearchExtension(searchQuery: query),
-            ],
-          ).toString(),
-          limit: 20,
-        ),
-      ],
+      requestFilter: RequestFilter(
+        kinds: const [UserMetadataEntity.kind],
+        authors: followingList.masterPubkeys,
+        search: SearchExtensions(
+          [
+            QuerySearchExtension(searchQuery: query),
+          ],
+        ).toString(),
+        limit: 20,
+      ),
     ),
   ];
 }


### PR DESCRIPTION
## Description
With more than 1 request filter in pagination requests there can be a situation
when we get created at of the last event in the stream but it is correct only for one of the filters.
So here I make sure we always has only one filter for pagination requests to fix such scenarios.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
