### PR TITLE
fix: don't show not interested in user profile and post details

### DIFF
--- a/lib/app/features/components/entities_list/components/article_list_item.dart
+++ b/lib/app/features/components/entities_list/components/article_list_item.dart
@@ -8,9 +8,14 @@ import 'package:ion/app/features/feed/views/components/article/article.dart';
 import 'package:ion/app/router/app_routes.gr.dart';
 
 class ArticleListItem extends ConsumerWidget {
-  const ArticleListItem({required this.article, super.key});
+  const ArticleListItem({
+    required this.article,
+    this.showNotInterested = true,
+    super.key,
+  });
 
   final ArticleEntity article;
+  final bool showNotInterested;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -24,6 +29,7 @@ class ArticleListItem extends ConsumerWidget {
             ArticleDetailsRoute(eventReference: eventReference.encode()).push<void>(context),
         child: Article(
           eventReference: eventReference,
+          showNotInterested: showNotInterested,
         ),
       ),
     );

--- a/lib/app/features/components/entities_list/components/post_list_item.dart
+++ b/lib/app/features/components/entities_list/components/post_list_item.dart
@@ -11,6 +11,7 @@ class PostListItem extends StatelessWidget {
   const PostListItem({
     required this.eventReference,
     this.displayParent = false,
+    this.showNotInterested = true,
     this.onVideoTap,
     super.key,
   });
@@ -21,6 +22,8 @@ class PostListItem extends StatelessWidget {
 
   final OnVideoTapCallback? onVideoTap;
 
+  final bool showNotInterested;
+
   @override
   Widget build(BuildContext context) {
     // TODO: process 20002 in the feed provider to fetch 10002
@@ -29,6 +32,7 @@ class PostListItem extends StatelessWidget {
       onTap: () => PostDetailsRoute(eventReference: eventReference.encode()).push<void>(context),
       behavior: HitTestBehavior.opaque,
       child: Post(
+        showNotInterested: showNotInterested,
         eventReference: eventReference,
         displayParent: displayParent,
         onVideoTap: onVideoTap,

--- a/lib/app/features/components/entities_list/components/repost_list_item.dart
+++ b/lib/app/features/components/entities_list/components/repost_list_item.dart
@@ -23,11 +23,13 @@ class RepostListItem extends ConsumerWidget {
   const RepostListItem({
     required this.eventReference,
     this.onVideoTap,
+    this.showNotInterested = true,
     super.key,
   });
 
   final EventReference eventReference;
   final OnVideoTapCallback? onVideoTap;
+  final bool showNotInterested;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -71,11 +73,13 @@ class RepostListItem extends ConsumerWidget {
                 eventReference: repostEntity.data.eventReference,
                 repostEventReference: eventReference,
                 onVideoTap: onVideoTap,
+                showNotInterested: showNotInterested,
               ),
             GenericRepostEntity() when repostEntity.data.kind == ModifiablePostEntity.kind => Post(
                 eventReference: repostEntity.data.eventReference,
                 repostEventReference: eventReference,
                 onVideoTap: onVideoTap,
+                showNotInterested: showNotInterested,
               ),
             GenericRepostEntity() when repostEntity.data.kind == ArticleEntity.kind => Padding(
                 padding: EdgeInsetsDirectional.symmetric(vertical: 12.0.s) +
@@ -83,6 +87,7 @@ class RepostListItem extends ConsumerWidget {
                 child: Article(
                   eventReference: repostEntity.data.eventReference,
                   addTrailingPadding: false,
+                  showNotInterested: showNotInterested,
                 ),
               ),
             _ => const SizedBox.shrink(),

--- a/lib/app/features/components/entities_list/entities_list.dart
+++ b/lib/app/features/components/entities_list/entities_list.dart
@@ -28,6 +28,7 @@ class EntitiesList extends HookWidget {
     this.onVideoTap,
     this.readFromDB = false,
     this.showMuted = false,
+    this.showNotInterested = true,
     super.key,
   });
 
@@ -37,6 +38,7 @@ class EntitiesList extends HookWidget {
   final OnVideoTapCallback? onVideoTap;
   final bool readFromDB;
   final bool showMuted;
+  final bool showNotInterested;
 
   @override
   Widget build(BuildContext context) {
@@ -56,6 +58,7 @@ class EntitiesList extends HookWidget {
                 onVideoTap: onVideoTap,
                 readFromDB: readFromDB,
                 showMuted: showMuted,
+                showNotInterested: showNotInterested,
               ),
             IonEntityListItem() => const SizedBox.shrink()
           };
@@ -71,6 +74,7 @@ class _EntityListItem extends ConsumerWidget {
     required this.displayParent,
     required this.readFromDB,
     required this.showMuted,
+    required this.showNotInterested,
     this.onVideoTap,
     double? separatorHeight,
     super.key,
@@ -82,6 +86,7 @@ class _EntityListItem extends ConsumerWidget {
   final bool readFromDB;
   final OnVideoTapCallback? onVideoTap;
   final bool showMuted;
+  final bool showNotInterested;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -108,14 +113,20 @@ class _EntityListItem extends ConsumerWidget {
       height: separatorHeight,
       child: switch (entity) {
         ModifiablePostEntity() || PostEntity() => PostListItem(
+            showNotInterested: showNotInterested,
             eventReference: entity.toEventReference(),
             displayParent: displayParent,
             onVideoTap: onVideoTap,
           ),
-        final ArticleEntity article => ArticleListItem(article: article),
-        GenericRepostEntity() ||
-        RepostEntity() =>
-          RepostListItem(eventReference: entity.toEventReference(), onVideoTap: onVideoTap),
+        final ArticleEntity article => ArticleListItem(
+            article: article,
+            showNotInterested: showNotInterested,
+          ),
+        GenericRepostEntity() || RepostEntity() => RepostListItem(
+            eventReference: entity.toEventReference(),
+            onVideoTap: onVideoTap,
+            showNotInterested: showNotInterested,
+          ),
         _ => const SizedBox.shrink()
       },
     );

--- a/lib/app/features/feed/views/components/article/article.dart
+++ b/lib/app/features/feed/views/components/article/article.dart
@@ -34,6 +34,7 @@ class Article extends ConsumerWidget {
     this.accentTheme = false,
     this.addTrailingPadding = true,
     this.showActionButtons = true,
+    this.showNotInterested = true,
     this.timeFormat = TimestampFormat.short,
     super.key,
   });
@@ -76,6 +77,7 @@ class Article extends ConsumerWidget {
   final bool isReplied;
   final Widget? footer;
   final bool accentTheme;
+  final bool showNotInterested;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -129,7 +131,10 @@ class Article extends ConsumerWidget {
                         if (isOwnedByCurrentUser)
                           OwnEntityMenu(eventReference: eventReference)
                         else
-                          UserInfoMenu(eventReference: eventReference),
+                          UserInfoMenu(
+                            eventReference: eventReference,
+                            showNotInterested: showNotInterested,
+                          ),
                       ],
                     )
                   : null,
@@ -180,7 +185,10 @@ class Article extends ConsumerWidget {
                                           if (isOwnedByCurrentUser)
                                             OwnEntityMenu(eventReference: eventReference)
                                           else
-                                            UserInfoMenu(eventReference: eventReference),
+                                            UserInfoMenu(
+                                              eventReference: eventReference,
+                                              showNotInterested: showNotInterested,
+                                            ),
                                         ],
                                       )
                                     : null,

--- a/lib/app/features/feed/views/components/overlay_menu/user_info_menu.dart
+++ b/lib/app/features/feed/views/components/overlay_menu/user_info_menu.dart
@@ -31,6 +31,7 @@ class UserInfoMenu extends ConsumerWidget {
     this.reportTitle,
     this.showShadow = false,
     this.padding = EdgeInsets.zero,
+    this.showNotInterested = true,
     this.iconSize,
     super.key,
   });
@@ -43,6 +44,7 @@ class UserInfoMenu extends ConsumerWidget {
   final bool showShadow;
   final EdgeInsetsGeometry padding;
   final double? iconSize;
+  final bool showNotInterested;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -66,13 +68,15 @@ class UserInfoMenu extends ConsumerWidget {
         constraints: BoxConstraints(maxWidth: 300.0.s),
         child: Column(
           children: [
-            OverlayMenuContainer(
-              child: _NotInterestedMenuItem(
-                pubkey: eventReference.masterPubkey,
-                closeMenu: closeMenu,
+            if (showNotInterested == true) ...[
+              OverlayMenuContainer(
+                child: _NotInterestedMenuItem(
+                  pubkey: eventReference.masterPubkey,
+                  closeMenu: closeMenu,
+                ),
               ),
-            ),
-            SizedBox(height: 14.0.s),
+              SizedBox(height: 14.0.s),
+            ],
             OverlayMenuContainer(
               child: Column(
                 children: [

--- a/lib/app/features/feed/views/components/post/post.dart
+++ b/lib/app/features/feed/views/components/post/post.dart
@@ -44,6 +44,7 @@ class Post extends ConsumerWidget {
     this.accentTheme = false,
     this.videoAutoplay = true,
     this.isTextSelectable = false,
+    this.showNotInterested = true,
     this.bodyMaxLines = 6,
     this.contentWrapper,
     this.onVideoTap,
@@ -67,6 +68,7 @@ class Post extends ConsumerWidget {
   final bool videoAutoplay;
   final Widget Function(Widget content)? contentWrapper;
   final OnVideoTapCallback? onVideoTap;
+  final bool showNotInterested;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -159,6 +161,7 @@ class Post extends ConsumerWidget {
                     )
                   : UserInfoMenu(
                       eventReference: eventReference,
+                      showNotInterested: showNotInterested,
                       padding: EdgeInsetsGeometry.symmetric(
                         horizontal: ScreenSideOffset.defaultSmallMargin,
                         vertical: 5.0.s,

--- a/lib/app/features/feed/views/pages/article_details_page/article_details_page.dart
+++ b/lib/app/features/feed/views/pages/article_details_page/article_details_page.dart
@@ -78,7 +78,10 @@ class ArticleDetailsPage extends HookConsumerWidget {
           if (isOwnedByCurrentUser)
             OwnEntityMenu(eventReference: eventReference, onDelete: context.pop)
           else
-            UserInfoMenu(eventReference: eventReference),
+            UserInfoMenu(
+              eventReference: eventReference,
+              showNotInterested: false,
+            ),
         ],
       ),
       body: Column(

--- a/lib/app/features/feed/views/pages/post_details_page/post_details_page.dart
+++ b/lib/app/features/feed/views/pages/post_details_page/post_details_page.dart
@@ -65,6 +65,7 @@ class PostDetailsPage extends HookConsumerWidget {
                         isTextSelectable: true,
                         bodyMaxLines: null,
                         displayParent: true,
+                        showNotInterested: false,
                       ),
                     ),
                     const SliverToBoxAdapter(child: SectionSeparator()),

--- a/lib/app/features/user/pages/profile_page/components/tabs/tab_entities_list.dart
+++ b/lib/app/features/user/pages/profile_page/components/tabs/tab_entities_list.dart
@@ -44,6 +44,7 @@ class TabEntitiesList extends HookConsumerWidget {
             .map((entity) => IonEntityListItem.event(eventReference: entity.toEventReference()))
             .toList(),
         displayParent: true,
+        showNotInterested: false,
       ),
     );
   }
@@ -98,6 +99,7 @@ class TabEntitiesList extends HookConsumerWidget {
                       )
                       .toList(),
                   showMuted: true,
+                  showNotInterested: false,
                   onVideoTap: ({
                     required String eventReference,
                     required int initialMediaIndex,


### PR DESCRIPTION
## Description
- Don't show `not interested` context menu option for posts in articles in those cases:
1. from a user profile feed;
2. from post or article details page;

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

https://github.com/user-attachments/assets/ded011f1-75e6-497b-9c66-7e9f0c45c7dc


## Screenshots (if applicable)

