### PR TITLE
fix: user already exists error match

### DIFF
--- a/packages/ion_identity_client/lib/src/core/types/ion_exception.dart
+++ b/packages/ion_identity_client/lib/src/core/types/ion_exception.dart
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: ice License 1.0
 
+import 'dart:convert';
+
 import 'package:dio/dio.dart';
 
 abstract class IONIdentityException implements Exception {
@@ -86,10 +88,15 @@ class UserAlreadyExistsException extends IONIdentityException {
   const UserAlreadyExistsException() : super('User already exists');
 
   static bool isMatch(DioException dioException) {
-    final responseData = dioException.response?.data;
+    // Backward compatibility with old response format (String)
+    final responseData = switch (dioException.response?.data) {
+      final Map<String, dynamic> mapData => mapData,
+      final String stringData => jsonDecode(stringData) as Map<String, dynamic>,
+      _ => null,
+    };
 
     try {
-      if (responseData is Map<String, dynamic>) {
+      if (responseData != null) {
         final error = responseData['error'] as Map<String, dynamic>?;
         if (error == null) return false;
 


### PR DESCRIPTION
## Description
This PR fixes UserAlreadyExistsException.isMatch method

## Task ID
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
