### PR TITLE
fix: hashtag parsing

### DIFF
--- a/lib/app/services/text_parser/model/text_matcher.dart
+++ b/lib/app/services/text_parser/model/text_matcher.dart
@@ -19,7 +19,7 @@ class HashtagMatcher extends TextMatcher {
   const HashtagMatcher();
 
   @override
-  String get pattern => r'#[A-Za-z0-9_\u00C0-\u017F\u0400-\u04FF\u4E00-\u9FFF\uAC00-\uD7AF\u3040-\u309F\u30A0-\u30FF]+[!+]?';
+  String get pattern => r'#[A-Za-z0-9_\u0400-\u04FF]+(?:[!+](?![A-Za-z0-9_\u0400-\u04FF]))?';
 }
 
 class UrlMatcher extends TextMatcher {

--- a/test/services/text_parser/text_parser_test.dart
+++ b/test/services/text_parser/text_parser_test.dart
@@ -236,6 +236,9 @@ void main() {
       (input: '#онлайн+', expected: '#онлайн+'),
       (input: '#tag_name.', expected: '#tag_name'),
       (input: '#tag!', expected: '#tag!'),
+      (input: '#tag,', expected: '#tag'),
+      (input: '#tag,g123!', expected: '#tag'),
+      (input: '#tag!g123,', expected: '#tag'),
     ], (t) {
       test('should parse "${t.input}" -> ${t.expected}', () {
         final results = parser.parse(t.input, onlyMatches: true);


### PR DESCRIPTION
## Description
fix hashtag regex 

## Additional Notes
We shouldn't allow any symbols except letters, numbers and underscore. We also support Cyrillic. Hash tag also should have option for + or ! in the end

## Task ID
ION-4091

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
