### PR TITLE
fix: keep user metadata alive for stories

### DIFF
--- a/lib/app/features/feed/views/pages/feed_page/components/stories/components/story_list.dart
+++ b/lib/app/features/feed/views/pages/feed_page/components/stories/components/story_list.dart
@@ -5,6 +5,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/screen_offset/screen_side_offset.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/auth/providers/auth_provider.m.dart';
+import 'package:ion/app/features/components/entities_list/list_cached_objects.dart';
 import 'package:ion/app/features/feed/create_post/model/create_post_option.dart';
 import 'package:ion/app/features/feed/create_post/providers/create_post_notifier.m.dart';
 import 'package:ion/app/features/feed/stories/providers/feed_stories_provider.r.dart';
@@ -31,21 +32,23 @@ class StoryList extends ConsumerWidget {
 
     return SliverPadding(
       padding: EdgeInsets.symmetric(horizontal: ScreenSideOffset.defaultSmallMargin),
-      sliver: SliverList.builder(
-        itemCount: filteredPubkeys.length + 1,
-        itemBuilder: (_, index) {
-          if (index == 0) {
-            return CurrentUserStoryListItem(
-              gradient: storyBorderGradients.first,
-            );
-          }
+      sliver: ListCachedObjectsWrapper(
+        child: SliverList.builder(
+          itemCount: filteredPubkeys.length + 1,
+          itemBuilder: (_, index) {
+            if (index == 0) {
+              return CurrentUserStoryListItem(
+                gradient: storyBorderGradients.first,
+              );
+            }
 
-          final pubkey = filteredPubkeys[index - 1];
-          return StoryListItem(
-            key: Key('story_list_item_$pubkey'),
-            pubkey: pubkey,
-          );
-        },
+            final pubkey = filteredPubkeys[index - 1];
+            return StoryListItem(
+              key: Key('story_list_item_$pubkey'),
+              pubkey: pubkey,
+            );
+          },
+        ),
       ),
     );
   }

--- a/lib/app/features/feed/views/pages/feed_page/components/stories/components/story_list_item.dart
+++ b/lib/app/features/feed/views/pages/feed_page/components/stories/components/story_list_item.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/extensions/extensions.dart';
+import 'package:ion/app/features/components/entities_list/list_cached_objects.dart';
 import 'package:ion/app/features/feed/stories/providers/feed_stories_provider.r.dart';
 import 'package:ion/app/features/feed/stories/providers/viewed_stories_provider.r.dart';
 import 'package:ion/app/features/feed/views/pages/feed_page/components/stories/components/story_item_content.dart';
@@ -13,6 +14,7 @@ import 'package:ion/app/features/feed/views/pages/feed_page/components/stories/c
 import 'package:ion/app/features/feed/views/pages/feed_page/components/stories/components/story_list_separator.dart';
 import 'package:ion/app/features/feed/views/pages/feed_page/components/stories/hooks/use_preload_story_media.dart';
 import 'package:ion/app/features/feed/views/pages/feed_page/components/stories/mock.dart';
+import 'package:ion/app/features/user/model/user_metadata.f.dart';
 import 'package:ion/app/features/user/providers/user_metadata_provider.r.dart';
 import 'package:ion/app/router/app_routes.gr.dart';
 
@@ -26,7 +28,16 @@ class StoryListItem extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final userMetadata = ref.watch(userMetadataProvider(pubkey)).valueOrNull;
+    final userMetadata = ref.watch(
+          userMetadataProvider(pubkey).select((value) {
+            final entity = value.valueOrNull;
+            if (entity != null) {
+              ListCachedObjects.updateObject<UserMetadataEntity>(context, entity);
+            }
+            return entity;
+          }),
+        ) ??
+        ListCachedObjects.maybeObjectOf<UserMetadataEntity>(context, pubkey);
     final userStory = ref.watch(feedStoriesByPubkeyProvider(pubkey, showOnlySelectedUser: true));
     final storyReference = userStory.firstOrNull?.toEventReference();
 


### PR DESCRIPTION
## Description
- user metadata provider gets disposed when scrolled and that causes glitches when scrolling back

## Task ID
ION-4056

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)


https://github.com/user-attachments/assets/48fa6401-4b02-4db1-95e6-39a3f0245b25

