### PR TITLE
fix:remove redundant separator on chas page

### DIFF
--- a/lib/app/features/chat/recent_chats/views/pages/recent_chats_timeline_page/recent_chats_timeline_page.dart
+++ b/lib/app/features/chat/recent_chats/views/pages/recent_chats_timeline_page/recent_chats_timeline_page.dart
@@ -212,7 +212,8 @@ class ConversationList extends ConsumerWidget {
                   conversation: conversation,
                   key: ValueKey(conversation.conversationId),
                 ),
-              const HorizontalSeparator(), // Add separator after each item
+              if (index < conversations.length - 1)
+                const HorizontalSeparator(), // Add separator after each item except the last one
             ],
           );
         },


### PR DESCRIPTION
## Description
There was doubling of the separator

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
<!-- Add corresponding task ID here. -->

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<img width="1170" height="2532" alt="IMG_0941" src="https://github.com/user-attachments/assets/dc995e30-b746-4f29-9d39-753ba2bf329d" />
<img width="1170" height="2532" alt="IMG_0940" src="https://github.com/user-attachments/assets/c6d4467c-431b-4ef6-a594-586423935543" />

