### PR TITLE
chore: change video compression profile from default high to main

### DIFF
--- a/lib/app/services/compressors/video_compressor.r.dart
+++ b/lib/app/services/compressors/video_compressor.r.dart
@@ -24,6 +24,7 @@ import 'package:ion/app/services/media_service/ffmpeg_args/ffmpeg_pixel_format_a
 import 'package:ion/app/services/media_service/ffmpeg_args/ffmpeg_preset_arg.dart';
 import 'package:ion/app/services/media_service/ffmpeg_args/ffmpeg_scale_arg.dart';
 import 'package:ion/app/services/media_service/ffmpeg_args/ffmpeg_video_codec_arg.dart';
+import 'package:ion/app/services/media_service/ffmpeg_args/ffmpeg_video_profile.dart';
 import 'package:ion/app/services/media_service/ffmpeg_commands_config.dart';
 import 'package:ion/app/services/media_service/media_service.m.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -42,6 +43,7 @@ class VideoCompressionSettings {
     required this.audioBitrate,
     required this.pixelFormat,
     required this.movFlags,
+    required this.profile,
     this.videoBitrate,
   });
 
@@ -56,6 +58,7 @@ class VideoCompressionSettings {
     audioBitrate: FfmpegAudioBitrateArg.medium,
     pixelFormat: FfmpegPixelFormatArg.yuv420p,
     movFlags: FfmpegMovFlagArg.faststart,
+    profile: FfmpegProfileArg.main,
   );
 
   final FFmpegVideoCodecArg videoCodec;
@@ -69,6 +72,7 @@ class VideoCompressionSettings {
   final FfmpegPixelFormatArg pixelFormat;
   final FfmpegMovFlagArg movFlags;
   final FfmpegBitrateArg? videoBitrate;
+  final FfmpegProfileArg profile;
 }
 
 // Video duration threshold for using hardware compression
@@ -140,6 +144,7 @@ class VideoCompressor implements Compressor<VideoCompressionSettings> {
         pixelFormat: settings.pixelFormat.name,
         scaleResolution: settings.scale.resolution,
         movFlags: settings.movFlags.value,
+        profile: settings.profile.value,
       );
 
       final session = await compressExecutor.execute(

--- a/lib/app/services/media_service/ffmpeg_args/ffmpeg_video_profile.dart
+++ b/lib/app/services/media_service/ffmpeg_args/ffmpeg_video_profile.dart
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: ice License 1.0
+
+enum FfmpegProfileArg {
+  baseline(name: 'Baseline', value: 'baseline'),
+  main(name: 'Main', value: 'main'),
+  high(name: 'High', value: 'high'),
+  high10(name: 'High 10', value: 'high10'),
+  high422(name: 'High 4:2:2', value: 'high422'),
+  high444(name: 'High 4:4:4', value: 'high444');
+
+  const FfmpegProfileArg({
+    required this.name,
+    required this.value,
+  });
+
+  final String name;
+  final String value;
+}

--- a/lib/app/services/media_service/ffmpeg_commands_config.dart
+++ b/lib/app/services/media_service/ffmpeg_commands_config.dart
@@ -17,6 +17,7 @@ class FFmpegCommands {
     required String scaleResolution,
     required String movFlags,
     required String crf,
+    required String profile,
   }) {
     return [
       '-i',
@@ -31,6 +32,8 @@ class FFmpegCommands {
       maxRate,
       '-bufsize',
       bufSize,
+      '-profile:v',
+      profile,
       '-movflags',
       movFlags,
       '-codec:a',


### PR DESCRIPTION
## Description
This PR changes ffmpeg video compression h.264 codec profile from default `high` to `main` that is supported by wider range of devices.

## Additional Notes
Initial Error:
```
PlatformException(VideoError, Video player had error x1.i: MediaCodecVideoRenderer error, index=0, format=Format(1, null, video/mp4, video/avc, avc1.64001F, -1, null, [608, 1080, 25.000002, ColorInfo(BT709, Limited range, SDR SMPTE 170M, false, 8bit Luma, 8bit Chroma)], [-1, -1]), format_supported=YES, null, null)
```

## Task ID
ION-3834

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [x] Chore
