### PR TITLE
fix: prohibit embeding special attributes

### DIFF
--- a/lib/app/components/text_editor/utils/links_handler.dart
+++ b/lib/app/components/text_editor/utils/links_handler.dart
@@ -3,6 +3,7 @@
 import 'dart:async';
 
 import 'package:flutter_quill/flutter_quill.dart';
+import 'package:ion/app/components/text_editor/utils/quill_text_utils.dart';
 import 'package:ion/app/components/text_editor/utils/text_editor_typing_listener.dart';
 import 'package:ion/app/services/text_parser/model/text_matcher.dart';
 
@@ -17,6 +18,7 @@ class LinksHandler extends TextEditorTypingListener {
   final _urlMatcher = const UrlMatcher();
   bool _isFormatting = false;
   Timer? _debounceTimer;
+
   // Track last processed text to avoid formatting on selection-only changes
   String? _lastProcessedText;
 
@@ -47,41 +49,50 @@ class LinksHandler extends TextEditorTypingListener {
 
   void _formatLinks(String text) {
     _isFormatting = true;
-    // Remove only existing link attributes
-    final deltaOps = controller.document.toDelta().toList();
-    var offset = 0;
-    for (final op in deltaOps) {
-      final attrs = op.attributes;
-      final len = op.data is String ? (op.data! as String).length : 1;
-      // Remove only auto-detected links (marked by autoLink) so manual links assigned with add link flow stay intact
-      if (attrs != null && attrs.containsKey(Attribute.link.key) && attrs.containsKey('autoLink')) {
-        controller
-          ..formatText(
-            offset,
-            len,
-            Attribute.clone(Attribute.link, null),
-          )
-          ..formatText(
-            offset,
-            len,
-            _clearAutoLinkAttr,
-          );
+    try {
+      // Remove only existing link attributes
+      final deltaOps = controller.document.toDelta().toList();
+      var offset = 0;
+      for (final op in deltaOps) {
+        final attrs = op.attributes;
+        final len = op.data is String ? (op.data! as String).length : 1;
+        // Remove only auto-detected links (marked by autoLink) so manual links assigned with add link flow stay intact
+        if (attrs != null &&
+            attrs.containsKey(Attribute.link.key) &&
+            attrs.containsKey('autoLink')) {
+          controller
+            ..formatText(
+              offset,
+              len,
+              Attribute.clone(Attribute.link, null),
+            )
+            ..formatText(
+              offset,
+              len,
+              _clearAutoLinkAttr,
+            );
+        }
+        offset += len;
       }
-      offset += len;
-    }
 
-    final matches = RegExp(_urlMatcher.pattern).allMatches(text);
-    for (final match in matches) {
-      final url = match.group(0);
-      if (url == null) continue;
-      controller
-        ..formatText(match.start, match.end - match.start, LinkAttribute(url))
-        ..formatText(
-          match.start,
-          match.end - match.start,
-          _autoLinkAttr,
-        );
+      final matches = RegExp(_urlMatcher.pattern).allMatches(text);
+      for (final match in matches) {
+        final url = match.group(0);
+        if (url == null) continue;
+
+        final start = match.start;
+        final length = match.end - match.start;
+
+        if (QuillTextUtils.rangeOverlapsOpsWithAttributes(deltaOps, start, length)) {
+          continue;
+        }
+
+        controller
+          ..formatText(start, length, LinkAttribute(url))
+          ..formatText(start, length, _autoLinkAttr);
+      }
+    } finally {
+      _isFormatting = false;
     }
-    _isFormatting = false;
   }
 }

--- a/test/services/text_parser/text_parser_test.dart
+++ b/test/services/text_parser/text_parser_test.dart
@@ -29,14 +29,14 @@ void main() {
     });
 
     test('should parse mentions with dots correctly', () {
-      final results = parser.parse('Hello @user.1 and @user.2');
+      final results = parser.parse('Hello @bacchus.1 and @bacchus.ice');
 
       expect(results.length, equals(4));
       expect(results[0].text, equals('Hello '));
-      expect(results[1].text, equals('@user.1'));
+      expect(results[1].text, equals('@bacchus.1'));
       expect(results[1].matcher, isA<MentionMatcher>());
       expect(results[2].text, equals(' and '));
-      expect(results[3].text, equals('@user.2'));
+      expect(results[3].text, equals('@bacchus.ice'));
       expect(results[3].matcher, isA<MentionMatcher>());
 
       expect(results.length, 4);


### PR DESCRIPTION
## Description
- Fixed issue when a text like 'Hello @pva.ice' was parsed into such quill delta:
`
[
  {
    "insert": "Hello "
  },
  {
    "insert": "@",
    "attributes": {
      "mention": "nostr:nprofile1qqsx4054h5xmzv7ysm56s6kghctcf3h6lpsnupcu4k0qss38myd6gmcj8u33t"
    }
  },
  {
    "insert": " ",
    "attributes": {
      "link": "pva.ice"
    }
  },
  {
    "insert": " \n"
  }
]
`

Fixed it by prohibiting embedded of special attributes (mention, hashtag, cashtag, link) one into another
On the video there are 2 post. 1st was posted before the fix and second is after.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots

https://github.com/user-attachments/assets/6369c777-8357-40bd-ba5f-bc9638097cc9


