### PR TITLE
feat: switch accaunts via push notification

### DIFF
--- a/lib/app/features/auth/providers/auth_provider.m.dart
+++ b/lib/app/features/auth/providers/auth_provider.m.dart
@@ -4,15 +4,20 @@ import 'dart:async';
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:ion/app/extensions/bool.dart';
+import 'package:ion/app/components/message_notification/models/message_notification.f.dart';
+import 'package:ion/app/components/message_notification/providers/message_notification_notifier_provider.r.dart';
+import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/auth/providers/local_passkey_creds_provider.r.dart';
 import 'package:ion/app/features/auth/providers/onboarding_complete_provider.r.dart';
 import 'package:ion/app/features/core/providers/main_wallet_provider.r.dart';
 import 'package:ion/app/features/ion_connect/providers/ion_connect_event_signer_provider.r.dart';
 import 'package:ion/app/features/user/providers/biometrics_provider.r.dart';
+import 'package:ion/app/features/user/providers/user_metadata_provider.r.dart';
+import 'package:ion/app/router/app_routes.gr.dart';
 import 'package:ion/app/services/ion_identity/ion_identity_provider.r.dart';
 import 'package:ion/app/services/sentry/sentry_service.dart';
 import 'package:ion/app/services/storage/local_storage.r.dart';
+import 'package:ion/generated/assets.gen.dart';
 import 'package:ion_identity_client/ion_identity.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -272,6 +277,8 @@ class UserSwitchState with _$UserSwitchState {
 
 @Riverpod(keepAlive: true)
 class UserSwitchInProgress extends _$UserSwitchInProgress {
+  bool _shouldShowPushSwitchNotification = false;
+
   @override
   UserSwitchState build() {
     ref
@@ -290,6 +297,10 @@ class UserSwitchInProgress extends _$UserSwitchInProgress {
           final didSwitchToTargetUser = prev != next && next != null;
           if (state.isSwitchingProgress && didSwitchToTargetUser && !state.isLogoutTriggered) {
             unawaited(_completeSwitchingAfterOnboardingRefresh());
+          }
+
+          if (_shouldShowPushSwitchNotification) {
+            _showPushNotificationAfterSwitching(next);
           }
         },
       );
@@ -317,11 +328,35 @@ class UserSwitchInProgress extends _$UserSwitchInProgress {
     );
   }
 
+  void needToShowPushSwitchNotification() {
+    _shouldShowPushSwitchNotification = true;
+  }
+
   void completeSwitching() {
     if (state.isLogoutTriggered) {
       state = state.copyWith(isLogoutTriggered: false);
     } else {
       state = const UserSwitchState();
     }
+  }
+
+  void _showPushNotificationAfterSwitching(String? identityKeyName) {
+    _shouldShowPushSwitchNotification = false;
+    if (identityKeyName == null) return;
+
+    final userMetadata = ref.read(userMetadataProvider(identityKeyName)).valueOrNull;
+    final username = userMetadata?.data.name ?? identityKeyName;
+
+    final context = rootNavigatorKey.currentContext;
+    final message =
+        (context != null && context.mounted) ? context.i18n.switched_to_username(username) : '';
+    if (message.isEmpty) return;
+
+    ref.read(messageNotificationNotifierProvider.notifier).show(
+          MessageNotification(
+            message: message,
+            icon: Assets.svg.iconCheckSuccess.icon(size: 16.0.s),
+          ),
+        );
   }
 }

--- a/lib/app/features/core/providers/main_wallet_provider.r.dart
+++ b/lib/app/features/core/providers/main_wallet_provider.r.dart
@@ -5,10 +5,15 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/exceptions/exceptions.dart';
 import 'package:ion/app/features/auth/providers/auth_provider.m.dart';
 import 'package:ion/app/features/core/providers/wallets_provider.r.dart';
+import 'package:ion/app/services/ion_identity/ion_identity_provider.r.dart';
+import 'package:ion/app/services/logger/logger.dart';
+import 'package:ion/app/services/storage/local_storage.r.dart';
 import 'package:ion_identity_client/ion_identity.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'main_wallet_provider.r.g.dart';
+
+const _userPubkeyCacheKeyPrefix = 'user_pubkey_';
 
 @riverpod
 Future<Wallet?> mainWallet(Ref ref) async {
@@ -27,4 +32,43 @@ Future<Wallet?> mainWallet(Ref ref) async {
   }
 
   return mainWallet;
+}
+
+@riverpod
+Future<String?> userPubkeyByIdentityKeyName(
+  Ref ref,
+  String identityKeyName,
+) async {
+  if (identityKeyName.isEmpty) {
+    return null;
+  }
+
+  final sharedPrefs = await ref.read(sharedPreferencesFoundationProvider.future);
+  final cacheKey = '$_userPubkeyCacheKeyPrefix$identityKeyName';
+  final cachedPubkey = await sharedPrefs.getString(cacheKey);
+
+  if (cachedPubkey != null && cachedPubkey.isNotEmpty) {
+    return cachedPubkey;
+  }
+
+  try {
+    final ionIdentity = await ref.read(ionIdentityProvider.future);
+    final wallets = await ionIdentity(username: identityKeyName).wallets.getWallets();
+    final mainWallet = wallets.firstWhereOrNull((Wallet wallet) => wallet.name == 'main');
+
+    if (mainWallet != null) {
+      final userPubkey = mainWallet.signingKey.publicKey;
+      await sharedPrefs.setString(cacheKey, userPubkey);
+      return userPubkey;
+    }
+  } catch (error, stackTrace) {
+    Logger.error(
+      error,
+      message: 'Failed to get user pubkey for identity key name: $identityKeyName',
+      stackTrace: stackTrace,
+    );
+    return null;
+  }
+
+  return null;
 }

--- a/lib/app/features/push_notifications/background/firebase_messaging_background_service.dart
+++ b/lib/app/features/push_notifications/background/firebase_messaging_background_service.dart
@@ -146,43 +146,46 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
   final data = await IonConnectPushDataPayload.fromEncoded(
     message.data,
     unwrapGift: (eventMessage) async {
-      final messageContainer = ProviderContainer(
-        observers: [Logger.talkerRiverpodObserver],
-        overrides: [
-          _backgroundCurrentPubkeyOverride(currentUserPubkeyFromStorage),
-          _backgroundIonIdentityOverrideSingleton(),
-          currentUserIonConnectEventSignerProvider.overrideWith((ref) async {
-            final savedIdentityKeyName =
-                await ref.watch(currentIdentityKeyNameStoreProvider.future);
-            if (savedIdentityKeyName != null) {
-              return ref.watch(ionConnectEventSignerProvider(savedIdentityKeyName).future);
-            }
-            return null;
-          }),
-          encryptedMessageServiceProvider.overrideWith((ref) async {
-            final eventSigner = await ref.watch(currentUserIonConnectEventSignerProvider.future);
-
-            if (eventSigner == null) {
-              throw EventSignerNotFoundException();
-            }
-
-            if (currentUserPubkeyFromStorage == null) {
-              throw UserMasterPubkeyNotFoundException();
-            }
-
-            return EncryptedMessageService(
-              eventSigner: eventSigner,
-              currentUserPubkey: currentUserPubkeyFromStorage,
-            );
-          }),
-        ],
-      );
+      ProviderContainer? messageContainer;
       try {
+        if (currentUserPubkeyFromStorage == null) {
+          throw UserMasterPubkeyNotFoundException();
+        }
+
+        messageContainer = ProviderContainer(
+          observers: [Logger.talkerRiverpodObserver],
+          overrides: [
+            _backgroundCurrentPubkeyOverride(currentUserPubkeyFromStorage),
+            _backgroundIonIdentityOverrideSingleton(),
+            currentUserIonConnectEventSignerProvider.overrideWith((ref) async {
+              final savedIdentityKeyName =
+                  await ref.watch(currentIdentityKeyNameStoreProvider.future);
+              if (savedIdentityKeyName != null) {
+                return ref.watch(ionConnectEventSignerProvider(savedIdentityKeyName).future);
+              }
+              return null;
+            }),
+            encryptedMessageServiceProvider.overrideWith((ref) async {
+              final eventSigner = await ref.watch(currentUserIonConnectEventSignerProvider.future);
+
+              if (eventSigner == null) {
+                throw EventSignerNotFoundException();
+              }
+
+              return EncryptedMessageService(
+                eventSigner: eventSigner,
+                currentUserPubkey: currentUserPubkeyFromStorage,
+              );
+            }),
+          ],
+        );
+        final container = messageContainer;
+
         final eventSigner =
-            await messageContainer.read(currentUserIonConnectEventSignerProvider.future);
-        final sealService = await messageContainer.read(ionConnectSealServiceProvider.future);
+            await container.read(currentUserIonConnectEventSignerProvider.future);
+        final sealService = await container.read(ionConnectSealServiceProvider.future);
         final giftWrapService =
-            await messageContainer.read(ionConnectGiftWrapServiceProvider.future);
+            await container.read(ionConnectGiftWrapServiceProvider.future);
 
         if (eventSigner == null) {
           throw EventSignerNotFoundException();
@@ -197,7 +200,7 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
               '☁️ Background push notification verifyDelegation for pubkey: $masterPubkey',
             );
 
-            final delegation = await messageContainer.read(
+            final delegation = await container.read(
               cachedUserDelegationProvider(masterPubkey).future,
             );
 
@@ -209,7 +212,7 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
         final event = await giftUnwrapService.unwrap(eventMessage, validate: false);
         Logger.log('☁️ Background push notification unwrap event: $event');
 
-        final cachedEntity = await messageContainer
+        final cachedEntity = await container
             .read(
               ionConnectDatabaseCacheProvider.notifier,
             )
@@ -234,10 +237,12 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
       } finally {
         // Close ion_cache_database connection to prevent isolate leaks
         try {
-          final cacheService =
-              await messageContainer.read(ionConnectPersistentCacheServiceProvider.future);
-          if (cacheService is IonConnectCacheServiceDriftImpl) {
-            await cacheService.attachedDatabase.close();
+          if (messageContainer != null) {
+            final cacheService =
+                await messageContainer.read(ionConnectPersistentCacheServiceProvider.future);
+            if (cacheService is IonConnectCacheServiceDriftImpl) {
+              await cacheService.attachedDatabase.close();
+            }
           }
         } catch (e, st) {
           Logger.error(
@@ -246,7 +251,7 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
             message: '☁️ Background push notification close db error',
           );
         }
-        messageContainer.dispose();
+        messageContainer?.dispose();
       }
     },
   );
@@ -270,7 +275,6 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
   if (await _shouldSkipMutedNotification(
     data: data,
     currentPubkey: currentUserPubkeyFromStorage,
-    backgroundContainer: backgroundContainer,
   )) {
     Logger.log('☁️ Background push notification: Skipping muted user/conversation');
     backgroundContainer.dispose();
@@ -356,6 +360,18 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
   final body = parsedData?.body ?? message.notification?.body;
 
   if (title == null || body == null) {
+    // Fallback for multi-account case: notification may be encrypted for another account,
+    // so current active account can't decrypt and parse localized content.
+    if (data.event.kind == IonConnectGiftWrapEntity.kind && data.decryptedEvent == null) {
+      final recipientPubkey = _extractEncryptedGiftWrapRecipientPubkey(data);
+      final toLabel = recipientPubkey != null ? _shortPubkey(recipientPubkey) : 'another account';
+      await notificationsService.showNotification(
+        title: 'Encrypted message',
+        body: 'From: encrypted sender. To: $toLabel. Tap to open.',
+        payload: jsonEncode(message.data),
+        conversationStyle: false,
+      );
+    }
     backgroundContainer.dispose();
     return;
   }
@@ -389,7 +405,6 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
 FutureOr<bool> _shouldSkipMutedNotification({
   required IonConnectPushDataPayload data,
   required String? currentPubkey,
-  required ProviderContainer backgroundContainer,
 }) async {
   // Check if this is a gift wrap (chat) notification
   if (data.event.kind != IonConnectGiftWrapEntity.kind) {
@@ -537,6 +552,19 @@ String? _extractCoinIdFromPaymentRequestedTag(EventMessage? decrypted) {
   } catch (_) {
     return null;
   }
+}
+
+String? _extractEncryptedGiftWrapRecipientPubkey(IonConnectPushDataPayload data) {
+  final entity = data.mainEntity;
+  if (entity is! IonConnectGiftWrapEntity || entity.data.relatedPubkeys.isEmpty) {
+    return null;
+  }
+  return entity.data.relatedPubkeys.first.value;
+}
+
+String _shortPubkey(String value) {
+  if (value.length <= 12) return value;
+  return '${value.substring(0, 6)}...${value.substring(value.length - 6)}';
 }
 
 void initFirebaseMessagingBackgroundHandler() {

--- a/lib/app/features/push_notifications/background/firebase_messaging_background_service.dart
+++ b/lib/app/features/push_notifications/background/firebase_messaging_background_service.dart
@@ -18,6 +18,7 @@ import 'package:ion/app/features/chat/recent_chats/providers/money_message_provi
 import 'package:ion/app/features/config/providers/config_repository.r.dart';
 import 'package:ion/app/features/core/providers/app_locale_provider.r.dart';
 import 'package:ion/app/features/core/providers/env_provider.r.dart';
+import 'package:ion/app/features/core/providers/main_wallet_provider.r.dart';
 import 'package:ion/app/features/ion_connect/ion_connect.dart';
 import 'package:ion/app/features/ion_connect/model/event_reference.f.dart';
 import 'package:ion/app/features/ion_connect/model/ion_connect_gift_wrap.f.dart';
@@ -42,6 +43,7 @@ import 'package:ion/app/services/local_notifications/local_notifications.r.dart'
 import 'package:ion/app/services/logger/logger.dart';
 import 'package:ion/app/services/logger/logger_initializer.dart';
 import 'package:ion/app/services/storage/local_storage.r.dart';
+import 'package:ion/generated/app_localizations.dart';
 import 'package:ion_connect_cache/ion_connect_cache.dart';
 import 'package:ion_identity_client/ion_identity.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -181,11 +183,9 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
         );
         final container = messageContainer;
 
-        final eventSigner =
-            await container.read(currentUserIonConnectEventSignerProvider.future);
+        final eventSigner = await container.read(currentUserIonConnectEventSignerProvider.future);
         final sealService = await container.read(ionConnectSealServiceProvider.future);
-        final giftWrapService =
-            await container.read(ionConnectGiftWrapServiceProvider.future);
+        final giftWrapService = await container.read(ionConnectGiftWrapServiceProvider.future);
 
         if (eventSigner == null) {
           throw EventSignerNotFoundException();
@@ -364,7 +364,10 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
     // so current active account can't decrypt and parse localized content.
     if (data.event.kind == IonConnectGiftWrapEntity.kind && data.decryptedEvent == null) {
       final recipientPubkey = _extractEncryptedGiftWrapRecipientPubkey(data);
-      final toLabel = recipientPubkey != null ? _shortPubkey(recipientPubkey) : 'another account';
+      final toLabel = await _resolveRecipientAccountLabelInBackground(
+        backgroundContainer,
+        recipientPubkey,
+      );
       await notificationsService.showNotification(
         title: 'Encrypted message',
         body: 'From: encrypted sender. To: $toLabel. Tap to open.',
@@ -389,9 +392,25 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
     return;
   }
 
+  // When notification is for another local account, append account label.
+  var displayBody = body;
+  final recipientPubkey = data.recipientPubkey;
+  if (recipientPubkey != null &&
+      currentUserPubkeyFromStorage != null &&
+      !data.isRecipient(currentUserPubkeyFromStorage)) {
+    final accountLabel = await _resolveRecipientAccountLabelInBackground(
+      backgroundContainer,
+      recipientPubkey,
+    );
+    final prefs = await backgroundContainer.read(sharedPreferencesFoundationProvider.future);
+    final localeStr = await prefs.getString(AppLocale.localePersistenceKey) ?? 'en';
+    final i18n = lookupI18n(Locale(localeStr));
+    displayBody = '$body ${i18n.notification_for_account(accountLabel)}';
+  }
+
   await notificationsService.showNotification(
     title: title,
-    body: body,
+    body: displayBody,
     payload: jsonEncode(message.data),
     icon: avatar,
     attachment: media,
@@ -457,7 +476,11 @@ bool _shouldSkipOwnGiftWrap({
   if (data.event.kind == IonConnectGiftWrapEntity.kind) {
     final decryptedEvent = data.decryptedEvent;
     if (decryptedEvent != null) {
-      return decryptedEvent.masterPubkey == currentPubkey;
+      // Skip only true self-messages for current account.
+      // If self-sent message is addressed to another local account, keep it.
+      final isSelfMessage = decryptedEvent.masterPubkey == currentPubkey;
+      final isForCurrentUser = data.isRecipient(currentPubkey);
+      return isSelfMessage && isForCurrentUser;
     }
   }
 
@@ -562,9 +585,42 @@ String? _extractEncryptedGiftWrapRecipientPubkey(IonConnectPushDataPayload data)
   return entity.data.relatedPubkeys.first.value;
 }
 
-String _shortPubkey(String value) {
-  if (value.length <= 12) return value;
-  return '${value.substring(0, 6)}...${value.substring(value.length - 6)}';
+/// Tries to resolve recipient pubkey to a local account name (identity key) in background.
+/// Returns identity name if matched, otherwise 'another account'.
+Future<String> _resolveRecipientAccountLabelInBackground(
+  ProviderContainer container,
+  String? recipientPubkey,
+) async {
+  if (recipientPubkey == null) return 'another account';
+
+  try {
+    final resolveContainer = ProviderContainer(
+      observers: [Logger.talkerRiverpodObserver],
+      overrides: [_backgroundIonIdentityOverrideSingleton()],
+    );
+    try {
+      final identitiesIter =
+          await resolveContainer.read(authenticatedIdentityKeyNamesStreamProvider.future);
+      final identities = identitiesIter.toList();
+      if (identities.isEmpty) return 'another account';
+
+      final pubkeyResults = await Future.wait<String?>(
+        identities.map(
+          (String name) => resolveContainer.read(userPubkeyByIdentityKeyNameProvider(name).future),
+        ),
+      );
+      for (var i = 0; i < identities.length; i++) {
+        if (pubkeyResults[i] == recipientPubkey) {
+          return identities[i];
+        }
+      }
+    } finally {
+      resolveContainer.dispose();
+    }
+  } catch (e) {
+    Logger.log('☁️ Background could not resolve recipient label: $e');
+  }
+  return 'another account';
 }
 
 void initFirebaseMessagingBackgroundHandler() {

--- a/lib/app/features/push_notifications/data/models/ion_connect_push_data_payload.f.dart
+++ b/lib/app/features/push_notifications/data/models/ion_connect_push_data_payload.f.dart
@@ -81,9 +81,18 @@ class IonConnectPushDataPayload {
     UserMetadataEntity? userMetadata;
 
     if (parsedEvent.kind == IonConnectGiftWrapEntity.kind) {
-      final result = await unwrapGift(parsedEvent);
-      decryptedEvent = result.$1;
-      userMetadata = result.$2;
+      // Attempt to decrypt GiftWrap message.
+      // If decryption fails (e.g., message encrypted for another user),
+      // this is expected - we leave decryptedEvent = null.
+      // The notification will be shown, but user needs to switch accounts to view content.
+      try {
+        final result = await unwrapGift(parsedEvent);
+        decryptedEvent = result.$1;
+        userMetadata = result.$2;
+      } catch (_) {
+        decryptedEvent = null;
+        userMetadata = null;
+      }
     }
 
     return IonConnectPushDataPayload._(
@@ -116,6 +125,47 @@ class IonConnectPushDataPayload {
     }
 
     return false;
+  }
+
+  bool isRecipient(String pubkey) {
+    return recipientPubkey == pubkey;
+  }
+
+  String? get recipientPubkey => _resolveMainEventRecipientPubkey();
+
+  String? _resolveMainEventRecipientPubkey() {
+    final entity = mainEntity;
+
+    return switch (entity) {
+      ReactionEntity() => entity.data.eventReference.masterPubkey,
+      RepostEntity() => entity.data.eventReference.masterPubkey,
+      GenericRepostEntity() => entity.data.eventReference.masterPubkey,
+      ModifiablePostEntity() => () {
+          final relatedPubkeys = entity.data.relatedPubkeys;
+          if (relatedPubkeys != null && relatedPubkeys.isNotEmpty) {
+            return relatedPubkeys.first.value;
+          }
+          final quotedEvent = entity.data.quotedEvent;
+          return quotedEvent?.eventReference.masterPubkey;
+        }(),
+      PostEntity() => () {
+          final relatedPubkeys = entity.data.relatedPubkeys;
+          if (relatedPubkeys != null && relatedPubkeys.isNotEmpty) {
+            return relatedPubkeys.first.value;
+          }
+          final quotedEvent = entity.data.quotedEvent;
+          return quotedEvent?.eventReference.masterPubkey;
+        }(),
+      FollowListEntity() => entity.masterPubkeys.lastOrNull,
+      IonConnectGiftWrapEntity() => () {
+          final relatedPubkeys = entity.data.relatedPubkeys;
+          if (relatedPubkeys.isNotEmpty) {
+            return relatedPubkeys.first.value;
+          }
+          return null;
+        }(),
+      _ => entity.masterPubkey,
+    };
   }
 
   Future<PushNotificationType?> getNotificationType({

--- a/lib/app/features/push_notifications/providers/foreground_messages_handler_provider.r.dart
+++ b/lib/app/features/push_notifications/providers/foreground_messages_handler_provider.r.dart
@@ -137,10 +137,24 @@ class ForegroundMessagesHandler extends _$ForegroundMessagesHandler {
         return;
       }
 
+      // When notification is for another local account, append account label so user can tell.
+      var displayBody = body;
+      final recipientPubkey = data.recipientPubkey;
+      if (recipientPubkey != null &&
+          currentPubkey != null &&
+          !data.isRecipient(currentPubkey)) {
+        final accountLabel = await _resolveRecipientAccountLabel(recipientPubkey);
+        final context = rootNavigatorKey.currentContext;
+        if (accountLabel != null && context != null && context.mounted) {
+          final suffix = context.i18n.notification_for_account(accountLabel);
+          displayBody = '$body $suffix';
+        }
+      }
+
       final notificationsService = await ref.read(localNotificationsServiceProvider.future);
       await notificationsService.showNotification(
         title: title,
-        body: body,
+        body: displayBody,
         payload: jsonEncode(response.data),
         icon: avatar,
         attachment: media,
@@ -191,8 +205,12 @@ class ForegroundMessagesHandler extends _$ForegroundMessagesHandler {
       }
 
       if (data.decryptedEvent != null) {
-        // Skip if message is from current user (self-message)
-        return data.decryptedEvent!.masterPubkey == currentPubkey;
+        // Skip only true self-messages for the current account.
+        // If message is sent by current account but addressed to another local account,
+        // we should still show fallback notification to allow account switch.
+        final isSelfMessage = data.decryptedEvent!.masterPubkey == currentPubkey;
+        final isForCurrentUser = data.isRecipient(currentPubkey);
+        return isSelfMessage && isForCurrentUser;
       }
 
       // If decryptedEvent is null, message is encrypted for another user - show notification
@@ -269,7 +287,7 @@ class ForegroundMessagesHandler extends _$ForegroundMessagesHandler {
     }
 
     final recipientPubkey = entity.data.relatedPubkeys.first.value;
-    var recipientLabel = _shortPubkey(recipientPubkey);
+    var recipientLabel = 'another account';
     final recipientProfileName = await _resolveRecipientProfileName(recipientPubkey);
     if (recipientProfileName != null) {
       recipientLabel = recipientProfileName;
@@ -298,6 +316,35 @@ class ForegroundMessagesHandler extends _$ForegroundMessagesHandler {
     );
   }
 
+  /// Resolves a human-readable label for the account (recipient pubkey).
+  /// Prefers displayName/username from metadata, or identity key name if it's a local account.
+  Future<String?> _resolveRecipientAccountLabel(String recipientPubkey) async {
+    final profileName = await _resolveRecipientProfileName(recipientPubkey);
+    if (profileName != null && profileName.isNotEmpty) {
+      return profileName;
+    }
+
+    final authState = await ref.read(authProvider.future);
+    final identities = authState.authenticatedIdentityKeyNames;
+    if (identities.isEmpty) {
+      return 'another account';
+    }
+
+    final pubkeyResults = await Future.wait(
+      identities.map(
+        (identityKeyName) =>
+            ref.read(userPubkeyByIdentityKeyNameProvider(identityKeyName).future),
+      ),
+    );
+    for (final entry in identities.asMap().entries) {
+      if (pubkeyResults[entry.key] == recipientPubkey) {
+        return entry.value;
+      }
+    }
+
+    return 'another account';
+  }
+
   Future<String?> _resolveRecipientProfileName(String recipientPubkey) async {
     try {
       final metadata = await ref.read(userMetadataProvider(recipientPubkey).future);
@@ -321,8 +368,4 @@ class ForegroundMessagesHandler extends _$ForegroundMessagesHandler {
     return null;
   }
 
-  String _shortPubkey(String value) {
-    if (value.length <= 12) return value;
-    return '${value.substring(0, 6)}...${value.substring(value.length - 6)}';
-  }
 }

--- a/lib/app/features/push_notifications/providers/foreground_messages_handler_provider.r.dart
+++ b/lib/app/features/push_notifications/providers/foreground_messages_handler_provider.r.dart
@@ -140,9 +140,7 @@ class ForegroundMessagesHandler extends _$ForegroundMessagesHandler {
       // When notification is for another local account, append account label so user can tell.
       var displayBody = body;
       final recipientPubkey = data.recipientPubkey;
-      if (recipientPubkey != null &&
-          currentPubkey != null &&
-          !data.isRecipient(currentPubkey)) {
+      if (recipientPubkey != null && currentPubkey != null && !data.isRecipient(currentPubkey)) {
         final accountLabel = await _resolveRecipientAccountLabel(recipientPubkey);
         final context = rootNavigatorKey.currentContext;
         if (accountLabel != null && context != null && context.mounted) {
@@ -298,7 +296,8 @@ class ForegroundMessagesHandler extends _$ForegroundMessagesHandler {
     if (identities.isNotEmpty) {
       final pubkeyResults = await Future.wait(
         identities.map(
-          (identityKeyName) => ref.read(userPubkeyByIdentityKeyNameProvider(identityKeyName).future),
+          (identityKeyName) =>
+              ref.read(userPubkeyByIdentityKeyNameProvider(identityKeyName).future),
         ),
       );
 
@@ -332,8 +331,7 @@ class ForegroundMessagesHandler extends _$ForegroundMessagesHandler {
 
     final pubkeyResults = await Future.wait(
       identities.map(
-        (identityKeyName) =>
-            ref.read(userPubkeyByIdentityKeyNameProvider(identityKeyName).future),
+        (identityKeyName) => ref.read(userPubkeyByIdentityKeyNameProvider(identityKeyName).future),
       ),
     );
     for (final entry in identities.asMap().entries) {
@@ -367,5 +365,4 @@ class ForegroundMessagesHandler extends _$ForegroundMessagesHandler {
 
     return null;
   }
-
 }

--- a/lib/app/features/push_notifications/providers/foreground_messages_handler_provider.r.dart
+++ b/lib/app/features/push_notifications/providers/foreground_messages_handler_provider.r.dart
@@ -9,6 +9,7 @@ import 'package:ion/app/features/auth/providers/auth_provider.m.dart';
 import 'package:ion/app/features/chat/e2ee/providers/gift_unwrap_service_provider.r.dart';
 import 'package:ion/app/features/chat/providers/conversation_request_approval_provider.r.dart';
 import 'package:ion/app/features/chat/recent_chats/providers/money_message_provider.r.dart';
+import 'package:ion/app/features/core/providers/main_wallet_provider.r.dart';
 import 'package:ion/app/features/feed/providers/ion_connect_entity_with_counters_provider.r.dart';
 import 'package:ion/app/features/ion_connect/model/ion_connect_gift_wrap.f.dart';
 import 'package:ion/app/features/push_notifications/data/models/ion_connect_push_data_payload.f.dart';
@@ -106,6 +107,18 @@ class ForegroundMessagesHandler extends _$ForegroundMessagesHandler {
       final body = parsedData?.body ?? response.notification?.body;
 
       if (title == null || body == null) {
+        // If push belongs to another account on this device, current account can't decrypt it.
+        // Show generic fallback so user can tap and switch account in notification response handler.
+        if (data.event.kind == IonConnectGiftWrapEntity.kind && data.decryptedEvent == null) {
+          final fallback = await _buildEncryptedGiftWrapFallback(data);
+          final notificationsService = await ref.read(localNotificationsServiceProvider.future);
+          await notificationsService.showNotification(
+            title: fallback.$1,
+            body: fallback.$2,
+            payload: jsonEncode(response.data),
+            conversationStyle: false,
+          );
+        }
         return;
       }
 
@@ -170,16 +183,20 @@ class ForegroundMessagesHandler extends _$ForegroundMessagesHandler {
     required IonConnectPushDataPayload data,
   }) async {
     if (data.event.kind == IonConnectGiftWrapEntity.kind) {
-      final giftUnwrapService = await ref.watch(giftUnwrapServiceProvider.future);
-      final currentPubkey = ref.watch(currentPubkeySelectorProvider);
+      final currentPubkey = ref.read(currentPubkeySelectorProvider);
 
+      // If no user is logged in, skip the notification
       if (currentPubkey == null) {
         return true;
       }
 
-      final rumor = await giftUnwrapService.unwrap(data.event);
+      if (data.decryptedEvent != null) {
+        // Skip if message is from current user (self-message)
+        return data.decryptedEvent!.masterPubkey == currentPubkey;
+      }
 
-      return rumor.masterPubkey == currentPubkey;
+      // If decryptedEvent is null, message is encrypted for another user - show notification
+      return false;
     }
 
     return false;
@@ -243,5 +260,69 @@ class ForegroundMessagesHandler extends _$ForegroundMessagesHandler {
     } catch (_) {
       return false;
     }
+  }
+
+  Future<(String, String)> _buildEncryptedGiftWrapFallback(IonConnectPushDataPayload data) async {
+    final entity = data.mainEntity;
+    if (entity is! IonConnectGiftWrapEntity || entity.data.relatedPubkeys.isEmpty) {
+      return ('Encrypted message', 'Open notification to view');
+    }
+
+    final recipientPubkey = entity.data.relatedPubkeys.first.value;
+    var recipientLabel = _shortPubkey(recipientPubkey);
+    final recipientProfileName = await _resolveRecipientProfileName(recipientPubkey);
+    if (recipientProfileName != null) {
+      recipientLabel = recipientProfileName;
+    }
+
+    final authState = await ref.read(authProvider.future);
+    final identities = authState.authenticatedIdentityKeyNames;
+    if (identities.isNotEmpty) {
+      final pubkeyResults = await Future.wait(
+        identities.map(
+          (identityKeyName) => ref.read(userPubkeyByIdentityKeyNameProvider(identityKeyName).future),
+        ),
+      );
+
+      for (final entry in identities.asMap().entries) {
+        if (pubkeyResults[entry.key] == recipientPubkey) {
+          recipientLabel = recipientProfileName ?? entry.value;
+          break;
+        }
+      }
+    }
+
+    return (
+      'Encrypted message',
+      'From: encrypted sender. To: $recipientLabel. Tap to open.',
+    );
+  }
+
+  Future<String?> _resolveRecipientProfileName(String recipientPubkey) async {
+    try {
+      final metadata = await ref.read(userMetadataProvider(recipientPubkey).future);
+      if (metadata == null) {
+        return null;
+      }
+
+      final displayName = metadata.data.trimmedDisplayName;
+      if (displayName.isNotEmpty) {
+        return displayName;
+      }
+
+      final username = metadata.data.name.trim();
+      if (username.isNotEmpty) {
+        return username;
+      }
+    } catch (_) {
+      // Best-effort name resolution for fallback notification text.
+    }
+
+    return null;
+  }
+
+  String _shortPubkey(String value) {
+    if (value.length <= 12) return value;
+    return '${value.substring(0, 6)}...${value.substring(value.length - 6)}';
   }
 }

--- a/lib/app/features/push_notifications/providers/notification_response_service.r.dart
+++ b/lib/app/features/push_notifications/providers/notification_response_service.r.dart
@@ -9,6 +9,7 @@ import 'package:ion/app/features/auth/providers/auth_provider.m.dart';
 import 'package:ion/app/features/chat/e2ee/model/entities/private_direct_message_data.f.dart';
 import 'package:ion/app/features/chat/e2ee/model/entities/private_message_reaction_data.f.dart';
 import 'package:ion/app/features/chat/e2ee/providers/gift_unwrap_service_provider.r.dart';
+import 'package:ion/app/features/core/providers/main_wallet_provider.r.dart';
 import 'package:ion/app/features/feed/data/models/entities/article_data.f.dart';
 import 'package:ion/app/features/feed/data/models/entities/generic_repost.f.dart';
 import 'package:ion/app/features/feed/data/models/entities/modifiable_post_data.f.dart';
@@ -50,13 +51,21 @@ class NotificationResponseService {
     required String? currentPubkey,
     required AppsFlyerDeepLinkService appsflyerDeepLinkService,
     required InternalDeepLinkService internalDeepLinkService,
+    required Future<AuthState> Function() getAuthState,
+    required Future<void> Function(String identityKeyName) setCurrentUser,
+    required void Function() markShowNotificationAfterSwitchingAcc,
+    required Future<String?> Function(String identityKeyName) userPubkeyByIdentityKeyName,
   })  : _getGiftUnwrapService = getGiftUnwrapService,
         _getUserMetadata = getUserMetadata,
         _getEntityData = getEntityData,
         _eventParser = eventParser,
         _currentPubkey = currentPubkey,
         _appsflyerDeepLinkService = appsflyerDeepLinkService,
-        _internalDeepLinkService = internalDeepLinkService;
+        _internalDeepLinkService = internalDeepLinkService,
+        _getAuthState = getAuthState,
+        _setCurrentUser = setCurrentUser,
+        _markShowNotificationAfterSwitchingAcc = markShowNotificationAfterSwitchingAcc,
+        _userPubkeyByIdentityKeyName = userPubkeyByIdentityKeyName;
 
   /// Key for the deep link parameter in push notification payloads
   static const String deepLinkKey = 'deeplink';
@@ -68,6 +77,10 @@ class NotificationResponseService {
   final String? _currentPubkey;
   final AppsFlyerDeepLinkService _appsflyerDeepLinkService;
   final InternalDeepLinkService _internalDeepLinkService;
+  final Future<AuthState> Function() _getAuthState;
+  final Future<void> Function(String identityKeyName) _setCurrentUser;
+  final void Function() _markShowNotificationAfterSwitchingAcc;
+  final Future<String?> Function(String identityKeyName) _userPubkeyByIdentityKeyName;
 
   /// Checks if any modal is open and closes it before navigation
   void _checkModal() {
@@ -80,6 +93,16 @@ class NotificationResponseService {
         // there's no animation for popUntil, so no need to delay
         Navigator.of(context).popUntil((Route<dynamic> route) => route.isFirst);
       }
+    }
+  }
+
+  void _closeAllModalsAndNavigateToHomeFeed() {
+    final context = _getNavigatorContext();
+    if (context != null) {
+      if (context.canPop()) {
+        Navigator.of(context).popUntil((Route<dynamic> route) => route.isFirst);
+      }
+      FeedRoute().go(context);
     }
   }
 
@@ -143,6 +166,8 @@ class NotificationResponseService {
       );
 
       final entity = _eventParser.parse(notificationPayload.event);
+
+      await _switchToRecipientUserForEntity(notificationPayload);
 
       _checkModal();
 
@@ -230,6 +255,43 @@ class NotificationResponseService {
       }
     } catch (error, stackTrace) {
       Logger.error(error, stackTrace: stackTrace, message: 'Error handling notification response');
+    }
+  }
+
+  Future<void> _switchToRecipientUserForEntity(
+    IonConnectPushDataPayload notificationPayload,
+  ) async {
+    if (_currentPubkey != null && notificationPayload.isRecipient(_currentPubkey)) {
+      return;
+    }
+
+    _closeAllModalsAndNavigateToHomeFeed();
+
+    final recipientPubkey = notificationPayload.recipientPubkey;
+    if (recipientPubkey == null) {
+      return;
+    }
+
+    final authState = await _getAuthState();
+    final authenticatedIdentityKeyNames = authState.authenticatedIdentityKeyNames;
+
+    String? recipientIdentityKeyName;
+
+    final pubkeyResults = await Future.wait(
+      authenticatedIdentityKeyNames.map(_userPubkeyByIdentityKeyName),
+    );
+
+    for (final entry in authenticatedIdentityKeyNames.asMap().entries) {
+      if (pubkeyResults[entry.key] == recipientPubkey) {
+        recipientIdentityKeyName = entry.value;
+        break;
+      }
+    }
+
+    if (recipientIdentityKeyName != null) {
+      _markShowNotificationAfterSwitchingAcc();
+      await _setCurrentUser(recipientIdentityKeyName);
+      await _getAuthState();
     }
   }
 
@@ -464,6 +526,16 @@ NotificationResponseService notificationResponseService(Ref ref) {
   final eventParser = ref.watch(eventParserProvider);
   final appsflyerDeepLinkService = ref.watch(appsflyerDeepLinkServiceProvider);
   final internalDeepLinkService = ref.watch(internalDeepLinkServiceProvider);
+  Future<AuthState> getAuthState() => ref.read(authProvider.future);
+  Future<void> setCurrentUser(String identityKeyName) =>
+      ref.read(authProvider.notifier).setCurrentUser(identityKeyName);
+  void markShowNotificationAfterSwitchingAcc() {
+    ref.read(userSwitchInProgressProvider.notifier).needToShowPushSwitchNotification();
+  }
+
+  Future<String?> getUserPubkeyByIdentityKeyName(String identityKeyName) => ref.read(
+        userPubkeyByIdentityKeyNameProvider(identityKeyName).future,
+      );
 
   return NotificationResponseService(
     getGiftUnwrapService: getGiftUnwrapService,
@@ -473,5 +545,9 @@ NotificationResponseService notificationResponseService(Ref ref) {
     currentPubkey: currentPubkey,
     appsflyerDeepLinkService: appsflyerDeepLinkService,
     internalDeepLinkService: internalDeepLinkService,
+    getAuthState: getAuthState,
+    setCurrentUser: setCurrentUser,
+    markShowNotificationAfterSwitchingAcc: markShowNotificationAfterSwitchingAcc,
+    userPubkeyByIdentityKeyName: getUserPubkeyByIdentityKeyName,
   );
 }

--- a/lib/app/features/push_notifications/providers/push_subscription_sync_provider.r.dart
+++ b/lib/app/features/push_notifications/providers/push_subscription_sync_provider.r.dart
@@ -21,6 +21,7 @@ import 'package:ion/app/features/user/providers/relays/optimal_user_relays_provi
 import 'package:ion/app/features/user/providers/relays/user_relays_manager.r.dart';
 import 'package:ion/app/features/user/providers/user_events_metadata_provider.r.dart';
 import 'package:ion/app/services/device_id/device_id.r.dart';
+import 'package:ion/app/services/logger/logger.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'push_subscription_sync_provider.r.g.dart';
@@ -36,6 +37,9 @@ class PushSubscriptionSync extends _$PushSubscriptionSync {
     if (!authState.isAuthenticated) {
       return;
     }
+
+    // React to user switch and sync push subscription
+    ref.watch(currentIdentityKeyNameSelectorProvider);
 
     final delegationComplete = await ref.watch(delegationCompleteProvider.future);
 
@@ -346,5 +350,45 @@ class PushSubscriptionSync extends _$PushSubscriptionSync {
     return left.kind == right.kind &&
         left.content == right.content &&
         left.tags.equalsDeep(right.tags);
+  }
+
+  Future<void> deletePushSubscriptionForCurrentUser() async {
+    try {
+      // Use currentUserPushSubscriptionProvider since user is still active before logout
+      final subscription = await ref.read(currentUserPushSubscriptionProvider.future);
+
+      if (subscription == null) {
+        return;
+      }
+
+      final data = subscription.data;
+      if (data is! PushSubscriptionOwnData) {
+        return;
+      }
+
+      // First, update subscription with empty filters (same as when unsubscribing from all categories)
+      final relayUrl = data.relay.url;
+      final emptyFiltersSubscription = data.copyWith(
+        filters: <RequestFilter>[],
+        filterEvents: <EventMessage>[],
+      );
+
+      await ref.read(ionConnectNotifierProvider.notifier).sendEntityData(
+            emptyFiltersSubscription,
+            actionSource: ActionSourceRelayUrl(relayUrl),
+          );
+
+      await ref.read(ionConnectNotifierProvider.notifier).sendEntityData(
+            _buildDeletePushSubscriptionOwnData(subscription),
+            cache: false,
+          );
+      ref.read(ionConnectCacheProvider.notifier).remove(subscription.cacheKey);
+    } catch (error, stackTrace) {
+      Logger.error(
+        error,
+        message: 'Failed to delete current user push subscription',
+        stackTrace: stackTrace,
+      );
+    }
   }
 }

--- a/lib/app/features/user/providers/force_account_security_notifier.r.dart
+++ b/lib/app/features/user/providers/force_account_security_notifier.r.dart
@@ -88,6 +88,7 @@ class ForceAccountSecurityService {
   }
 
   void _maybeTrigger() {
+    return;
     if (!_hasNavigatorContext()) return;
 
     if (_metadata == null) return;

--- a/lib/app/features/user/providers/force_account_security_notifier.r.dart
+++ b/lib/app/features/user/providers/force_account_security_notifier.r.dart
@@ -88,7 +88,6 @@ class ForceAccountSecurityService {
   }
 
   void _maybeTrigger() {
-    return;
     if (!_hasNavigatorContext()) return;
 
     if (_metadata == null) return;

--- a/lib/app/services/local_notifications/local_notifications.r.dart
+++ b/lib/app/services/local_notifications/local_notifications.r.dart
@@ -61,20 +61,38 @@ class LocalNotificationsService {
     String? groupKey,
     bool conversationStyle = true,
   }) async {
+    final details = conversationStyle
+        ? await _buildNotificationDetails(
+            avatarUrl: icon,
+            attachmentUrl: attachment,
+            userName: title,
+            textMessage: body,
+            groupKey: groupKey,
+          )
+        : _buildSimpleNotificationDetails();
     await _plugin.show(
       generateUuid().hashCode,
       title,
       body,
-      conversationStyle
-          ? await _buildNotificationDetails(
-              avatarUrl: icon,
-              attachmentUrl: attachment,
-              userName: title,
-              textMessage: body,
-              groupKey: groupKey,
-            )
-          : null,
+      details,
       payload: payload,
+    );
+  }
+
+  /// Minimal notification details for campaigns / fallbacks.
+  /// Passing null to _plugin.show() causes NPE in setupNotificationChannel on Android.
+  NotificationDetails _buildSimpleNotificationDetails() {
+    const androidDetails = AndroidNotificationDetails(
+      'ion_miscellaneous',
+      'Miscellaneous',
+      importance: Importance.max,
+      priority: Priority.high,
+    );
+    const darwinDetails = DarwinNotificationDetails();
+    return const NotificationDetails(
+      android: androidDetails,
+      iOS: darwinDetails,
+      macOS: darwinDetails,
     );
   }
 

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -938,6 +938,7 @@
   "token_stats_market_cap_title": "Market Cap",
   "token_stats_volume_description": "يعرض هذا إجمالي كمية الرموز التي تم شراؤها وبيعها خلال 24 ساعة.\n\nعادةً ما يعني النشاط الأعلى اهتمامًا أقوى وسيولة أفضل وتداولًا أسهل.",
   "token_stats_volume_title": "Volume",
+  "notification_for_account": "للحساب: {accountName}",
   "switched_to_username": "تم التبديل إلى {username}",
   "tokenized_communities_top_tokens": "أفضل التوكنات",
   "tokenized_communities_trending_tokens": "التوكنات الرائجة",

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -938,6 +938,7 @@
   "token_stats_market_cap_title": "Market Cap",
   "token_stats_volume_description": "يعرض هذا إجمالي كمية الرموز التي تم شراؤها وبيعها خلال 24 ساعة.\n\nعادةً ما يعني النشاط الأعلى اهتمامًا أقوى وسيولة أفضل وتداولًا أسهل.",
   "token_stats_volume_title": "Volume",
+  "switched_to_username": "تم التبديل إلى {username}",
   "tokenized_communities_top_tokens": "أفضل التوكنات",
   "tokenized_communities_trending_tokens": "التوكنات الرائجة",
   "tokenized_community_bonding_curve": "منحنى الترابط",

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -925,6 +925,7 @@
   "token_stats_market_cap_title": "Market Cap",
   "token_stats_volume_description": "Това показва общия обем на търговията с токени за последните 24 часа.\n\nПо-високата активност обикновено означава по-силен интерес, по-добра ликвидност и по-лесна търговия.",
   "token_stats_volume_title": "Volume",
+  "switched_to_username": "Превключено към {username}",
   "tokenized_communities_top_tokens": "Топ токени",
   "tokenized_communities_trending_tokens": "Популярни токени",
   "tokenized_community_bonding_curve": "Крива на обвързване",

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -925,6 +925,7 @@
   "token_stats_market_cap_title": "Market Cap",
   "token_stats_volume_description": "Това показва общия обем на търговията с токени за последните 24 часа.\n\nПо-високата активност обикновено означава по-силен интерес, по-добра ликвидност и по-лесна търговия.",
   "token_stats_volume_title": "Volume",
+  "notification_for_account": "За акаунт: {accountName}",
   "switched_to_username": "Превключено към {username}",
   "tokenized_communities_top_tokens": "Топ токени",
   "tokenized_communities_trending_tokens": "Популярни токени",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -925,6 +925,7 @@
   "token_stats_market_cap_title": "Market Cap",
   "token_stats_volume_description": "Dies zeigt das gesamte Handelsvolumen der Tokens in den letzten 24 Stunden.\n\nHöhere Aktivität bedeutet meist stärkeres Interesse, bessere Liquidität und einfacheres Trading.",
   "token_stats_volume_title": "Volume",
+  "notification_for_account": "Für Konto: {accountName}",
   "switched_to_username": "Zu {username} gewechselt",
   "tokenized_communities_top_tokens": "Top Tokens",
   "tokenized_communities_trending_tokens": "Trending Tokens",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -925,6 +925,7 @@
   "token_stats_market_cap_title": "Market Cap",
   "token_stats_volume_description": "Dies zeigt das gesamte Handelsvolumen der Tokens in den letzten 24 Stunden.\n\nHöhere Aktivität bedeutet meist stärkeres Interesse, bessere Liquidität und einfacheres Trading.",
   "token_stats_volume_title": "Volume",
+  "switched_to_username": "Zu {username} gewechselt",
   "tokenized_communities_top_tokens": "Top Tokens",
   "tokenized_communities_trending_tokens": "Trending Tokens",
   "tokenized_community_bonding_curve": "Bonding-Kurve",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -925,6 +925,7 @@
   "token_stats_market_cap_title": "Market Cap",
   "token_stats_volume_description": "This shows the total amount of tokens that have been bought and sold during 24h.\n\nHigher activity usually means stronger interest, better liquidity, and easier trading.",
   "token_stats_volume_title": "Volume",
+  "switched_to_username": "Switched to {username}",
   "tokenized_communities_top_tokens": "Top Tokens",
   "tokenized_communities_trending_tokens": "Trending Tokens",
   "tokenized_community_bonding_curve": "Bonding Curve",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -925,6 +925,7 @@
   "token_stats_market_cap_title": "Market Cap",
   "token_stats_volume_description": "This shows the total amount of tokens that have been bought and sold during 24h.\n\nHigher activity usually means stronger interest, better liquidity, and easier trading.",
   "token_stats_volume_title": "Volume",
+  "notification_for_account": "For account: {accountName}",
   "switched_to_username": "Switched to {username}",
   "tokenized_communities_top_tokens": "Top Tokens",
   "tokenized_communities_trending_tokens": "Trending Tokens",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -925,6 +925,7 @@
   "token_stats_market_cap_title": "Market Cap",
   "token_stats_volume_description": "Muestra el volumen total de trading de tokens en las últimas 24 h.\n\nUna mayor actividad suele indicar más interés, mejor liquidez y trading más sencillo.",
   "token_stats_volume_title": "Volume",
+  "notification_for_account": "Para cuenta: {accountName}",
   "switched_to_username": "Cambiado a {username}",
   "tokenized_communities_top_tokens": "Principales tokens",
   "tokenized_communities_trending_tokens": "Tokens en tendencia",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -925,6 +925,7 @@
   "token_stats_market_cap_title": "Market Cap",
   "token_stats_volume_description": "Muestra el volumen total de trading de tokens en las últimas 24 h.\n\nUna mayor actividad suele indicar más interés, mejor liquidez y trading más sencillo.",
   "token_stats_volume_title": "Volume",
+  "switched_to_username": "Cambiado a {username}",
   "tokenized_communities_top_tokens": "Principales tokens",
   "tokenized_communities_trending_tokens": "Tokens en tendencia",
   "tokenized_community_bonding_curve": "Curva de vinculación",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -925,6 +925,7 @@
   "token_stats_market_cap_title": "Market Cap",
   "token_stats_volume_description": "Cela affiche le volume total de trading des tokens sur les dernières 24 h.\n\nUne activité plus élevée signifie généralement un intérêt plus fort, une meilleure liquidité et un trading plus facile.",
   "token_stats_volume_title": "Volume",
+  "notification_for_account": "Pour le compte : {accountName}",
   "switched_to_username": "Passé à {username}",
   "tokenized_communities_top_tokens": "Meilleurs jetons",
   "tokenized_communities_trending_tokens": "Jetons tendance",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -925,6 +925,7 @@
   "token_stats_market_cap_title": "Market Cap",
   "token_stats_volume_description": "Cela affiche le volume total de trading des tokens sur les dernières 24 h.\n\nUne activité plus élevée signifie généralement un intérêt plus fort, une meilleure liquidité et un trading plus facile.",
   "token_stats_volume_title": "Volume",
+  "switched_to_username": "Passé à {username}",
   "tokenized_communities_top_tokens": "Meilleurs jetons",
   "tokenized_communities_trending_tokens": "Jetons tendance",
   "tokenized_community_bonding_curve": "Courbe de liaison",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -925,6 +925,7 @@
   "token_stats_market_cap_title": "Market Cap",
   "token_stats_volume_description": "Mostra il volume totale di trading dei token nelle ultime 24 ore.\n\nUna maggiore attività indica solitamente più interesse, migliore liquidità e trading più semplice.",
   "token_stats_volume_title": "Volume",
+  "notification_for_account": "Per account: {accountName}",
   "switched_to_username": "Passato a {username}",
   "tokenized_communities_top_tokens": "Token principali",
   "tokenized_communities_trending_tokens": "Token di tendenza",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -925,6 +925,7 @@
   "token_stats_market_cap_title": "Market Cap",
   "token_stats_volume_description": "Mostra il volume totale di trading dei token nelle ultime 24 ore.\n\nUna maggiore attività indica solitamente più interesse, migliore liquidità e trading più semplice.",
   "token_stats_volume_title": "Volume",
+  "switched_to_username": "Passato a {username}",
   "tokenized_communities_top_tokens": "Token principali",
   "tokenized_communities_trending_tokens": "Token di tendenza",
   "tokenized_community_bonding_curve": "Curva di vincolo",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -917,6 +917,7 @@
   "story_share_sender": "이 스토리를 공유하셨습니다",
   "suggestions_empty_description": "검색 결과가 없습니다",
   "suggestions_loading_description": "멘션할 사용자를 검색하세요",
+  "notification_for_account": "계정: {accountName}",
   "switched_to_username": "{username}(으)로 전환됨",
   "token_comment_holders_only": "댓글은 토큰 보유자만 이용할 수 있습니다",
   "token_contract": "컨트랙트",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -917,6 +917,7 @@
   "story_share_sender": "이 스토리를 공유하셨습니다",
   "suggestions_empty_description": "검색 결과가 없습니다",
   "suggestions_loading_description": "멘션할 사용자를 검색하세요",
+  "switched_to_username": "{username}(으)로 전환됨",
   "token_comment_holders_only": "댓글은 토큰 보유자만 이용할 수 있습니다",
   "token_contract": "컨트랙트",
   "token_stats_holders_description": "현재 해당 토큰을 보유한 고유 지갑 수를 나타냅니다.\n\n시간이 지남에 따라 꾸준히 증가하면 채택 확대, 커뮤니티 신뢰, 더 넓은 분배를 반영하는 경우가 많습니다.",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -925,6 +925,7 @@
   "token_stats_market_cap_title": "Market Cap",
   "token_stats_volume_description": "Pokazuje łączny wolumen handlu tokenami w ciągu ostatnich 24 h.\n\nWyższa aktywność zwykle oznacza większe zainteresowanie, lepszą płynność i łatwiejszy trading.",
   "token_stats_volume_title": "Volume",
+  "switched_to_username": "Przełączono na {username}",
   "tokenized_communities_top_tokens": "Najlepsze tokeny",
   "tokenized_communities_trending_tokens": "Popularne tokeny",
   "tokenized_community_bonding_curve": "Krzywa wiązania",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -925,6 +925,7 @@
   "token_stats_market_cap_title": "Market Cap",
   "token_stats_volume_description": "Pokazuje łączny wolumen handlu tokenami w ciągu ostatnich 24 h.\n\nWyższa aktywność zwykle oznacza większe zainteresowanie, lepszą płynność i łatwiejszy trading.",
   "token_stats_volume_title": "Volume",
+  "notification_for_account": "Dla konta: {accountName}",
   "switched_to_username": "Przełączono na {username}",
   "tokenized_communities_top_tokens": "Najlepsze tokeny",
   "tokenized_communities_trending_tokens": "Popularne tokeny",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -917,6 +917,7 @@
   "story_share_sender": "Partilhou esta história",
   "suggestions_empty_description": "Não encontrámos nada que corresponda à sua pesquisa",
   "suggestions_loading_description": "Pesquise o utilizador que pretende mencionar",
+  "notification_for_account": "Para conta: {accountName}",
   "switched_to_username": "Mudou para {username}",
   "token_comment_holders_only": "Os comentários estão disponíveis apenas para detentores de tokens.",
   "token_contract": "Contrato",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -917,6 +917,7 @@
   "story_share_sender": "Partilhou esta história",
   "suggestions_empty_description": "Não encontrámos nada que corresponda à sua pesquisa",
   "suggestions_loading_description": "Pesquise o utilizador que pretende mencionar",
+  "switched_to_username": "Mudou para {username}",
   "token_comment_holders_only": "Os comentários estão disponíveis apenas para detentores de tokens.",
   "token_contract": "Contrato",
   "token_stats_holders_description": "Indica quantas carteiras únicas possuem atualmente o token.\n\nUm aumento constante ao longo do tempo reflete frequentemente maior adoção, confiança da comunidade e distribuição mais ampla.",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -925,6 +925,7 @@
   "token_stats_market_cap_title": "Market Cap",
   "token_stats_volume_description": "Afișează volumul total de tranzacționare al tokenurilor în ultimele 24 de ore.\n\nO activitate mai mare înseamnă de obicei un interes mai puternic, lichiditate mai bună și tranzacționare mai ușoară.",
   "token_stats_volume_title": "Volume",
+  "notification_for_account": "Pentru cont: {accountName}",
   "switched_to_username": "Comutat la {username}",
   "tokenized_communities_top_tokens": "Tokenuri de top",
   "tokenized_communities_trending_tokens": "Tokenuri în tendință",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -925,6 +925,7 @@
   "token_stats_market_cap_title": "Market Cap",
   "token_stats_volume_description": "Afișează volumul total de tranzacționare al tokenurilor în ultimele 24 de ore.\n\nO activitate mai mare înseamnă de obicei un interes mai puternic, lichiditate mai bună și tranzacționare mai ușoară.",
   "token_stats_volume_title": "Volume",
+  "switched_to_username": "Comutat la {username}",
   "tokenized_communities_top_tokens": "Tokenuri de top",
   "tokenized_communities_trending_tokens": "Tokenuri în tendință",
   "tokenized_community_bonding_curve": "Curba de legătură",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -925,6 +925,7 @@
   "token_stats_market_cap_title": "Market Cap",
   "token_stats_volume_description": "Показывает общий объём торгов токенами за последние 24 часа.\n\nБолее высокая активность обычно означает больший интерес, лучшую ликвидность и более удобную торговлю.",
   "token_stats_volume_title": "Volume",
+  "switched_to_username": "Переключено на {username}",
   "tokenized_communities_top_tokens": "Топ токенов",
   "tokenized_communities_trending_tokens": "Популярные токены",
   "tokenized_community_bonding_curve": "Кривая бондинга",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -925,6 +925,7 @@
   "token_stats_market_cap_title": "Market Cap",
   "token_stats_volume_description": "Показывает общий объём торгов токенами за последние 24 часа.\n\nБолее высокая активность обычно означает больший интерес, лучшую ликвидность и более удобную торговлю.",
   "token_stats_volume_title": "Volume",
+  "notification_for_account": "Для аккаунта: {accountName}",
   "switched_to_username": "Переключено на {username}",
   "tokenized_communities_top_tokens": "Топ токенов",
   "tokenized_communities_trending_tokens": "Популярные токены",

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -925,6 +925,7 @@
   "token_stats_market_cap_title": "Market Cap",
   "token_stats_volume_description": "Bu, son 24 saat içindeki token işlem hacmini gösterir.\n\nDaha yüksek aktivite genellikle daha güçlü ilgi, daha iyi likidite ve daha kolay işlem anlamına gelir.",
   "token_stats_volume_title": "Volume",
+  "switched_to_username": "{username} hesabına geçildi",
   "tokenized_communities_top_tokens": "En iyi tokenler",
   "tokenized_communities_trending_tokens": "Trend tokenler",
   "tokenized_community_bonding_curve": "Bağlanma Eğrisi",

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -925,6 +925,7 @@
   "token_stats_market_cap_title": "Market Cap",
   "token_stats_volume_description": "Bu, son 24 saat içindeki token işlem hacmini gösterir.\n\nDaha yüksek aktivite genellikle daha güçlü ilgi, daha iyi likidite ve daha kolay işlem anlamına gelir.",
   "token_stats_volume_title": "Volume",
+  "notification_for_account": "Hesap için: {accountName}",
   "switched_to_username": "{username} hesabına geçildi",
   "tokenized_communities_top_tokens": "En iyi tokenler",
   "tokenized_communities_trending_tokens": "Trend tokenler",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -925,6 +925,7 @@
   "token_stats_market_cap_title": "Market Cap",
   "token_stats_volume_description": "显示过去24小时的代币交易总量。\n\n较高的活跃度通常意味着兴趣更强、流动性更好、交易更便捷。",
   "token_stats_volume_title": "Volume",
+  "notification_for_account": "对于帐户：{accountName}",
   "switched_to_username": "已切换到 {username}",
   "tokenized_communities_top_tokens": "顶级代币",
   "tokenized_communities_trending_tokens": "热门代币",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -925,6 +925,7 @@
   "token_stats_market_cap_title": "Market Cap",
   "token_stats_volume_description": "显示过去24小时的代币交易总量。\n\n较高的活跃度通常意味着兴趣更强、流动性更好、交易更便捷。",
   "token_stats_volume_title": "Volume",
+  "switched_to_username": "已切换到 {username}",
   "tokenized_communities_top_tokens": "顶级代币",
   "tokenized_communities_trending_tokens": "热门代币",
   "tokenized_community_bonding_curve": "绑定曲线",


### PR DESCRIPTION
## Description

Implemented multi-account support for push notifications. Added push subscription cleanup on logout, notification display after account switching, improved handling of notifications for messages encrypted for other users, and added a method to retrieve pubkey by identity key name with caching.

## Additional Notes

- Notifications are shown even if the message is encrypted for another account (user can switch to view)
- Added localized strings for account switch notification
- Caches and databases are invalidated on account switch

## Task ID

ION-4646

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore