### PR TITLE
feat: external tx push

### DIFF
--- a/ios/NotificationServiceExtension/Translation/Models/IonConnectPushDataPayload.swift
+++ b/ios/NotificationServiceExtension/Translation/Models/IonConnectPushDataPayload.swift
@@ -395,7 +395,7 @@ class IonConnectPushDataPayload: Decodable {
         }
 
         // Non-encrypted WalletAssetEntity events (from external sources)
-        if (type == .paymentReceived || type == .anonymousPaymentReceived), event.kind == WalletAssetEntity.kind {
+        if type == .anonymousPaymentReceived, event.kind == WalletAssetEntity.kind {
             let txData = IonConnectPushDataPayload.buildTransactionData(from: event)
             if let tx = txData {
                 data["coinAmount"] = tx.coinAmount

--- a/ios/NotificationServiceExtension/Translation/Models/IonConnectPushDataPayload.swift
+++ b/ios/NotificationServiceExtension/Translation/Models/IonConnectPushDataPayload.swift
@@ -273,7 +273,7 @@ class IonConnectPushDataPayload: Decodable {
         } else if entity is TokenBuyingActivityResponseEntity {
             return .moreBuyersJoined
         } else if entity is WalletAssetEntity {
-            return .paymentReceived
+            return .anonymousPaymentReceived
         }
 
         return nil
@@ -392,9 +392,10 @@ class IonConnectPushDataPayload: Decodable {
 
         if let entity = mainEntity as? TokenGlobalStatResponseEntity {
             data["ticker"] = entity.data.tokenAction.data.tokenTicker
+        }
 
         // Non-encrypted WalletAssetEntity events (from external sources)
-        if type == .paymentReceived, event.kind == WalletAssetEntity.kind {
+        if (type == .paymentReceived || type == .anonymousPaymentReceived), event.kind == WalletAssetEntity.kind {
             let txData = IonConnectPushDataPayload.buildTransactionData(from: event)
             if let tx = txData {
                 data["coinAmount"] = tx.coinAmount
@@ -864,6 +865,7 @@ enum PushNotificationType: String, Decodable {
     case follower
     case paymentRequest
     case paymentReceived
+    case anonymousPaymentReceived
     case chatDocumentMessage
     case chatEmojiMessage
     case chatPhotoMessage

--- a/ios/NotificationServiceExtension/Translation/Models/IonConnectPushDataPayload.swift
+++ b/ios/NotificationServiceExtension/Translation/Models/IonConnectPushDataPayload.swift
@@ -272,6 +272,8 @@ class IonConnectPushDataPayload: Decodable {
             return .trendingToken
         } else if entity is TokenBuyingActivityResponseEntity {
             return .moreBuyersJoined
+        } else if entity is WalletAssetEntity {
+            return .paymentReceived
         }
 
         return nil
@@ -390,6 +392,14 @@ class IonConnectPushDataPayload: Decodable {
 
         if let entity = mainEntity as? TokenGlobalStatResponseEntity {
             data["ticker"] = entity.data.tokenAction.data.tokenTicker
+
+        // Non-encrypted WalletAssetEntity events (from external sources)
+        if type == .paymentReceived, event.kind == WalletAssetEntity.kind {
+            let txData = IonConnectPushDataPayload.buildTransactionData(from: event)
+            if let tx = txData {
+                data["coinAmount"] = tx.coinAmount
+                data["coinSymbol"] = tx.coinSymbol
+            }
         }
 
         return data

--- a/ios/NotificationServiceExtension/Translation/Models/TranslationModels.swift
+++ b/ios/NotificationServiceExtension/Translation/Models/TranslationModels.swift
@@ -30,6 +30,7 @@ struct PushNotificationTranslations: TranslationWithVersion, Decodable {
     let follower: NotificationTranslation?
     let paymentRequest: NotificationTranslation?
     let paymentReceived: NotificationTranslation?
+    let anonymousPaymentReceived: NotificationTranslation?
     let chatDocumentMessage: NotificationTranslation?
     let chatEmojiMessage: NotificationTranslation?
     let chatPhotoMessage: NotificationTranslation?
@@ -75,7 +76,7 @@ struct PushNotificationTranslations: TranslationWithVersion, Decodable {
         case quote, quoteArticle, quoteComment
         case like, likeArticle, likeComment, likeStory
         case follower
-        case paymentRequest, paymentReceived
+        case paymentRequest, paymentReceived, anonymousPaymentReceived
         case chatDocumentMessage, chatEmojiMessage, chatPhotoMessage
         case chatTextMessage, chatProfileMessage, chatReaction, reactToStory
         case chatSharePostMessage, chatShareArticleMessage, chatShareStoryMessage, replyToStory

--- a/ios/NotificationServiceExtension/Translation/NotificationTranslationService.swift
+++ b/ios/NotificationServiceExtension/Translation/NotificationTranslationService.swift
@@ -206,6 +206,8 @@ class NotificationTranslationService {
                 return translations.paymentRequest
             case .paymentReceived:
                 return translations.paymentReceived
+            case .anonymousPaymentReceived:
+                return translations.anonymousPaymentReceived
             case .chatDocumentMessage:
                 return translations.chatDocumentMessage
             case .chatEmojiMessage:

--- a/lib/app/features/chat/recent_chats/providers/money_message/money_message_display_resolver.dart
+++ b/lib/app/features/chat/recent_chats/providers/money_message/money_message_display_resolver.dart
@@ -35,7 +35,7 @@ class MoneyMessageDisplayResolver {
     );
   }
 
-  Future<MoneyDisplayData?> resolveMoneyDisplayDataFromPaymentSentTag(
+  Future<MoneyDisplayData?> resolveMoneyDisplayDataFromEventMessage(
     EventMessage eventMessage,
   ) async {
     final walletAssetEntity = paymentSentWalletAssetEntityFromMessage(eventMessage);

--- a/lib/app/features/chat/recent_chats/providers/money_message/money_message_event_extractors.dart
+++ b/lib/app/features/chat/recent_chats/providers/money_message/money_message_event_extractors.dart
@@ -28,13 +28,17 @@ EventMessage? eventMessageFromTag(EventMessage source, String tagName) {
   return null;
 }
 
+/// Using eventMessage as is if this is unencrypted WalletAssetEntity.
+/// Try to extract 1756 (WalletAssetEntity) from "payment-sent" tag otherwise.
 WalletAssetEntity? paymentSentWalletAssetEntityFromMessage(
   EventMessage eventMessage,
 ) {
-  final walletAssetEvent = eventMessageFromTag(
-    eventMessage,
-    ReplaceablePrivateDirectMessageData.paymentSentTagName,
-  );
+  final walletAssetEvent = eventMessage.kind == WalletAssetEntity.kind
+      ? eventMessage
+      : eventMessageFromTag(
+          eventMessage,
+          ReplaceablePrivateDirectMessageData.paymentSentTagName,
+        );
 
   if (walletAssetEvent == null) {
     return null;

--- a/lib/app/features/chat/recent_chats/providers/money_message_provider.r.dart
+++ b/lib/app/features/chat/recent_chats/providers/money_message_provider.r.dart
@@ -132,8 +132,7 @@ Future<MoneyDisplayData?> transactionDisplayData(
   EventMessage eventMessage,
 ) async {
   final displayResolver = await ref.watch(moneyMessageDisplayResolverProvider.future);
-  final fromEmbedded =
-      await displayResolver.resolveMoneyDisplayDataFromPaymentSentTag(eventMessage);
+  final fromEmbedded = await displayResolver.resolveMoneyDisplayDataFromEventMessage(eventMessage);
   if (fromEmbedded != null) return fromEmbedded;
 
   final transactionData = await ref.watch(transactionDataForMessageProvider(eventMessage).future);

--- a/lib/app/features/push_notifications/data/models/ion_connect_push_data_payload.f.dart
+++ b/lib/app/features/push_notifications/data/models/ion_connect_push_data_payload.f.dart
@@ -155,7 +155,7 @@ class IonConnectPushDataPayload {
     } else if (entity is TokenBuyingActivityResponseEntity) {
       return PushNotificationType.moreBuyersJoined;
     } else if (entity is WalletAssetEntity) {
-      return PushNotificationType.paymentReceived;
+      return PushNotificationType.anonymousPaymentReceived;
     }
 
     return null;
@@ -727,6 +727,7 @@ enum PushNotificationType {
   follower,
   paymentRequest,
   paymentReceived,
+  anonymousPaymentReceived,
   chatDocumentMessage,
   chatEmojiMessage,
   chatPhotoMessage,

--- a/lib/app/features/push_notifications/data/models/ion_connect_push_data_payload.f.dart
+++ b/lib/app/features/push_notifications/data/models/ion_connect_push_data_payload.f.dart
@@ -154,6 +154,8 @@ class IonConnectPushDataPayload {
       return PushNotificationType.trendingToken;
     } else if (entity is TokenBuyingActivityResponseEntity) {
       return PushNotificationType.moreBuyersJoined;
+    } else if (entity is WalletAssetEntity) {
+      return PushNotificationType.paymentReceived;
     }
 
     return null;

--- a/lib/app/features/push_notifications/data/models/ion_connect_push_data_payload.f.dart
+++ b/lib/app/features/push_notifications/data/models/ion_connect_push_data_payload.f.dart
@@ -538,6 +538,14 @@ class IonConnectPushDataPayload {
       data['ticker'] = entity.data.tokenAction.data.tokenTicker;
     }
 
+    if (entity is WalletAssetEntity) {
+      final fundsRequestData = await getFundsRequestData(event);
+      if (fundsRequestData != null) {
+        data['coinAmount'] = fundsRequestData.amount;
+        data['coinSymbol'] = fundsRequestData.coin;
+      }
+    }
+
     return data;
   }
 

--- a/lib/app/features/push_notifications/providers/app_translations_provider.m.dart
+++ b/lib/app/features/push_notifications/providers/app_translations_provider.m.dart
@@ -111,6 +111,7 @@ class PushNotificationTranslations
     NotificationTranslation? follower,
     NotificationTranslation? paymentRequest,
     NotificationTranslation? paymentReceived,
+    NotificationTranslation? anonymousPaymentReceived,
     NotificationTranslation? chatDocumentMessage,
     NotificationTranslation? chatEmojiMessage,
     NotificationTranslation? chatPhotoMessage,

--- a/lib/app/features/push_notifications/providers/notification_data_parser_provider.r.dart
+++ b/lib/app/features/push_notifications/providers/notification_data_parser_provider.r.dart
@@ -251,6 +251,10 @@ class NotificationDataParser {
             await translator.translate((t) => t.paymentReceived?.title),
             await translator.translate((t) => t.paymentReceived?.body)
           ),
+        PushNotificationType.anonymousPaymentReceived => (
+            await translator.translate((t) => t.anonymousPaymentReceived?.title),
+            await translator.translate((t) => t.anonymousPaymentReceived?.body)
+          ),
         PushNotificationType.chatDocumentMessage => (
             await translator.translate((t) => t.chatDocumentMessage?.title),
             await translator.translate((t) => t.chatDocumentMessage?.body)

--- a/lib/app/features/push_notifications/providers/selected_push_categories_ion_subscription_provider.r.dart
+++ b/lib/app/features/push_notifications/providers/selected_push_categories_ion_subscription_provider.r.dart
@@ -100,9 +100,9 @@ class SelectedPushCategoriesIonSubscription extends _$SelectedPushCategoriesIonS
 
     final filters = categoryFilters.nonNulls.expand<RequestFilter>((filters) => filters).toList();
 
-    final messageFilter = _buildFilterForMessages(selectedPushCategories);
-    if (messageFilter != null) {
-      filters.add(messageFilter);
+    final encryptedFilter = _buildFilterForEncryptedEvents(selectedPushCategories);
+    if (encryptedFilter != null) {
+      filters.add(encryptedFilter);
     }
 
     final accountsFilters =
@@ -142,6 +142,7 @@ class SelectedPushCategoriesIonSubscription extends _$SelectedPushCategoriesIonS
       PushNotificationCategory.likes => _buildFilterForLikes(),
       PushNotificationCategory.newFollowers => _buildFilterForNewFollowers(),
       PushNotificationCategory.tokenUpdates => _buildFilterForTokenUpdates(),
+      PushNotificationCategory.messagePaymentReceived => _buildFilterForPaymentReceived(),
       _ => null,
     };
   }
@@ -283,7 +284,9 @@ class SelectedPushCategoriesIonSubscription extends _$SelectedPushCategoriesIonS
     ];
   }
 
-  RequestFilter? _buildFilterForMessages(List<PushNotificationCategory> categories) {
+  /// Handling encrypted categories all together since they are combined
+  /// into a single filter (they all are encrypted with gift wraps).
+  RequestFilter? _buildFilterForEncryptedEvents(List<PushNotificationCategory> categories) {
     final messageCategories = [
       PushNotificationCategory.directMessages,
       PushNotificationCategory.messagePaymentRequest,
@@ -455,5 +458,24 @@ class SelectedPushCategoriesIonSubscription extends _$SelectedPushCategoriesIonS
               !blockedUsersPubkeys.contains(userPubkey),
         )
         .toList();
+  }
+
+  /// Alongside the encrypted [WalletAssetEntity.kind] events, we also need to listen for
+  /// unencrypted ones.
+  ///
+  /// Encrypted ones are produced when transaction is made from within the app.
+  /// Unencrypted ones are produced by BE when transaction is made from
+  ///   outside of the app (e.g., from an external wallet).
+  List<RequestFilter> _buildFilterForPaymentReceived() {
+    final currentUserPubkey = ref.watch(currentPubkeySelectorProvider);
+    if (currentUserPubkey == null) throw UserMasterPubkeyNotFoundException();
+    return [
+      RequestFilter(
+        kinds: const [WalletAssetEntity.kind],
+        tags: {
+          '#p': [currentUserPubkey],
+        },
+      ),
+    ];
   }
 }


### PR DESCRIPTION
## Description
This PR handles unencrypted 1756 events.
Encrypted ones are produced when transaction is made from within the app.
Unencrypted ones are produced by BE when transaction is made from outside of the app (e.g., from an external wallet).

## Task ID
ION-5197

## Type of Change
- [x] New feature
