### PR TITLE
fix: adjust bottom padding for backup modals

### DIFF
--- a/lib/app/features/protect_account/backup/views/pages/backup_options_page.dart
+++ b/lib/app/features/protect_account/backup/views/pages/backup_options_page.dart
@@ -72,6 +72,7 @@ class BackupOptionsPage extends ConsumerWidget {
                   isOptionEnabled: isBackupEnabled,
                   onTap: () => BackupRecoveryKeysRoute().push<void>(context),
                 ),
+                SizedBox(height: 12.0.s),
                 const ScreenBottomOffset(),
               ],
             ),

--- a/lib/app/features/protect_account/backup/views/pages/backup_with_cloud_page/backup_with_cloud_success_page.dart
+++ b/lib/app/features/protect_account/backup/views/pages/backup_with_cloud_page/backup_with_cloud_success_page.dart
@@ -47,6 +47,7 @@ class BackupWithCloudSuccessPage extends HookConsumerWidget {
                 onPressed: goToSecureAccountOptions,
               ),
             ),
+            const ScreenBottomOffset(),
           ],
         ),
       ),

--- a/lib/app/features/protect_account/backup/views/pages/backup_with_cloud_page/components/backup_with_cloud_password_input_body.dart
+++ b/lib/app/features/protect_account/backup/views/pages/backup_with_cloud_page/components/backup_with_cloud_password_input_body.dart
@@ -107,7 +107,6 @@ final class BackupWithCloudPasswordInputBody extends HookConsumerWidget {
               ),
             ),
             ScreenBottomOffset(
-              margin: 16.0.s,
               child: Button(
                 label: Text(context.i18n.button_continue),
                 mainAxisSize: MainAxisSize.max,

--- a/lib/app/features/protect_account/backup/views/pages/create_recover_key_page/create_recovery_key_page.dart
+++ b/lib/app/features/protect_account/backup/views/pages/create_recover_key_page/create_recovery_key_page.dart
@@ -30,6 +30,7 @@ class CreateRecoveryKeyPage extends StatelessWidget {
             _NavBar(),
             _Header(),
             _Body(),
+            ScreenBottomOffset(margin: 32),
           ],
         ),
       ),

--- a/lib/app/features/protect_account/secure_account/views/pages/secure_account_modal.dart
+++ b/lib/app/features/protect_account/secure_account/views/pages/secure_account_modal.dart
@@ -128,7 +128,7 @@ class SecureAccountModal extends HookConsumerWidget {
                   SecureAccountOptionsRoute(showCloseButton: false).push<void>(context);
                 },
               ),
-              ScreenBottomOffset(margin: 16.0.s),
+              const ScreenBottomOffset(),
             ],
           ),
         ),


### PR DESCRIPTION
## Description
Fix custom modal bottom padding issues

## Additional Notes

- Adjust bottom padding for backup modals
- Adjust bottom padding for secure modal

## Task ID
5801

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
<img width="492" height="1068" alt="image (3)" src="https://github.com/user-attachments/assets/589c40b1-2a0a-47af-9493-ac047866292b" />
<img width="1024" height="1944" alt="image" src="https://github.com/user-attachments/assets/d8906e4c-0f2d-4675-b242-8733446875ff" />
<img width="540" height="1200" alt="Screenshot_20260317_192649" src="https://github.com/user-attachments/assets/5305d88b-7ddc-41d5-96e8-bbd0cf154053" />
<img width="540" height="1200" alt="Screenshot_20260317_192726" src="https://github.com/user-attachments/assets/3de06f4a-3e2b-49b1-8e87-353ea369e297" />
