### PR TITLE
fix(tc): Freeze confirmed trade plan and pause quote polling during submit

### DIFF
--- a/lib/app/features/tokenized_communities/domain/trade_community_token_service.dart
+++ b/lib/app/features/tokenized_communities/domain/trade_community_token_service.dart
@@ -6,6 +6,7 @@ import 'package:ion/app/exceptions/exceptions.dart';
 import 'package:ion/app/features/ion_connect/model/event_reference.f.dart';
 import 'package:ion/app/features/tokenized_communities/domain/trade_community_token_repository.dart';
 import 'package:ion/app/features/tokenized_communities/domain/trade_debug_context.dart';
+import 'package:ion/app/features/tokenized_communities/domain/trade_execution_plan.dart';
 import 'package:ion/app/features/tokenized_communities/domain/trade_quote_builder.dart';
 import 'package:ion/app/features/tokenized_communities/domain/trade_route_builder.dart';
 import 'package:ion/app/features/tokenized_communities/domain/trade_user_ops_builder.dart';
@@ -56,9 +57,10 @@ class TradeCommunityTokenService {
     required int tokenDecimals,
     required UserActionSignerNew userActionSigner,
     required PricingResponse expectedPricing,
+    required TradeExecutionPlan executionPlan,
+    required double slippagePercent,
     required bool shouldSendEvents,
     FatAddressV2Data? fatAddressData,
-    double slippagePercent = TokenizedCommunitiesConstants.defaultSlippagePercent,
   }) async {
     TradeRoutePlan? route;
     TradeQuotePlan? quote;
@@ -69,6 +71,7 @@ class TradeCommunityTokenService {
     bool? firstBuy;
     bool? hasUserPosition;
     bool? isCreatorTokenMissingForContentFirstBuy;
+    BigInt? previousPositionRaw;
 
     try {
       Logger.info(
@@ -82,8 +85,7 @@ class TradeCommunityTokenService {
       existingTokenAddress = _extractTokenAddress(tokenInfo);
       firstBuy = await _isFirstBuy(externalAddress, externalAddressType);
       hasUserPosition = _hasUserPosition(tokenInfo);
-
-      final previousPositionRaw = _extractPositionRaw(tokenInfo);
+      previousPositionRaw = _extractPositionRaw(tokenInfo);
       Logger.info(
         '[TradeCommunityTokenService] Token info | existingTokenAddress=$existingTokenAddress | firstBuy=$firstBuy | hasUserPosition=$hasUserPosition',
       );
@@ -93,36 +95,22 @@ class TradeCommunityTokenService {
         isFirstBuy: firstBuy,
         fatAddressData: fatAddressData,
       );
-      Logger.info(
-        '[TradeCommunityTokenService] Resolving pricing identifier | externalAddress=$externalAddress | hasTokenAddress=${tokenInfo?.addresses.blockchain != null} | hasFatAddress=${fatAddressData != null}',
-      );
-      final pricingIdentifier = _resolveBuyPricingIdentifier(
-        externalAddress: externalAddress,
-        tokenInfo: tokenInfo,
-        fatAddressData: fatAddressData,
-      );
-      Logger.info(
-        '[TradeCommunityTokenService] Pricing identifier resolved | pricingIdentifier=$pricingIdentifier',
-      );
       final paymentRoleOverride = await _resolvePaymentTokenRoleOverride(
         externalAddress: externalAddress,
         externalAddressType: externalAddressType,
         paymentTokenAddress: baseTokenAddress,
       );
-      final routeQuote = await _buildRouteAndQuote(
-        externalAddress: externalAddress,
-        externalAddressType: externalAddressType,
-        mode: CommunityTokenTradeMode.buy,
+      route = executionPlan.route;
+      quote = executionPlan.quote;
+      _ensureRouteMatchesCurrentTrade(
+        route: route,
+        expectedExternalAddress: externalAddress,
+        expectedExternalAddressType: externalAddressType,
+        expectedMode: CommunityTokenTradeMode.buy,
+        expectedPaymentRoleOverride: paymentRoleOverride,
+        expectedCreatorTokenMissingForContentFirstBuy: isCreatorTokenMissingForContentFirstBuy,
         paymentTokenAddress: baseTokenAddress,
-        paymentRoleOverride: paymentRoleOverride,
-        isCreatorTokenMissingForContentFirstBuy: isCreatorTokenMissingForContentFirstBuy,
-        pricingIdentifier: pricingIdentifier,
-        amountIn: amountIn,
-        slippagePercent: slippagePercent,
-        fatAddressHex: fatAddressData?.toHex(),
       );
-      route = routeQuote.route;
-      quote = routeQuote.quote;
       Logger.info(
         '[TradeCommunityTokenService] Building user operations | quoteAmount=${quote.finalPricing.amount} | quoteAmountUSD=${quote.finalPricing.amountUSD}',
       );
@@ -281,14 +269,16 @@ class TradeCommunityTokenService {
     required int tokenDecimals,
     required UserActionSignerNew userActionSigner,
     required PricingResponse expectedPricing,
+    required TradeExecutionPlan executionPlan,
+    required double slippagePercent,
     required bool shouldSendEvents,
-    double slippagePercent = TokenizedCommunitiesConstants.defaultSlippagePercent,
   }) async {
     TradeRoutePlan? route;
     TradeQuotePlan? quote;
     List<EvmUserOperation>? userOps;
     TransactionResult? transaction;
     CommunityToken? tokenInfo;
+    BigInt? previousPositionRaw;
 
     try {
       Logger.info(
@@ -300,30 +290,20 @@ class TradeCommunityTokenService {
         externalAddressType: externalAddressType,
         paymentTokenAddress: paymentTokenAddress,
       );
-      Logger.info('[TradeCommunityTokenService] Building route');
-      route = routeBuilder.build(
-        externalAddress: externalAddress,
-        externalAddressType: externalAddressType,
-        mode: CommunityTokenTradeMode.sell,
-        paymentTokenAddress: paymentTokenAddress,
-        paymentTokenRoleOverride: paymentRoleOverride,
-      );
-
       Logger.info('[TradeCommunityTokenService] Fetching token info');
-      tokenInfo = await repository.fetchTokenInfo(externalAddress);
-
-      final previousPositionRaw = _extractPositionRaw(tokenInfo);
-
-      Logger.info(
-        '[TradeCommunityTokenService] Building quote | pricingIdentifier=$externalAddress | amountIn=$amountIn | slippagePercent=$slippagePercent',
-      );
-      quote = await quoteBuilder.build(
+      route = executionPlan.route;
+      quote = executionPlan.quote;
+      _ensureRouteMatchesCurrentTrade(
         route: route,
-        pricingIdentifier: externalAddress,
-        amountIn: amountIn,
+        expectedExternalAddress: externalAddress,
+        expectedExternalAddressType: externalAddressType,
+        expectedMode: CommunityTokenTradeMode.sell,
+        expectedPaymentRoleOverride: paymentRoleOverride,
+        expectedCreatorTokenMissingForContentFirstBuy: false,
         paymentTokenAddress: paymentTokenAddress,
-        slippagePercent: slippagePercent,
       );
+      tokenInfo = await repository.fetchTokenInfo(externalAddress);
+      previousPositionRaw = _extractPositionRaw(tokenInfo);
       Logger.info('[TradeCommunityTokenService] Building user operations');
       userOps = await userOpsBuilder.buildUserOps(
         route: route,
@@ -420,13 +400,14 @@ class TradeCommunityTokenService {
     }
   }
 
-  Future<PricingResponse> getQuote({
+  Future<TradeExecutionPlan> getQuote({
     required String externalAddress,
     required ExternalAddressType externalAddressType,
     required String pricingIdentifier,
     required CommunityTokenTradeMode mode,
     required String amount,
     required String paymentTokenAddress,
+    required double slippagePercent,
     FatAddressV2Data? fatAddressData,
     Future<FatAddressV2Data> Function(PricingResponse pricing)? fatAddressDataWithPricingResolver,
   }) async {
@@ -441,7 +422,7 @@ class TradeCommunityTokenService {
       fatAddressData: fatAddressData,
     );
     final amountIn = BigInt.parse(amount);
-    final initialRouteQuote = await _buildRouteAndQuote(
+    final initialExecutionPlan = await _buildRouteAndQuote(
       externalAddress: externalAddress,
       externalAddressType: externalAddressType,
       mode: mode,
@@ -450,7 +431,7 @@ class TradeCommunityTokenService {
       isCreatorTokenMissingForContentFirstBuy: isCreatorTokenMissingForContentFirstBuy,
       pricingIdentifier: pricingIdentifier,
       amountIn: amountIn,
-      slippagePercent: 0,
+      slippagePercent: slippagePercent,
       fatAddressHex: _looksLikeHex(pricingIdentifier) ? pricingIdentifier : null,
     );
 
@@ -463,8 +444,9 @@ class TradeCommunityTokenService {
       isCreatorTokenMissingForContentFirstBuy: isCreatorTokenMissingForContentFirstBuy,
       pricingIdentifier: pricingIdentifier,
       amountIn: amountIn,
-      initialRouteQuote: initialRouteQuote,
+      initialExecutionPlan: initialExecutionPlan,
       fatAddressData: fatAddressData,
+      slippagePercent: slippagePercent,
       fatAddressDataWithPricingResolver: fatAddressDataWithPricingResolver,
     );
   }
@@ -520,23 +502,7 @@ class TradeCommunityTokenService {
     }
   }
 
-  String _resolveBuyPricingIdentifier({
-    required String externalAddress,
-    required CommunityToken? tokenInfo,
-    FatAddressV2Data? fatAddressData,
-  }) {
-    final tokenAddress = tokenInfo?.addresses.blockchain?.trim() ?? '';
-    if (tokenAddress.isNotEmpty) {
-      return externalAddress;
-    }
-    final fatHex = fatAddressData?.toHex() ?? '';
-    if (fatHex.isNotEmpty) {
-      return fatHex;
-    }
-    throw StateError('fatAddressData is required for first buy of $externalAddress');
-  }
-
-  Future<_RouteQuote> _buildRouteAndQuote({
+  Future<TradeExecutionPlan> _buildRouteAndQuote({
     required String externalAddress,
     required ExternalAddressType externalAddressType,
     required CommunityTokenTradeMode mode,
@@ -568,10 +534,10 @@ class TradeCommunityTokenService {
       slippagePercent: slippagePercent,
       fatAddressHex: fatAddressHex,
     );
-    return _RouteQuote(route: route, quote: quote);
+    return TradeExecutionPlan(route: route, quote: quote);
   }
 
-  Future<PricingResponse> _resolveQuoteWithEnrichedFatAddress({
+  Future<TradeExecutionPlan> _resolveQuoteWithEnrichedFatAddress({
     required String externalAddress,
     required ExternalAddressType externalAddressType,
     required CommunityTokenTradeMode mode,
@@ -580,8 +546,9 @@ class TradeCommunityTokenService {
     required bool isCreatorTokenMissingForContentFirstBuy,
     required String pricingIdentifier,
     required BigInt amountIn,
-    required _RouteQuote initialRouteQuote,
+    required TradeExecutionPlan initialExecutionPlan,
     required FatAddressV2Data? fatAddressData,
+    required double slippagePercent,
     required Future<FatAddressV2Data> Function(PricingResponse pricing)?
         fatAddressDataWithPricingResolver,
   }) async {
@@ -589,15 +556,15 @@ class TradeCommunityTokenService {
         fatAddressData != null &&
         fatAddressDataWithPricingResolver != null;
     if (!shouldEnrichFatAddress) {
-      return initialRouteQuote.quote.finalPricing;
+      return initialExecutionPlan;
     }
 
     final enrichedFatAddress = await fatAddressDataWithPricingResolver(
-      initialRouteQuote.quote.finalPricing,
+      initialExecutionPlan.quote.finalPricing,
     );
     final enrichedHex = enrichedFatAddress.toHex();
     if (enrichedHex.isEmpty || enrichedHex == pricingIdentifier) {
-      return initialRouteQuote.quote.finalPricing;
+      return initialExecutionPlan;
     }
 
     final enrichedRouteQuote = await _buildRouteAndQuote(
@@ -609,10 +576,55 @@ class TradeCommunityTokenService {
       isCreatorTokenMissingForContentFirstBuy: isCreatorTokenMissingForContentFirstBuy,
       pricingIdentifier: enrichedHex,
       amountIn: amountIn,
-      slippagePercent: 0,
+      slippagePercent: slippagePercent,
       fatAddressHex: enrichedHex,
     );
-    return enrichedRouteQuote.quote.finalPricing;
+    return enrichedRouteQuote;
+  }
+
+  void _ensureRouteMatchesCurrentTrade({
+    required TradeRoutePlan route,
+    required String expectedExternalAddress,
+    required ExternalAddressType expectedExternalAddressType,
+    required CommunityTokenTradeMode expectedMode,
+    required TradeTokenRole? expectedPaymentRoleOverride,
+    required bool expectedCreatorTokenMissingForContentFirstBuy,
+    required String paymentTokenAddress,
+  }) {
+    final expectedRoute = routeBuilder.build(
+      externalAddress: expectedExternalAddress,
+      externalAddressType: expectedExternalAddressType,
+      mode: expectedMode,
+      paymentTokenAddress: paymentTokenAddress,
+      paymentTokenRoleOverride: expectedPaymentRoleOverride,
+      isCreatorTokenMissingForContentFirstBuy: expectedCreatorTokenMissingForContentFirstBuy,
+    );
+    if (!_sameRoute(route, expectedRoute)) {
+      throw StateError('Confirmed trade route is no longer valid');
+    }
+  }
+
+  bool _sameRoute(TradeRoutePlan left, TradeRoutePlan right) {
+    if (left.externalAddress != right.externalAddress ||
+        left.externalAddressType != right.externalAddressType ||
+        left.creatorExternalAddress != right.creatorExternalAddress ||
+        left.steps.length != right.steps.length) {
+      return false;
+    }
+
+    for (var i = 0; i < left.steps.length; i++) {
+      final leftStep = left.steps[i];
+      final rightStep = right.steps[i];
+      if (leftStep.type != rightStep.type ||
+          leftStep.mode != rightStep.mode ||
+          leftStep.externalAddress != rightStep.externalAddress ||
+          leftStep.fromRole != rightStep.fromRole ||
+          leftStep.toRole != rightStep.toRole) {
+        return false;
+      }
+    }
+
+    return true;
   }
 
   Future<TradeTokenRole?> _resolvePaymentTokenRoleOverride({
@@ -982,14 +994,4 @@ class TradeCommunityTokenService {
       return null;
     }
   }
-}
-
-class _RouteQuote {
-  const _RouteQuote({
-    required this.route,
-    required this.quote,
-  });
-
-  final TradeRoutePlan route;
-  final TradeQuotePlan quote;
 }

--- a/lib/app/features/tokenized_communities/domain/trade_execution_plan.dart
+++ b/lib/app/features/tokenized_communities/domain/trade_execution_plan.dart
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:ion/app/features/tokenized_communities/domain/trade_quote_builder.dart';
+import 'package:ion/app/features/tokenized_communities/domain/trade_route_builder.dart';
+
+class TradeExecutionPlan {
+  const TradeExecutionPlan({
+    required this.route,
+    required this.quote,
+  });
+
+  final TradeRoutePlan route;
+  final TradeQuotePlan quote;
+}

--- a/lib/app/features/tokenized_communities/providers/community_token_trade_notifier_provider.r.dart
+++ b/lib/app/features/tokenized_communities/providers/community_token_trade_notifier_provider.r.dart
@@ -114,14 +114,14 @@ class CommunityTokenTradeNotifier extends _$CommunityTokenTradeNotifier {
       final service = await ref.read(tradeCommunityTokenServiceProvider.future);
       Logger.info('[CommunityTokenTradeNotifier] Trade service obtained');
 
-      final expectedPricing = formState.quotePricing;
-
-      if (formState.isQuoting || expectedPricing == null) {
+      final executionPlan = formState.executionPlan;
+      if (formState.isQuoting || executionPlan == null) {
         Logger.error(
-          '[CommunityTokenTradeNotifier] Quote not ready | isQuoting=${formState.isQuoting} | expectedPricing=$expectedPricing',
+          '[CommunityTokenTradeNotifier] Execution plan not ready | isQuoting=${formState.isQuoting} | hasExecutionPlan=${executionPlan != null}',
         );
         throw StateError('Quote is not ready yet');
       }
+      final expectedPricing = executionPlan.quote.finalPricing;
 
       await _ensurePricingValidForBuy(
         expectedPricing: expectedPricing,
@@ -192,10 +192,11 @@ class CommunityTokenTradeNotifier extends _$CommunityTokenTradeNotifier {
         baseTokenTicker: token.abbreviation,
         tokenDecimals: token.decimals,
         expectedPricing: expectedPricing,
+        executionPlan: executionPlan,
+        slippagePercent: formState.slippage,
         fatAddressData: fatAddressData,
         userActionSigner: signer,
         shouldSendEvents: formState.shouldSendEvents,
-        slippagePercent: formState.slippage,
       );
 
       Logger.info(
@@ -342,14 +343,14 @@ class CommunityTokenTradeNotifier extends _$CommunityTokenTradeNotifier {
       final service = await ref.read(tradeCommunityTokenServiceProvider.future);
       Logger.info('[CommunityTokenTradeNotifier] Trade service obtained');
 
-      final expectedPricing = formState.quotePricing;
-
-      if (formState.isQuoting || expectedPricing == null) {
+      final executionPlan = formState.executionPlan;
+      if (formState.isQuoting || executionPlan == null) {
         Logger.error(
-          '[CommunityTokenTradeNotifier] Quote not ready | isQuoting=${formState.isQuoting} | expectedPricing=$expectedPricing',
+          '[CommunityTokenTradeNotifier] Execution plan not ready | isQuoting=${formState.isQuoting} | hasExecutionPlan=${executionPlan != null}',
         );
         throw StateError('Quote is not ready yet');
       }
+      final expectedPricing = executionPlan.quote.finalPricing;
       Logger.info('[CommunityTokenTradeNotifier] Quote ready | expectedPricing=$expectedPricing');
 
       Logger.info('[CommunityTokenTradeNotifier] Step 6: Calling sellCommunityToken service');
@@ -376,6 +377,8 @@ class CommunityTokenTradeNotifier extends _$CommunityTokenTradeNotifier {
         communityTokenAddress: communityTokenAddress,
         tokenDecimals: TokenizedCommunitiesConstants.communityTokenDecimals,
         expectedPricing: expectedPricing,
+        executionPlan: executionPlan,
+        slippagePercent: formState.slippage,
         userActionSigner: signer,
         shouldSendEvents: formState.shouldSendEvents,
       );
@@ -593,7 +596,11 @@ class CommunityTokenTradeNotifier extends _$CommunityTokenTradeNotifier {
     final initial = pricing.initialPrice?.trim() ?? '';
     final finalPrice = pricing.finalPrice?.trim() ?? '';
     final supply = pricing.emissionVolume?.trim() ?? '';
-    return address.isNotEmpty && initial.isNotEmpty && finalPrice.isNotEmpty && supply.isNotEmpty;
+    return address.isNotEmpty &&
+        !_isZeroEvmAddress(address) &&
+        initial.isNotEmpty &&
+        finalPrice.isNotEmpty &&
+        supply.isNotEmpty;
   }
 
   bool _hasRequiredCreatorParams(PricingResponse pricing) {
@@ -603,6 +610,14 @@ class CommunityTokenTradeNotifier extends _$CommunityTokenTradeNotifier {
     final initial = params.initialPrice?.trim() ?? '';
     final finalPrice = params.finalPrice?.trim() ?? '';
     final supply = params.emissionVolume?.trim() ?? '';
-    return address.isNotEmpty && initial.isNotEmpty && finalPrice.isNotEmpty && supply.isNotEmpty;
+    return address.isNotEmpty &&
+        !_isZeroEvmAddress(address) &&
+        initial.isNotEmpty &&
+        finalPrice.isNotEmpty &&
+        supply.isNotEmpty;
+  }
+
+  bool _isZeroEvmAddress(String value) {
+    return value.trim().toLowerCase() == '0x0000000000000000000000000000000000000000';
   }
 }

--- a/lib/app/features/tokenized_communities/providers/trade_community_token_controller_provider.r.dart
+++ b/lib/app/features/tokenized_communities/providers/trade_community_token_controller_provider.r.dart
@@ -8,6 +8,7 @@ import 'package:ion/app/features/core/extensions/ref_lifecycle_listen_extension.
 import 'package:ion/app/features/core/providers/wallets_provider.r.dart';
 import 'package:ion/app/features/ion_connect/model/event_reference.f.dart';
 import 'package:ion/app/features/tokenized_communities/domain/content_payment_token_resolver_service.dart';
+import 'package:ion/app/features/tokenized_communities/domain/trade_execution_plan.dart';
 import 'package:ion/app/features/tokenized_communities/enums/community_token_trade_mode.dart';
 import 'package:ion/app/features/tokenized_communities/providers/content_payment_token_context_provider.r.dart';
 import 'package:ion/app/features/tokenized_communities/providers/fat_address_data_provider.r.dart';
@@ -54,6 +55,7 @@ class TradeCommunityTokenController extends _$TradeCommunityTokenController {
   CommunityTokenPricingIdentifierResolver? _pricingIdentifierResolver;
   TradeCommunityLastPaymentCoinService? _lastPaymentCoinService;
   Completer<void>? _updateDerivedStateCompleter;
+  bool _isQuotePollingPaused = false;
 
   @override
   TradeCommunityTokenState build(TradeCommunityTokenControllerParams params) {
@@ -425,6 +427,7 @@ class TradeCommunityTokenController extends _$TradeCommunityTokenController {
 
   void setAmount(double amount, {bool useFullAmount = false}) {
     state = state.copyWith(amount: amount, useFullAmount: useFullAmount);
+    _setExecutionPlan(null);
     _scheduleQuoteUpdates();
     _refreshFormattedAmounts();
   }
@@ -468,6 +471,7 @@ class TradeCommunityTokenController extends _$TradeCommunityTokenController {
   void selectPaymentToken(CoinData token) {
     state = state.copyWith(selectedPaymentToken: token);
     _lastPaymentCoinService!.saveLastUsedPaymentToken(token);
+    _setExecutionPlan(null);
     _updateDerivedState();
     _scheduleQuoteUpdates();
     _refreshFormattedAmounts();
@@ -475,17 +479,33 @@ class TradeCommunityTokenController extends _$TradeCommunityTokenController {
 
   void setSlippage(double slippage) {
     state = state.copyWith(slippage: slippage);
+    _setExecutionPlan(null);
+    _scheduleQuoteUpdates();
   }
 
   void setShouldSendEvents({required bool send}) {
     state = state.copyWith(shouldSendEvents: send);
   }
 
+  void pauseQuotePolling() {
+    _isQuotePollingPaused = true;
+    _quoteController?.cancel();
+    state = state.copyWith(isQuoting: false);
+  }
+
+  void resumeQuotePolling() {
+    if (!_isQuotePollingPaused) {
+      return;
+    }
+    _isQuotePollingPaused = false;
+    _scheduleQuoteUpdates();
+  }
+
   void _resetTradeFormOnModeChange() {
     _quoteController?.cancel();
     state = state.copyWith(
       amount: 0,
-      quotePricing: null,
+      executionPlan: null,
       isQuoting: false,
       communityTokenAmountUSDFormatted: null,
       paymentTokenAmountUSDFormatted: null,
@@ -688,23 +708,27 @@ class TradeCommunityTokenController extends _$TradeCommunityTokenController {
   }
 
   void _scheduleQuoteUpdates() {
+    if (_isQuotePollingPaused) {
+      return;
+    }
+
     final quoteController = _quoteController;
     if (quoteController == null) return;
 
     quoteController.schedule(
       request: _buildQuoteRequest(),
       onReset: () {
-        _setQuotePricing(null);
+        _setExecutionPlan(null);
       },
       onStart: () => state = state.copyWith(isQuoting: true),
-      onSuccess: _setQuotePricing,
+      onSuccess: _setExecutionPlan,
       onError: (error, stackTrace) {
         Logger.error(
           error,
           stackTrace: stackTrace,
           message: 'Failed to get quote',
         );
-        _setQuotePricing(null);
+        _setExecutionPlan(null);
       },
       onPollError: (error, stackTrace) {
         Logger.error(
@@ -734,6 +758,7 @@ class TradeCommunityTokenController extends _$TradeCommunityTokenController {
         mode: mode,
         amount: state.amount,
         amountDecimals: amountDecimals,
+        slippagePercent: state.slippage,
         pricingIdentifierResolver: () => _resolvePricingIdentifier(mode),
         paymentTokenAddress: resolvePaymentTokenAddress(token),
         fatAddressDataWithPricingResolver: (pricing) {
@@ -755,7 +780,7 @@ class TradeCommunityTokenController extends _$TradeCommunityTokenController {
         message: 'Failed to build quote request',
       );
       state = state.copyWith(
-        quotePricing: null,
+        executionPlan: null,
         isQuoting: false,
       );
       return null;
@@ -774,10 +799,10 @@ class TradeCommunityTokenController extends _$TradeCommunityTokenController {
     return resolver.resolve(mode);
   }
 
-  void _setQuotePricing(PricingResponse? pricing) {
-    final formatted = _computeFormattedAmounts(pricing);
+  void _setExecutionPlan(TradeExecutionPlan? executionPlan) {
+    final formatted = _computeFormattedAmounts(executionPlan?.quote.finalPricing);
     state = state.copyWith(
-      quotePricing: pricing,
+      executionPlan: executionPlan,
       isQuoting: false,
       communityTokenAmountUSDFormatted: formatted.community,
       paymentTokenAmountUSDFormatted: formatted.payment,
@@ -786,7 +811,7 @@ class TradeCommunityTokenController extends _$TradeCommunityTokenController {
   }
 
   void _refreshFormattedAmounts() {
-    final formatted = _computeFormattedAmounts(state.quotePricing);
+    final formatted = _computeFormattedAmounts(state.executionPlan?.quote.finalPricing);
     state = state.copyWith(
       communityTokenAmountUSDFormatted: formatted.community,
       paymentTokenAmountUSDFormatted: formatted.payment,

--- a/lib/app/features/tokenized_communities/services/trade_community_token_quote_controller.dart
+++ b/lib/app/features/tokenized_communities/services/trade_community_token_quote_controller.dart
@@ -3,6 +3,7 @@
 import 'dart:async';
 
 import 'package:ion/app/features/tokenized_communities/domain/trade_community_token_service.dart';
+import 'package:ion/app/features/tokenized_communities/domain/trade_execution_plan.dart';
 import 'package:ion/app/features/tokenized_communities/enums/community_token_trade_mode.dart';
 import 'package:ion/app/features/tokenized_communities/services/pricing_identifier_resolver.dart';
 import 'package:ion/app/features/tokenized_communities/utils/external_address_extension.dart';
@@ -19,6 +20,7 @@ class TradeCommunityTokenQuoteRequest {
     required this.mode,
     required this.amount,
     required this.amountDecimals,
+    required this.slippagePercent,
     required this.pricingIdentifierResolver,
     required this.paymentTokenAddress,
     this.fatAddressDataWithPricingResolver,
@@ -33,6 +35,7 @@ class TradeCommunityTokenQuoteRequest {
 
   /// Decimals used to convert [amount] to blockchain units.
   final int amountDecimals;
+  final double slippagePercent;
 
   final PricingIdentifierResolver pricingIdentifierResolver;
   final String paymentTokenAddress;
@@ -78,7 +81,7 @@ class TradeCommunityTokenQuoteController {
     required TradeCommunityTokenQuoteRequest? request,
     required void Function() onReset,
     required void Function() onStart,
-    required void Function(PricingResponse pricing) onSuccess,
+    required void Function(TradeExecutionPlan executionPlan) onSuccess,
     required void Function(Object error, StackTrace stackTrace) onError,
     bool enablePolling = true,
     Duration pollInterval = const Duration(milliseconds: 500),
@@ -124,7 +127,7 @@ class TradeCommunityTokenQuoteController {
     required TradeCommunityTokenQuoteRequest request,
     required Duration pollInterval,
     required void Function()? onStart,
-    required void Function(PricingResponse pricing) onSuccess,
+    required void Function(TradeExecutionPlan executionPlan) onSuccess,
     required void Function(Object error, StackTrace stackTrace) onError,
   }) async {
     while (currentRequestId == _requestId) {
@@ -145,7 +148,7 @@ class TradeCommunityTokenQuoteController {
     required int currentRequestId,
     required TradeCommunityTokenQuoteRequest request,
     required void Function()? onStart,
-    required void Function(PricingResponse pricing) onSuccess,
+    required void Function(TradeExecutionPlan executionPlan) onSuccess,
     required void Function(Object error, StackTrace stackTrace) onError,
   }) async {
     if (currentRequestId != _requestId) return;
@@ -164,19 +167,20 @@ class TradeCommunityTokenQuoteController {
       final resolution = await request.pricingIdentifierResolver();
       if (currentRequestId != _requestId) return;
 
-      final pricing = await service.getQuote(
+      final executionPlan = await service.getQuote(
         externalAddress: request.externalAddress,
         externalAddressType: request.externalAddressType,
         pricingIdentifier: resolution.pricingIdentifier,
         mode: request.mode,
         amount: apiAmount,
         paymentTokenAddress: request.paymentTokenAddress,
+        slippagePercent: request.slippagePercent,
         fatAddressData: resolution.fatAddressData,
         fatAddressDataWithPricingResolver: request.fatAddressDataWithPricingResolver,
       );
 
       if (currentRequestId != _requestId) return;
-      onSuccess(pricing);
+      onSuccess(executionPlan);
     } catch (e, stackTrace) {
       if (currentRequestId != _requestId) return;
       onError(e, stackTrace);

--- a/lib/app/features/tokenized_communities/views/trade_community_token_dialog.dart
+++ b/lib/app/features/tokenized_communities/views/trade_community_token_dialog.dart
@@ -292,7 +292,7 @@ class TradeCommunityTokenDialog extends HookConsumerWidget {
         state.quoteAmount! > BigInt.zero &&
         state.targetWallet != null &&
         !state.isQuoting &&
-        state.quotePricing != null &&
+        state.executionPlan != null &&
         state.selectedPaymentToken != null &&
         selectedPaymentTokenAmount != null &&
         selectedPaymentTokenAmount >= state.amount;
@@ -305,7 +305,7 @@ class TradeCommunityTokenDialog extends HookConsumerWidget {
         state.quoteAmount! > BigInt.zero &&
         state.targetWallet != null &&
         !state.isQuoting &&
-        state.quotePricing != null &&
+        state.executionPlan != null &&
         state.selectedPaymentToken != null &&
         state.communityTokenCoinsGroup != null;
   }
@@ -386,7 +386,6 @@ class TradeCommunityTokenDialog extends HookConsumerWidget {
     Logger.info(
       '[TradeCommunityTokenDialog] Button pressed | mode=$mode | externalAddress=${params.externalAddress}',
     );
-
     if (state.targetWallet == null || state.selectedPaymentToken == null) {
       Logger.warning(
         '[TradeCommunityTokenDialog] Missing wallet or token | wallet=${state.targetWallet?.id} | token=${state.selectedPaymentToken?.abbreviation}',
@@ -407,14 +406,14 @@ class TradeCommunityTokenDialog extends HookConsumerWidget {
 
     if (isBuy && !_isBuyContinueButtonEnabled(state)) {
       Logger.warning(
-        '[TradeCommunityTokenDialog] Buy button not enabled | amount=${state.amount} | quoteAmount=${state.quoteAmount} | quoteReady=${state.quotePricing != null} | isQuoting=${state.isQuoting}',
+        '[TradeCommunityTokenDialog] Buy button not enabled | amount=${state.amount} | quoteReady=${state.executionPlan != null} | isQuoting=${state.isQuoting}',
       );
       return;
     }
 
     if (!isBuy && !_isSellContinueButtonEnabled(state)) {
       Logger.warning(
-        '[TradeCommunityTokenDialog] Sell button not enabled | amount=${state.amount} | balance=${state.communityTokenBalance} | quoteReady=${state.quotePricing != null}',
+        '[TradeCommunityTokenDialog] Sell button not enabled | amount=${state.amount} | balance=${state.communityTokenBalance} | quoteReady=${state.executionPlan != null}',
       );
       return;
     }
@@ -423,30 +422,38 @@ class TradeCommunityTokenDialog extends HookConsumerWidget {
       '[TradeCommunityTokenDialog] Starting trade operation | mode=$mode | amount=${state.amount} | token=${state.selectedPaymentToken?.abbreviation} | wallet=${state.targetWallet?.id}',
     );
 
-    await guardPasskeyDialog(
-      context,
-      (child) => RiverpodUserActionSignerRequestBuilder(
-        provider: communityTokenTradeNotifierProvider(params),
-        request: (signer) async {
-          Logger.info(
-            '[TradeCommunityTokenDialog] Passkey authenticated, calling trade notifier | mode=$mode',
-          );
-          final notifier = ref.read(
-            communityTokenTradeNotifierProvider(params).notifier,
-          );
-          if (mode == CommunityTokenTradeMode.buy) {
-            Logger.info('[TradeCommunityTokenDialog] Calling buy()');
-            await notifier.buy(signer);
-            Logger.info('[TradeCommunityTokenDialog] buy() completed');
-          } else {
-            Logger.info('[TradeCommunityTokenDialog] Calling sell()');
-            await notifier.sell(signer);
-            Logger.info('[TradeCommunityTokenDialog] sell() completed');
-          }
-        },
-        child: child,
-      ),
-    );
+    final tradeTokenController = ref.read(tradeCommunityTokenControllerProvider(params).notifier)
+      ..pauseQuotePolling();
+    try {
+      await guardPasskeyDialog(
+        context,
+        (child) => RiverpodUserActionSignerRequestBuilder(
+          provider: communityTokenTradeNotifierProvider(params),
+          request: (signer) async {
+            Logger.info(
+              '[TradeCommunityTokenDialog] Passkey authenticated, calling trade notifier | mode=$mode',
+            );
+            final notifier = ref.read(
+              communityTokenTradeNotifierProvider(params).notifier,
+            );
+            if (mode == CommunityTokenTradeMode.buy) {
+              Logger.info('[TradeCommunityTokenDialog] Calling buy()');
+              await notifier.buy(signer);
+              Logger.info('[TradeCommunityTokenDialog] buy() completed');
+            } else {
+              Logger.info('[TradeCommunityTokenDialog] Calling sell()');
+              await notifier.sell(signer);
+              Logger.info('[TradeCommunityTokenDialog] sell() completed');
+            }
+          },
+          child: child,
+        ),
+      );
+    } finally {
+      if (context.mounted) {
+        tradeTokenController.resumeQuotePolling();
+      }
+    }
   }
 
   void _showSuccessMessage(

--- a/lib/app/features/tokenized_communities/views/trade_community_token_state.f.dart
+++ b/lib/app/features/tokenized_communities/views/trade_community_token_state.f.dart
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:ion/app/features/tokenized_communities/domain/trade_execution_plan.dart';
 import 'package:ion/app/features/tokenized_communities/enums/community_token_trade_mode.dart';
 import 'package:ion/app/features/tokenized_communities/providers/suggested_token_details.f.dart';
 import 'package:ion/app/features/tokenized_communities/utils/constants.dart';
@@ -8,7 +9,6 @@ import 'package:ion/app/features/wallets/model/coin_data.f.dart';
 import 'package:ion/app/features/wallets/model/coins_group.f.dart';
 import 'package:ion/app/features/wallets/model/network_data.f.dart';
 import 'package:ion_identity_client/ion_identity.dart';
-import 'package:ion_token_analytics/ion_token_analytics.dart';
 
 part 'trade_community_token_state.f.freezed.dart';
 
@@ -17,7 +17,7 @@ class TradeCommunityTokenState with _$TradeCommunityTokenState {
   const factory TradeCommunityTokenState({
     @Default(CommunityTokenTradeMode.buy) CommunityTokenTradeMode mode,
     @Default(0) double amount,
-    PricingResponse? quotePricing,
+    TradeExecutionPlan? executionPlan,
     @Default(false) bool isQuoting,
     String? communityTokenAmountUSDFormatted,
     String? paymentTokenAmountUSDFormatted,
@@ -40,7 +40,7 @@ class TradeCommunityTokenState with _$TradeCommunityTokenState {
   const TradeCommunityTokenState._();
 
   BigInt? get quoteAmount {
-    final pricing = quotePricing;
+    final pricing = executionPlan?.quote.finalPricing;
     if (pricing == null) return null;
     return BigInt.tryParse(pricing.amount);
   }


### PR DESCRIPTION
## Description
- Use the confirmed trade execution plan during buy/sell submission instead of rebuilding trade state at submit time.
- Store route + quote together in state as `executionPlan`, submit against that frozen plan, and validate that the route still matches the current trade context.
- Also reject zero bonding model addresses on the client and pause quote/pricing polling while the passkey/sign flow is in progress, resuming it only if the trade is canceled or fails.

## Type of Change
- [x] Bug fix