### PR TITLE
fix: remove the chat folders slide from left transition

### DIFF
--- a/lib/app/router/chat_routes.dart
+++ b/lib/app/router/chat_routes.dart
@@ -106,7 +106,6 @@ class ArchivedChatsMainRoute extends BaseRouteData with _$ArchivedChatsMainRoute
   ArchivedChatsMainRoute()
       : super(
           child: const ArchivedChatsMainPage(),
-          type: IceRouteType.slideFromLeft,
         );
 }
 
@@ -114,7 +113,6 @@ class RequestsChatsMainRoute extends BaseRouteData with _$RequestsChatsMainRoute
   RequestsChatsMainRoute()
       : super(
           child: const RequestsChatsMainPage(),
-          type: IceRouteType.slideFromLeft,
         );
 }
 


### PR DESCRIPTION
## Description
- removed IceRouteType.slideFromLeft

## Task ID
ION-5837

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)

https://github.com/user-attachments/assets/08f2be3f-572d-476c-9581-53a94813ad07

