### PR TITLE
fix: success title in confirm email flow and inconsistent paddings

### DIFF
--- a/lib/app/features/protect_account/authenticator/views/pages/delete_authenticator/authenticator_delete_success.dart
+++ b/lib/app/features/protect_account/authenticator/views/pages/delete_authenticator/authenticator_delete_success.dart
@@ -36,7 +36,7 @@ class AuthenticatorDeleteSuccessPage extends HookConsumerWidget {
           SizedBox(
             height: 22.0.s,
           ),
-          ScreenSideOffset.large(
+          ScreenSideOffset.medium(
             child: Button(
               mainAxisSize: MainAxisSize.max,
               label: Text(locale.button_back_to_security),

--- a/lib/app/features/protect_account/authenticator/views/pages/setup_authenticator/authenticator_setup_success_page.dart
+++ b/lib/app/features/protect_account/authenticator/views/pages/setup_authenticator/authenticator_setup_success_page.dart
@@ -34,7 +34,7 @@ class AuthenticatorSetupSuccessPage extends HookConsumerWidget {
             SizedBox(
               height: 22.0.s,
             ),
-            ScreenSideOffset.large(
+            ScreenSideOffset.medium(
               child: Button(
                 mainAxisSize: MainAxisSize.max,
                 label: Text(

--- a/lib/app/features/protect_account/backup/views/pages/backup_with_cloud_page/backup_with_cloud_success_page.dart
+++ b/lib/app/features/protect_account/backup/views/pages/backup_with_cloud_page/backup_with_cloud_success_page.dart
@@ -38,7 +38,7 @@ class BackupWithCloudSuccessPage extends HookConsumerWidget {
             SizedBox(
               height: 22.0.s,
             ),
-            ScreenSideOffset.large(
+            ScreenSideOffset.medium(
               child: Button(
                 mainAxisSize: MainAxisSize.max,
                 label: Text(

--- a/lib/app/features/protect_account/backup/views/pages/recovery_keys_success_page.dart
+++ b/lib/app/features/protect_account/backup/views/pages/recovery_keys_success_page.dart
@@ -38,7 +38,7 @@ class RecoveryKeysSuccessPage extends HookConsumerWidget {
           SizedBox(
             height: 28.0.s,
           ),
-          ScreenSideOffset.large(
+          ScreenSideOffset.medium(
             child: Button(
               onPressed: goToSecureAccountOptions,
               label: Text(locale.button_back_to_security),

--- a/lib/app/features/protect_account/components/two_fa_success_step.dart
+++ b/lib/app/features/protect_account/components/two_fa_success_step.dart
@@ -41,7 +41,7 @@ class TwoFaSuccessStep extends HookConsumerWidget {
         SizedBox(
           height: 22.0.s,
         ),
-        ScreenSideOffset.large(
+        ScreenSideOffset.medium(
           child: Button(
             mainAxisSize: MainAxisSize.max,
             label: Text(locale.button_back_to_security),

--- a/lib/app/features/protect_account/email/views/pages/setup_email/email_setup_success_page.dart
+++ b/lib/app/features/protect_account/email/views/pages/setup_email/email_setup_success_page.dart
@@ -25,7 +25,7 @@ class EmailSetupSuccessPage extends HookConsumerWidget {
         ScreenSideOffset.medium(
           child: InfoCard(
             iconAsset: Assets.svg.actionWalletConfirmemail,
-            title: locale.common_successfully,
+            title: locale.common_successfully_added,
             description: locale.email_success_description,
           ),
         ),

--- a/lib/app/features/protect_account/email/views/pages/setup_email/email_setup_success_page.dart
+++ b/lib/app/features/protect_account/email/views/pages/setup_email/email_setup_success_page.dart
@@ -32,7 +32,7 @@ class EmailSetupSuccessPage extends HookConsumerWidget {
         SizedBox(
           height: 22.0.s,
         ),
-        ScreenSideOffset.large(
+        ScreenSideOffset.medium(
           child: Button(
             mainAxisSize: MainAxisSize.max,
             label: Text(locale.button_back_to_security),

--- a/lib/app/features/protect_account/phone/views/pages/setup_phone/phone_setup_success_page.dart
+++ b/lib/app/features/protect_account/phone/views/pages/setup_phone/phone_setup_success_page.dart
@@ -24,7 +24,7 @@ class PhoneSetupSuccessPage extends HookConsumerWidget {
         ScreenSideOffset.medium(
           child: InfoCard(
             iconAsset: Assets.svg.actionWalletConfirmphone,
-            title: locale.common_successfully,
+            title: locale.common_successfully_added,
             description: locale.phone_success_description,
           ),
         ),

--- a/lib/app/features/protect_account/phone/views/pages/setup_phone/phone_setup_success_page.dart
+++ b/lib/app/features/protect_account/phone/views/pages/setup_phone/phone_setup_success_page.dart
@@ -31,7 +31,7 @@ class PhoneSetupSuccessPage extends HookConsumerWidget {
         SizedBox(
           height: 22.0.s,
         ),
-        ScreenSideOffset.large(
+        ScreenSideOffset.medium(
           child: Button(
             mainAxisSize: MainAxisSize.max,
             label: Text(locale.button_back_to_security),

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -276,7 +276,7 @@
   "common_selected": "المحدد",
   "common_show_less": "أظهر أقل",
   "common_show_more": "أظهر المزيد",
-  "common_successfully": "بنجاح",
+  "common_successfully_added": "تمت الإضافة بنجاح",
   "common_title": "العنوان",
   "common_unarchive": "استعادة الكل من الأرشيف",
   "common_unarchive_single": "استعادة من الأرشيف",

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -275,7 +275,7 @@
   "common_selected": "Избрано",
   "common_show_less": "Покажи по-малко",
   "common_show_more": "Покажи повече",
-  "common_successfully": "Успешно",
+  "common_successfully_added": "Успешно добавено",
   "common_title": "Заглавие",
   "common_unarchive": "Разархивирай всички",
   "common_unarchive_single": "Разархивирай",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -275,7 +275,7 @@
   "common_selected": "Ausgewählt",
   "common_show_less": "Weniger anzeigen",
   "common_show_more": "Mehr anzeigen",
-  "common_successfully": "Erfolgreich",
+  "common_successfully_added": "Erfolgreich hinzugefügt",
   "common_title": "Titel",
   "common_unarchive": "Alle entarchivieren",
   "common_unarchive_single": "Entarchivieren",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -275,7 +275,7 @@
   "common_selected": "Selected",
   "common_show_less": "Show less",
   "common_show_more": "Show more",
-  "common_successfully": "Successfully",
+  "common_successfully_added": "Successfully added",
   "common_title": "Title",
   "common_unarchive": "Unarchive all",
   "common_unarchive_single": "Unarchive",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -275,7 +275,7 @@
   "common_selected": "Seleccionado",
   "common_show_less": "Mostrar menos",
   "common_show_more": "Mostrar más",
-  "common_successfully": "Exitosamente",
+  "common_successfully_added": "Agregado correctamente",
   "common_title": "Título",
   "common_unarchive": "Desarchivar todo",
   "common_unarchive_single": "Desarchivar",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -275,7 +275,7 @@
   "common_selected": "Sélectionné",
   "common_show_less": "Afficher moins",
   "common_show_more": "Afficher plus",
-  "common_successfully": "Avec succès",
+  "common_successfully_added": "Ajouté avec succès",
   "common_title": "Titre",
   "common_unarchive": "Tout désarchiver",
   "common_unarchive_single": "Désarchiver",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -275,7 +275,7 @@
   "common_selected": "Selezionato",
   "common_show_less": "Mostra meno",
   "common_show_more": "Mostra di più",
-  "common_successfully": "Con successo",
+  "common_successfully_added": "Aggiunto con successo",
   "common_title": "Titolo",
   "common_unarchive": "Ripristina tutto",
   "common_unarchive_single": "Ripristina",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -275,7 +275,7 @@
   "common_selected": "선택됨",
   "common_show_less": "간략히 보기",
   "common_show_more": "더 보기",
-  "common_successfully": "완료",
+  "common_successfully_added": "추가 완료",
   "common_title": "제목",
   "common_unarchive": "보관 해제 모두",
   "common_unarchive_single": "보관 해제",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -275,7 +275,7 @@
   "common_selected": "Wybrane",
   "common_show_less": "Pokaż mniej",
   "common_show_more": "Pokaż więcej",
-  "common_successfully": "Pomyślnie",
+  "common_successfully_added": "Dodano pomyślnie",
   "common_title": "Tytuł",
   "common_unarchive": "Przywróć z archiwum wszystko",
   "common_unarchive_single": "Przywróć z archiwum",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -275,7 +275,7 @@
   "common_selected": "Selecionado",
   "common_show_less": "Mostrar menos",
   "common_show_more": "Mostrar mais",
-  "common_successfully": "Com sucesso",
+  "common_successfully_added": "Adicionado com sucesso",
   "common_title": "Título",
   "common_unarchive": "Desarquivar tudo",
   "common_unarchive_single": "Desarquivar",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -275,7 +275,7 @@
   "common_selected": "Selectat",
   "common_show_less": "Arată mai puțin",
   "common_show_more": "Arată mai mult",
-  "common_successfully": "Cu succes",
+  "common_successfully_added": "Adăugat cu succes",
   "common_title": "Titlu",
   "common_unarchive": "Dezarhivează tot",
   "common_unarchive_single": "Dezarhivează",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -275,7 +275,7 @@
   "common_selected": "Выбрано",
   "common_show_less": "Показать меньше",
   "common_show_more": "Показать больше",
-  "common_successfully": "Успешно",
+  "common_successfully_added": "Успешно добавлено",
   "common_title": "Заголовок",
   "common_unarchive": "Разархивировать всё",
   "common_unarchive_single": "Разархивировать",

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -275,7 +275,7 @@
   "common_selected": "Seçildi",
   "common_show_less": "Daha az göster",
   "common_show_more": "Daha fazla göster",
-  "common_successfully": "Başarıyla",
+  "common_successfully_added": "Başarıyla eklendi",
   "common_title": "Başlık",
   "common_unarchive": "Tümünü arşivden çıkar",
   "common_unarchive_single": "Arşivden çıkar",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -275,7 +275,7 @@
   "common_selected": "已选择",
   "common_show_less": "显示更少",
   "common_show_more": "显示更多",
-  "common_successfully": "成功",
+  "common_successfully_added": "添加成功",
   "common_title": "标题",
   "common_unarchive": "全部取消归档",
   "common_unarchive_single": "取消归档",


### PR DESCRIPTION
## Description
- changed the incorrect title and updated translations

## Task ID
ION-5833

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-03-19 at 11 44 08" src="https://github.com/user-attachments/assets/dc469fcd-47c2-44ec-b0bb-591ff596a6d6" />
